### PR TITLE
chore: Add twitter4j.Status as a mock Source Document

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -520,7 +520,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
                     <configuration>
-                        <forkCount>4</forkCount>
+                        <forkCount>2</forkCount>
                         <reuseForks>false</reuseForks>
                     </configuration>
                 </plugin>

--- a/runtime/runtime/pom.xml
+++ b/runtime/runtime/pom.xml
@@ -261,6 +261,10 @@
                     <groupId>io.atlasmap</groupId>
                     <artifactId>atlas-java-test-model</artifactId>
                 </dependency>
+                <dependency>
+                    <groupId>org.twitter4j</groupId>
+                    <artifactId>twitter4j-core</artifactId>
+                </dependency>
             </dependencies>
         </profile>
     </profiles>

--- a/ui/src/app/lib/atlasmap-data-mapper/services/initialization.service.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/services/initialization.service.ts
@@ -82,8 +82,9 @@ export class InitializationService {
         }
 
         if (this.cfg.initCfg.addMockJavaSources || this.cfg.initCfg.addMockJavaSingleSource) {
-            this.cfg.addJavaDocument('io.atlasmap.java.test.TargetTestClass', true);
+            this.cfg.addJavaDocument('twitter4j.Status', true);
             if (this.cfg.initCfg.addMockJavaSources) {
+                this.cfg.addJavaDocument('io.atlasmap.java.test.TargetTestClass', true);
                 this.cfg.addJavaDocument('io.atlasmap.java.test.SourceContact', true);
                 this.cfg.addJavaDocument('io.atlasmap.java.test.SourceAddress', true);
                 this.cfg.addJavaDocument('io.atlasmap.java.test.TestListOrders', true);


### PR DESCRIPTION
Fixes: #180

chore: Reduce surefire fork count, expecting to avoid recent VM termination in CircleCI