### PR TITLE
(atlas-ui) Add element id's for inputs and selects in mapping details

### DIFF
--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping.field.action.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping.field.action.component.ts
@@ -42,7 +42,8 @@ import { TransitionModel, FieldAction, FieldActionConfig } from '../../models/tr
                 </div>
                 <div class="form-group argument" *ngFor="let argConfig of action.config.arguments; let i = index">
                     <label style="">{{ argConfig.name }}</label>
-                    <input type="text" [(ngModel)]="action.getArgumentValue(argConfig.name).value" (change)="selectionChanged($event)"/>
+                    <input type="text" id="input-index-{{action.getArgumentValue(argConfig.name).value}}"
+                        [(ngModel)]="action.getArgumentValue(argConfig.name).value" (change)="selectionChanged($event)"/>
                     <div class="clear"></div>
                 </div>
             </div>

--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping.field.detail.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping.field.detail.component.ts
@@ -51,7 +51,8 @@ import { MappingModel, FieldMappingPair, MappedField } from '../../models/mappin
                 {{ getParentObjectName() }}
             </label>
             <div style="width:100%;">
-                <input type="text" [ngModel]="mappedField.field.getFieldLabel(false)" [typeahead]="dataSource"
+                <input type="text" id="input-{{isSource?'source':'target'}}-{{mappedField.field.getFieldLabel(false)}}"
+                    [ngModel]="mappedField.field.getFieldLabel(false)" [typeahead]="dataSource"
                     typeaheadWaitMs="200" (typeaheadOnSelect)="selectionChanged($event)"
                     typeaheadOptionField="displayName" [typeaheadItemTemplate]="typeaheadTemplate">
             </div>

--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/transition.selection.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/transition.selection.component.ts
@@ -35,7 +35,7 @@ import { LookupTableComponent } from './lookup.table.component';
                 </div>
                 <div *ngIf="!modeIsEnum()">
                     <label>Action</label>
-                    <select (change)="selectionChanged($event);" selector="mode"
+                    <select  id="select-action" (change)="selectionChanged($event);" selector="mode"
                         [ngModel]="fieldPair.transition.mode">
                         <option value="{{modes.COMBINE}}">Combine</option>
                         <option value="{{modes.MAP}}">Map</option>
@@ -45,7 +45,7 @@ import { LookupTableComponent } from './lookup.table.component';
                 </div>
                 <div *ngIf="fieldPair.transition.isSeparateMode() || fieldPair.transition.isCombineMode()" style="margin-top:10px;">
                     <label>Separator:</label>
-                    <select (change)="selectionChanged($event);" selector="separator"
+                    <select  id="select-separator" (change)="selectionChanged($event);" selector="separator"
                         [ngModel]="fieldPair.transition.delimiter">
                         <option value="{{delimeters.COLON}}">Colon</option>
                         <option value="{{delimeters.COMMA}}">Comma</option>


### PR DESCRIPTION
Adds element id's for source/target, index inputs, and action,separator selects. 
closes #92 
