### PR TITLE
fix: wrong id's on field actions input string

### DIFF
--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping.field.action.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping.field.action.component.ts
@@ -42,7 +42,7 @@ import { TransitionModel, FieldAction, FieldActionConfig } from '../../models/tr
                 </div>
                 <div class="form-group argument" *ngFor="let argConfig of action.config.arguments; let i = index">
                     <label style="">{{ argConfig.name }}</label>
-                    <input type="text" id="input-index-{{action.getArgumentValue(argConfig.name).value}}"
+                    <input type="text" class="input-{{argConfig.name}}"
                         [(ngModel)]="action.getArgumentValue(argConfig.name).value" (change)="selectionChanged($event)"/>
                     <div class="clear"></div>
                 </div>


### PR DESCRIPTION
"Class" attribute is used instead of "id" due to possibility to get non-unique id values ( combine/separate index input). This helps QE to easily manipulate with inputs in automated tests.
  