### PR TITLE
i225 - test PR - fix add transformation button for some types

### DIFF
--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping.field.action.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping.field.action.component.ts
@@ -77,8 +77,12 @@ export class MappingFieldActionComponent {
 
     public getActionConfigs(): FieldActionConfig[] {
         const configs: FieldActionConfig[] = [];
+
+        // Start with the complete list of field actions.
         for (const config of TransitionModel.actionConfigs) {
-            if (config.appliesToField(this.mappedField.field, this.fieldPair)) {
+
+            // Filter down to those field actions that apply to the selected field pair.
+            if (config.appliesToField(this.fieldPair)) {
                 configs.push(config);
             }
         }

--- a/ui/src/app/lib/atlasmap-data-mapper/models/mapping.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/mapping.model.ts
@@ -249,7 +249,7 @@ export class FieldMappingPair {
             const actionsToRemove: FieldAction[] = [];
             for (const action of mappedField.actions) {
                 const actionConfig: FieldActionConfig = TransitionModel.getActionConfigForName(action.name);
-                if (actionConfig != null && !actionConfig.appliesToField(mappedField.field, this)) {
+                if (actionConfig != null && !actionConfig.appliesToField(this)) {
                     actionsToRemove.push(action);
                 }
             }


### PR DESCRIPTION
fix: Missing 'Add Transformation' button for certain field types.
Fixes: #225, #107

Signed-off-by: Paul Leacu <pleacu@redhat.com>
Test PR until reviewed

Hey - since this is my first crack at AtlasMap the more eyes on this the better!

The inital issue was that the 'Add Transformation' button wasn't showing up for some field types.
The MappingFieldActionComponent class has a method to return an array of applicable field actions
for the selected field pair types.  It walks all of the field actions as defined in the TransitionModel
and allows it to determine if we should add the field action to the array.  A non-zero array triggers
the 'Add Transformation' button.

The issue is with the FieldActionConfig class/ appliesToField method in the transition model.
It's basically only set up to work with 'STRING' and 'NUMBER' field actions.  It does go through
some effort to relate generic field action method 'STRING' and 'NUMBER' types to their
sources/targets field types but no other types.

What I did:

* Removed the "field" argument to the appliesToField() method - the field mapping pair was already
  being supplied.

* Made sure the field pair was already fully mapped.

* Checked for string and number types.

* Allowed non-primitive types if the selected field pair types matched the field action types.

Please see the test PR for details.

thkx!


