### PR TITLE
fix: Refactor Document initialization model (#242)

### DIFF
--- a/ui/src/app/lib/atlasmap-data-mapper/components/document.definition.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/document.definition.component.ts
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-import { Component, Input, ViewChildren, ElementRef, QueryList, ViewChild } from '@angular/core';
+import { Component, Input, ViewChildren, ElementRef, QueryList, ViewChild, OnInit } from '@angular/core';
 
 import { DocumentType, ConfigModel } from '../models/config.model';
 import { Field } from '../models/field.model';
@@ -37,7 +37,7 @@ import { ModalWindowComponent } from './modal.window.component';
                     <h2 class="card-pf-title">
                         <div class="docName">
                             <i class="fa {{ isSource ? 'fa-hdd-o' : 'fa-download' }}"></i>
-                            <label>{{ getSourcesTargetsLabel() }}</label>
+                            <label>{{ sourcesTargetsLabel }}</label>
                         </div>
                         <i (click)="toggleSearch()" [attr.class]="getSearchIconCSSClass()"></i>
                         <div class="clear"></div>
@@ -53,7 +53,7 @@ import { ModalWindowComponent } from './modal.window.component';
                 </div>
                 <div [attr.class]="searchMode ? 'fieldListSearchOpen' : 'fieldList'" style="overflow:auto;"
                     (scroll)="handleScroll($event)">
-                    <div *ngFor="let docDef of cfg.getDocs(isSource)" #docDetail class="docIdentifier" [attr.id]='docDef.shortName'>
+                    <div *ngFor="let docDef of documents" #docDetail class="docIdentifier" [attr.id]='docDef.shortName'>
                         <div class="card-pf-title documentHeader" tooltip="{{ docDef.fullName }}" placement="bottom"
                             *ngIf="isDocNameVisible(docDef)" (click)="toggleFieldVisibility(docDef)">
                             <div style="float:left">
@@ -71,7 +71,7 @@ import { ModalWindowComponent } from './modal.window.component';
                             <document-field-detail #fieldDetail *ngFor="let f of docDef.fields" [modalWindow]="modalWindow"
                                 [field]="f" [cfg]="cfg" [lineMachine]="lineMachine"></document-field-detail>
                             <div class="FieldDetail"
-                                *ngIf="!searchMode && docDef.isPropertyOrConstant() && !docDef.fields.length">
+                                *ngIf="!searchMode && docDef.isPropertyOrConstant && (!docDef.fields || !docDef.fields.length)">
                                 <label style="width:100%; padding:5px 16px; margin:0">
                                     No {{ docDef.type == 'Property' ? 'properties' : 'constants' }} exist.
                                 </label>
@@ -88,7 +88,7 @@ import { ModalWindowComponent } from './modal.window.component';
     `,
 })
 
-export class DocumentDefinitionComponent {
+export class DocumentDefinitionComponent implements OnInit {
     @Input() cfg: ConfigModel;
     @Input() isSource = false;
     @Input() lineMachine: LineMachineComponent;
@@ -102,6 +102,18 @@ export class DocumentDefinitionComponent {
     private searchFilter = '';
     private scrollTop = 0;
     private searchResultsExist = false;
+
+    private sourcesTargetsLabel: String;
+    private documents: DocumentDefinition[];
+
+    ngOnInit(): void {
+        if (this.isSource) {
+            this.sourcesTargetsLabel = (this.cfg.sourceDocs.length > 1) ? 'Sources' : 'Source';
+        } else {
+            this.sourcesTargetsLabel = (this.cfg.targetDocs.length > 1) ? 'Targets' : 'Target';
+        }
+        this.documents = this.cfg.getDocs(this.isSource);
+    }
 
     getDocDefElementPosition(docDef: DocumentDefinition): any {
         for (const c of this.docElements.toArray()) {
@@ -165,14 +177,6 @@ export class DocumentDefinitionComponent {
         return this.searchMode ? (cssClass + ' selectedIcon') : cssClass;
     }
 
-    getSourcesTargetsLabel(): string {
-        if (this.isSource) {
-            return (this.cfg.sourceDocs.length > 1) ? 'Sources' : 'Source';
-        } else {
-            return (this.cfg.targetDocs.length > 1) ? 'Targets' : 'Target';
-        }
-    }
-
     getFieldCount(): number {
         let count = 0;
         for (const docDef of this.cfg.getDocs(this.isSource)) {
@@ -194,21 +198,21 @@ export class DocumentDefinitionComponent {
 
     addField(docDef: DocumentDefinition, event: any): void {
         event.stopPropagation();
-        const self: DocumentDefinitionComponent = this;
+        const self = this;
         this.modalWindow.reset();
         this.modalWindow.confirmButtonText = 'Save';
-        const isProperty: boolean = docDef.type == DocumentType.PROPERTY;
-        const isConstant: boolean = docDef.type == DocumentType.CONSTANT;
+        const isProperty = docDef.type == DocumentType.PROPERTY;
+        const isConstant = docDef.type == DocumentType.CONSTANT;
         this.modalWindow.headerText = isProperty ? 'Create Property' : (isConstant ? 'Create Constant' : 'Create Field');
         this.modalWindow.nestedComponentInitializedCallback = (mw: ModalWindowComponent) => {
             if (isProperty) {
-                const propertyComponent: PropertyFieldEditComponent = mw.nestedComponent as PropertyFieldEditComponent;
+                const propertyComponent = mw.nestedComponent as PropertyFieldEditComponent;
                 propertyComponent.initialize(null);
             } else if (isConstant) {
-                const constantComponent: ConstantFieldEditComponent = mw.nestedComponent as ConstantFieldEditComponent;
+                const constantComponent = mw.nestedComponent as ConstantFieldEditComponent;
                 constantComponent.initialize(null);
             } else {
-                const fieldComponent: FieldEditComponent = mw.nestedComponent as FieldEditComponent;
+                const fieldComponent = mw.nestedComponent as FieldEditComponent;
                 fieldComponent.isSource = this.isSource;
                 fieldComponent.initialize(null, docDef, true);
             }
@@ -217,13 +221,13 @@ export class DocumentDefinitionComponent {
             : (isConstant ? ConstantFieldEditComponent : FieldEditComponent);
         this.modalWindow.okButtonHandler = (mw: ModalWindowComponent) => {
             if (isProperty) {
-                const propertyComponent: PropertyFieldEditComponent = mw.nestedComponent as PropertyFieldEditComponent;
+                const propertyComponent = mw.nestedComponent as PropertyFieldEditComponent;
                 docDef.addField(propertyComponent.getField());
             } else if (isConstant) {
-                const constantComponent: ConstantFieldEditComponent = mw.nestedComponent as ConstantFieldEditComponent;
+                const constantComponent = mw.nestedComponent as ConstantFieldEditComponent;
                 docDef.addField(constantComponent.getField());
             } else {
-                const fieldComponent: FieldEditComponent = mw.nestedComponent as FieldEditComponent;
+                const fieldComponent = mw.nestedComponent as FieldEditComponent;
                 docDef.addField(fieldComponent.getField());
             }
             self.cfg.mappingService.saveCurrentMapping();
@@ -246,7 +250,7 @@ export class DocumentDefinitionComponent {
     }
 
     isAddFieldAvailable(docDef: DocumentDefinition): boolean {
-        return docDef.isPropertyOrConstant()
+        return docDef.isPropertyOrConstant
             || (!docDef.isSource && docDef.type == DocumentType.JSON)
             || (!docDef.isSource && docDef.type == DocumentType.XML);
     }

--- a/ui/src/app/lib/atlasmap-data-mapper/components/document.definition.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/document.definition.component.ts
@@ -103,7 +103,7 @@ export class DocumentDefinitionComponent implements OnInit {
     private scrollTop = 0;
     private searchResultsExist = false;
 
-    private sourcesTargetsLabel: String;
+    private sourcesTargetsLabel: string;
     private documents: DocumentDefinition[];
 
     ngOnInit(): void {

--- a/ui/src/app/lib/atlasmap-data-mapper/components/document.field.detail.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/document.field.detail.component.ts
@@ -17,7 +17,7 @@
 import { Component, Input, ElementRef, ViewChild, ViewChildren, QueryList } from '@angular/core';
 import { DomSanitizer, SafeStyle } from '@angular/platform-browser';
 
-import { ConfigModel } from '../models/config.model';
+import { DocumentType, ConfigModel } from '../models/config.model';
 import { Field } from '../models/field.model';
 
 import { LineMachineComponent } from './line.machine.component';
@@ -134,7 +134,7 @@ export class DocumentFieldDetailComponent {
         if (this.field.isCollection) {
             return 'fa fa-list-ul';
         }
-        if (this.field.docDef.initCfg.type.isXML()) {
+        if (this.field.docDef.type == DocumentType.XML) {
             return this.field.isAttribute ? 'fa fa-at' : 'fa fa-code';
         }
         return 'fa fa-file-o';

--- a/ui/src/app/lib/atlasmap-data-mapper/components/field.edit.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/field.edit.component.ts
@@ -18,7 +18,7 @@ import { Component } from '@angular/core';
 
 import { DocumentDefinition, NamespaceModel } from '../models/document.definition.model';
 import { Field } from '../models/field.model';
-import { ConfigModel } from '../models/config.model';
+import { DocumentType, ConfigModel } from '../models/config.model';
 import { Observable } from 'rxjs/Observable';
 import { ModalWindowValidator } from './modal.window.component';
 import { DataMapperUtil } from '../common/data.mapper.util';
@@ -117,7 +117,7 @@ export class FieldEditComponent implements ModalWindowValidator {
         this.valueType = (this.field.type == null) ? 'STRING' : this.field.type;
         this.parentField = (this.field.parentField == null) ? DocumentDefinition.getNoneField() : this.field.parentField;
 
-        if (this.docDef.initCfg.type.isXML()) {
+        if (this.docDef.type == DocumentType.XML) {
             this.fieldType = this.field.isAttribute ? 'attribute' : 'element';
             this.parentField = (this.field.parentField == null) ? docDef.fields[0] : this.field.parentField;
             const unqualifiedNS: NamespaceModel = NamespaceModel.getUnqualifiedNamespace();
@@ -179,7 +179,7 @@ export class FieldEditComponent implements ModalWindowValidator {
     public executeSearch(filter: string): any[] {
         const formattedFields: any[] = [];
 
-        if (this.docDef.initCfg.type.isJSON()) {
+        if (this.docDef.type == DocumentType.JSON) {
             const noneField: Field = DocumentDefinition.getNoneField();
             formattedFields.push({ 'field': noneField, 'displayName': noneField.getFieldLabel(true) });
         }
@@ -207,7 +207,7 @@ export class FieldEditComponent implements ModalWindowValidator {
         this.field.type = this.valueType;
         this.field.userCreated = true;
         this.field.serviceObject.jsonType = 'io.atlasmap.json.v2.JsonField';
-        if (this.docDef.initCfg.type.isXML()) {
+        if (this.docDef.type == DocumentType.XML) {
             this.field.isAttribute = (this.fieldType == 'attribute');
             this.field.namespaceAlias = this.namespaceAlias;
             const unqualifiedNS: NamespaceModel = NamespaceModel.getUnqualifiedNamespace();

--- a/ui/src/app/lib/atlasmap-data-mapper/components/toolbar.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/toolbar.component.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { Component, Input } from '@angular/core';
 
-import { ConfigModel } from '../models/config.model';
+import { DocumentType, ConfigModel } from '../models/config.model';
 import { DocumentDefinition } from '../models/document.definition.model';
 
 import { LineMachineComponent } from './line.machine.component';
@@ -115,7 +115,7 @@ export class ToolbarComponent {
 
     public targetSupportsTemplate(): boolean {
         const targetDoc: DocumentDefinition = this.cfg.targetDocs[0];
-        return targetDoc.initCfg.type.isXML() || targetDoc.initCfg.type.isJSON();
+        return targetDoc.type == DocumentType.XML || targetDoc.type == DocumentType.JSON;
     }
 
     public toolbarButtonClicked(action: string, event: any): void {

--- a/ui/src/app/lib/atlasmap-data-mapper/models/config.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/config.model.ts
@@ -41,105 +41,105 @@ export const enum InspectionType {
 }
 
 export class DataMapperInitializationModel {
-    public dataMapperVersion = '0.9.2017.07.28';
-    public initialized = false;
-    public loadingStatus = 'Loading.';
-    public initializationErrorOccurred = false;
+    dataMapperVersion = '0.9.2017.07.28';
+    initialized = false;
+    loadingStatus = 'Loading.';
+    initializationErrorOccurred = false;
 
-    public baseJavaInspectionServiceUrl: string;
-    public baseXMLInspectionServiceUrl: string;
-    public baseJSONInspectionServiceUrl: string;
-    public baseMappingServiceUrl: string;
+    baseJavaInspectionServiceUrl: string;
+    baseXMLInspectionServiceUrl: string;
+    baseJSONInspectionServiceUrl: string;
+    baseMappingServiceUrl: string;
 
     /* class path fetching configuration */
-    public classPathFetchTimeoutInMilliseconds = 30000;
+    classPathFetchTimeoutInMilliseconds = 30000;
     // if classPath is specified, maven call to resolve pom will be skipped
-    public pomPayload: string;
+    pomPayload: string;
 
-    public classPath: string;
+    classPath: string;
 
     /* inspection service filtering flags */
-    public fieldNameBlacklist: string[] = [];
-    public classNameBlacklist: string[] = [];
-    public disablePrivateOnlyFields = false;
-    public disableProtectedOnlyFields = false;
-    public disablePublicOnlyFields = false;
-    public disablePublicGetterSetterFields = false;
+    fieldNameBlacklist: string[] = [];
+    classNameBlacklist: string[] = [];
+    disablePrivateOnlyFields = false;
+    disableProtectedOnlyFields = false;
+    disablePublicOnlyFields = false;
+    disablePublicGetterSetterFields = false;
 
     /* mock data configuration */
-    public discardNonMockSources = false;
-    public addMockJSONMappings = false;
-    public addMockJavaSingleSource = false;
-    public addMockJavaSources = false;
-    public addMockJavaCachedSource = false;
-    public addMockXMLInstanceSources = false;
-    public addMockXMLSchemaSources = false;
-    public addMockJSONSources = false;
-    public addMockJSONInstanceSources = false;
-    public addMockJSONSchemaSources = false;
+    discardNonMockSources = false;
+    addMockJSONMappings = false;
+    addMockJavaSingleSource = false;
+    addMockJavaSources = false;
+    addMockJavaCachedSource = false;
+    addMockXMLInstanceSources = false;
+    addMockXMLSchemaSources = false;
+    addMockJSONSources = false;
+    addMockJSONInstanceSources = false;
+    addMockJSONSchemaSources = false;
 
-    public addMockJavaTarget = false;
-    public addMockJavaCachedTarget = false;
-    public addMockXMLInstanceTarget = false;
-    public addMockXMLSchemaTarget = false;
-    public addMockJSONTarget = false;
-    public addMockJSONInstanceTarget = false;
-    public addMockJSONSchemaTarget = false;
+    addMockJavaTarget = false;
+    addMockJavaCachedTarget = false;
+    addMockXMLInstanceTarget = false;
+    addMockXMLSchemaTarget = false;
+    addMockJSONTarget = false;
+    addMockJSONInstanceTarget = false;
+    addMockJSONSchemaTarget = false;
 
     /* debug logging toggles */
-    public debugDocumentServiceCalls = false;
-    public debugDocumentParsing = false;
-    public debugMappingServiceCalls = false;
-    public debugClassPathServiceCalls = false;
-    public debugValidationServiceCalls = false;
-    public debugFieldActionServiceCalls = false;
+    debugDocumentServiceCalls = false;
+    debugDocumentParsing = false;
+    debugMappingServiceCalls = false;
+    debugClassPathServiceCalls = false;
+    debugValidationServiceCalls = false;
+    debugFieldActionServiceCalls = false;
 
-    public mappingInitialized = false;
-    public fieldActionsInitialized = false;
+    mappingInitialized = false;
+    fieldActionsInitialized = false;
 }
 
 export class DocumentInitializationModel {
-    public id: string;
-    public type: DocumentType;
-    public shortName: string;
-    public fullName: string;
-    public isSource: boolean;
-    public inspectionType: InspectionType;
-    public inspectionSource: string;
-    public inspectionResult: string;
+    id: string;
+    type: DocumentType;
+    shortName: string;
+    fullName: string;
+    isSource: boolean;
+    inspectionType: InspectionType;
+    inspectionSource: string;
+    inspectionResult: string;
 }
 
 export class ConfigModel {
-    public static mappingServicesPackagePrefix = 'io.atlasmap.v2';
-    public static javaServicesPackagePrefix = 'io.atlasmap.java.v2';
+    static mappingServicesPackagePrefix = 'io.atlasmap.v2';
+    static javaServicesPackagePrefix = 'io.atlasmap.java.v2';
 
-    public initCfg: DataMapperInitializationModel = new DataMapperInitializationModel;
+    initCfg: DataMapperInitializationModel = new DataMapperInitializationModel;
 
     /* current ui state config */
-    public showMappingDetailTray = false;
-    public showMappingTable = false;
-    public showNamespaceTable = false;
-    public showLinesAlways = true;
-    public showTypes = false;
-    public showMappedFields = true;
-    public showUnmappedFields = true;
-    public currentDraggedField: Field = null;
+    showMappingDetailTray = false;
+    showMappingTable = false;
+    showNamespaceTable = false;
+    showLinesAlways = true;
+    showTypes = false;
+    showMappedFields = true;
+    showUnmappedFields = true;
+    currentDraggedField: Field = null;
 
-    public documentService: DocumentManagementService;
-    public mappingService: MappingManagementService;
-    public errorService: ErrorHandlerService;
-    public initializationService: InitializationService;
+    documentService: DocumentManagementService;
+    mappingService: MappingManagementService;
+    errorService: ErrorHandlerService;
+    initializationService: InitializationService;
 
-    public sourceDocs: DocumentDefinition[] = [];
-    public targetDocs: DocumentDefinition[] = [];
-    public propertyDoc: DocumentDefinition = new DocumentDefinition();
-    public constantDoc: DocumentDefinition = new DocumentDefinition();
-    public mappingFiles: string[] = [];
+    sourceDocs: DocumentDefinition[] = [];
+    targetDocs: DocumentDefinition[] = [];
+    propertyDoc: DocumentDefinition = new DocumentDefinition();
+    constantDoc: DocumentDefinition = new DocumentDefinition();
+    mappingFiles: string[] = [];
 
-    public mappings: MappingDefinition = null;
+    mappings: MappingDefinition = null;
 
-    public errors: ErrorInfo[] = [];
-    public validationErrors: ErrorInfo[] = [];
+    errors: ErrorInfo[] = [];
+    validationErrors: ErrorInfo[] = [];
 
     private static cfg: ConfigModel = new ConfigModel();
 

--- a/ui/src/app/lib/atlasmap-data-mapper/models/document.definition.model.spec.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/document.definition.model.spec.ts
@@ -1,15 +1,14 @@
 /* tslint:disable:no-unused-variable */
 
 import { TestBed, async, inject } from '@angular/core/testing';
-import { NamespaceModel, DocumentType, DocumentInitializationConfig, DocumentDefinition  } from './document.definition.model';
+import { NamespaceModel, DocumentDefinition  } from './document.definition.model';
+import { DocumentType  } from './config.model';
 
 describe('DocumentDefinitionModel', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
         NamespaceModel,
-        DocumentType,
-        DocumentInitializationConfig,
         DocumentDefinition,
      ],
     });
@@ -17,11 +16,9 @@ describe('DocumentDefinitionModel', () => {
 
   it(
     'should ...',
-    inject([NamespaceModel, DocumentType, DocumentInitializationConfig, DocumentDefinition],
-       (ns: NamespaceModel, docType: DocumentType, initCfg: DocumentInitializationConfig, doc: DocumentDefinition) => {
+    inject([NamespaceModel, DocumentDefinition],
+       (ns: NamespaceModel, doc: DocumentDefinition) => {
       expect(ns).toBeTruthy();
-      expect(docType).toBeTruthy();
-      expect(initCfg).toBeTruthy();
       expect(doc).toBeTruthy();
     }),
   );

--- a/ui/src/app/lib/atlasmap-data-mapper/models/document.definition.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/document.definition.model.ts
@@ -57,33 +57,33 @@ export class NamespaceModel {
 }
 
 export class DocumentDefinition {
-    public id: string;
-    public _type: DocumentType;
-    public shortName: string;
-    public fullName: string;
-    public uri: string;
-    public inspectionType: InspectionType;
-    public inspectionSource: string;
-    public inspectionResult: string;
-    public isSource: boolean;
-    public isPropertyOrConstant: boolean;
+    id: string;
+    _type: DocumentType;
+    shortName: string;
+    fullName: string;
+    uri: string;
+    inspectionType: InspectionType;
+    inspectionSource: string;
+    inspectionResult: string;
+    isSource: boolean;
+    isPropertyOrConstant: boolean;
 
-    public classPath: string;
-    public initialized = false;
-    public errorOccurred = false;
-    public pathSeparator = '/';
-    public fields: Field[] = [];
-    public allFields: Field[] = [];
-    public terminalFields: Field[] = [];
-    public complexFieldsByClassIdentifier: { [key: string]: Field; } = {};
-    public enumFieldsByClassIdentifier: { [key: string]: Field; } = {};
-    public fieldsByPath: { [key: string]: Field; } = {};
-    public fieldPaths: string[] = [];
-    public showFields = true;
-    public visibleInCurrentDocumentSearch = true;
-    public namespaces: NamespaceModel[] = [];
-    public characterEncoding: string = null;
-    public locale: string = null;
+    classPath: string;
+    initialized = false;
+    errorOccurred = false;
+    pathSeparator = '/';
+    fields: Field[] = [];
+    allFields: Field[] = [];
+    terminalFields: Field[] = [];
+    complexFieldsByClassIdentifier: { [key: string]: Field; } = {};
+    enumFieldsByClassIdentifier: { [key: string]: Field; } = {};
+    fieldsByPath: { [key: string]: Field; } = {};
+    fieldPaths: string[] = [];
+    showFields = true;
+    visibleInCurrentDocumentSearch = true;
+    namespaces: NamespaceModel[] = [];
+    characterEncoding: string = null;
+    locale: string = null;
 
     private static noneField: Field = null;
 

--- a/ui/src/app/lib/atlasmap-data-mapper/models/document.definition.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/document.definition.model.ts
@@ -15,7 +15,7 @@
 */
 
 import { Field } from './field.model';
-import { ConfigModel } from '../models/config.model';
+import { DocumentType, InspectionType, ConfigModel } from '../models/config.model';
 import { MappingDefinition } from '../models/mapping.definition.model';
 import { DataMapperUtil } from '../common/data.mapper.util';
 
@@ -56,72 +56,27 @@ export class NamespaceModel {
     }
 }
 
-export enum DocumentTypes {
-    JAVA = 'Java',
-    XML = 'XML',
-    JSON = 'JSON',
-    CSV = 'CSV',
-    CONSTANT = 'Constants',
-    PROPERTY = 'Property'
-}
+export class DocumentDefinition {
+    public id: string;
+    public type: DocumentType;
+    public shortName: string;
+    public fullName: string;
+    public uri: string;
+    public inspectionType: InspectionType;
+    public inspectionSource: string;
+    public inspectionResult: string;
+    public isSource: boolean;
 
-export class DocumentType {
-    public type: DocumentTypes = DocumentTypes.JAVA;
-
-    public isJava(): boolean {
-        return this.type == DocumentTypes.JAVA;
-    }
-
-    public isXML(): boolean {
-        return this.type == DocumentTypes.XML;
-    }
-
-    public isJSON(): boolean {
-        return this.type == DocumentTypes.JSON;
-    }
-
-    public isCSV(): boolean {
-        return this.type == DocumentTypes.CSV;
-    }
-
-    public isConstant(): boolean {
-        return this.type == DocumentTypes.CONSTANT;
-    }
-
-    public isProperty(): boolean {
-        return this.type == DocumentTypes.PROPERTY;
-    }
-
-    public isPropertyOrConstant(): boolean {
-        return this.isProperty() || this.isConstant();
-    }
-}
-
-export class DocumentInitializationConfig {
-    public documentIdentifier: string;
-    public shortIdentifier: string;
-    public type: DocumentType = new DocumentType();
     public classPath: string;
     public initialized = false;
     public errorOccurred = false;
     public pathSeparator = '/';
-    public documentContents: string = null;
-    public inspectionResultContents: string = null;
-    public inspectionType: string = null;
-}
-
-export class DocumentDefinition {
-    public initCfg: DocumentInitializationConfig = new DocumentInitializationConfig();
-    public name: string;
-    public fullyQualifiedName: string;
     public fields: Field[] = [];
     public allFields: Field[] = [];
     public terminalFields: Field[] = [];
-    public isSource: boolean;
     public complexFieldsByClassIdentifier: { [key: string]: Field; } = {};
     public enumFieldsByClassIdentifier: { [key: string]: Field; } = {};
     public fieldsByPath: { [key: string]: Field; } = {};
-    public uri: string = null;
     public fieldPaths: string[] = [];
     public showFields = true;
     public visibleInCurrentDocumentSearch = true;
@@ -174,14 +129,22 @@ export class DocumentDefinition {
     }
 
     public getName(includeType: boolean): string {
-        let name: string = this.name;
-        if (ConfigModel.getConfig().showTypes && !this.initCfg.type.isPropertyOrConstant()) {
-            const type: string = this.initCfg.type.type;
+        let name: string = this.shortName;
+        if (ConfigModel.getConfig().showTypes && !this.isPropertyOrConstant()) {
+            const type: string = this.type;
             if (type) {
                 name += ' (' + type + ')';
             }
         }
         return name;
+    }
+
+    public isPropertyOrConstant(): boolean {
+        const type: DocumentType = this.type;
+        if (!type) {
+            return false;
+        }
+        return type == DocumentType.CONSTANT || type == DocumentType.PROPERTY;
     }
 
     public getNamespaceForAlias(alias: string): NamespaceModel {
@@ -202,7 +165,7 @@ export class DocumentDefinition {
         }
         let field: Field = this.fieldsByPath[fieldPath];
         //if we can't find the field we're looking for, find parent fields and populate their children
-        const pathSeparator: string = this.initCfg.pathSeparator;
+        const pathSeparator: string = this.pathSeparator;
         let originalPath: string = fieldPath;
         //strip beginning path separator from path
         if (originalPath != null && originalPath.indexOf(pathSeparator) == 0) {
@@ -255,7 +218,7 @@ export class DocumentDefinition {
     }
 
     public initializeFromFields(): void {
-        if (this.initCfg.type.isJava()) {
+        if (this.type == DocumentType.JAVA) {
             this.prepareComplexFields();
         }
 
@@ -277,17 +240,17 @@ export class DocumentDefinition {
             }
         }
 
-        this.initCfg.initialized = true;
+        this.initialized = true;
     }
 
     public updateField(field: Field, oldPath: string): void {
         Field.alphabetizeFields(this.fields);
         if (field.parentField == null
             || field.parentField == DocumentDefinition.getNoneField()
-            || this.initCfg.type.isPropertyOrConstant()) {
+            || this.isPropertyOrConstant()) {
             this.populateFieldParentPaths(field, null, 0);
         } else {
-            const pathSeparator: string = this.initCfg.pathSeparator;
+            const pathSeparator: string = this.pathSeparator;
             this.populateFieldParentPaths(field, field.parentField.path  + pathSeparator,
                 field.parentField.fieldDepth + 1);
         }
@@ -302,7 +265,7 @@ export class DocumentDefinition {
     public addField(field: Field): void {
         if (field.parentField == null
             || field.parentField == DocumentDefinition.getNoneField()
-            || this.initCfg.type.isPropertyOrConstant()) {
+            || this.isPropertyOrConstant()) {
             this.fields.push(field);
             Field.alphabetizeFields(this.fields);
             this.populateFieldParentPaths(field, null, 0);
@@ -310,7 +273,7 @@ export class DocumentDefinition {
             this.populateChildren(field.parentField);
             field.parentField.children.push(field);
             Field.alphabetizeFields(field.parentField.children);
-            const pathSeparator: string = this.initCfg.pathSeparator;
+            const pathSeparator: string = this.pathSeparator;
             this.populateFieldParentPaths(field, field.parentField.path  + pathSeparator,
                 field.parentField.fieldDepth + 1);
         }
@@ -331,7 +294,7 @@ export class DocumentDefinition {
 
         //copy cached field children
         cachedField = cachedField.copy();
-        const pathSeparator: string = this.initCfg.pathSeparator;
+        const pathSeparator: string = this.pathSeparator;
         for (let childField of cachedField.children) {
             childField = childField.copy();
             childField.parentField = field;
@@ -390,12 +353,12 @@ export class DocumentDefinition {
         }
     }
 
-    public static getDocumentByIdentifier(documentIdentifier: string, docs: DocumentDefinition[]): DocumentDefinition {
-        if (documentIdentifier == null || docs == null || !docs.length) {
+    public static getDocumentByIdentifier(documentId: string, docs: DocumentDefinition[]): DocumentDefinition {
+        if (documentId == null || docs == null || !docs.length) {
             return null;
         }
         for (const doc of docs) {
-            if (doc.initCfg.documentIdentifier === documentIdentifier) {
+            if (doc.id === documentId) {
                 return doc;
             }
         }
@@ -405,7 +368,7 @@ export class DocumentDefinition {
 
     private populateFieldParentPaths(field: Field, parentPath: string, depth: number): void {
         if (parentPath == null) {
-            parentPath = this.initCfg.pathSeparator;
+            parentPath = this.pathSeparator;
         }
         field.path = parentPath + field.getNameWithNamespace();
         if (field.isCollection) {
@@ -418,7 +381,7 @@ export class DocumentDefinition {
             field.serviceObject.path = field.path;
         }
         field.fieldDepth = depth;
-        const pathSeparator: string = this.initCfg.pathSeparator;
+        const pathSeparator: string = this.pathSeparator;
         for (const childField of field.children) {
             childField.parentField = field;
             this.populateFieldParentPaths(childField, field.path + pathSeparator, depth + 1);

--- a/ui/src/app/lib/atlasmap-data-mapper/models/document.definition.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/document.definition.model.ts
@@ -58,7 +58,7 @@ export class NamespaceModel {
 
 export class DocumentDefinition {
     public id: string;
-    public type: DocumentType;
+    public _type: DocumentType;
     public shortName: string;
     public fullName: string;
     public uri: string;
@@ -66,6 +66,7 @@ export class DocumentDefinition {
     public inspectionSource: string;
     public inspectionResult: string;
     public isSource: boolean;
+    public isPropertyOrConstant: boolean;
 
     public classPath: string;
     public initialized = false;
@@ -85,6 +86,15 @@ export class DocumentDefinition {
     public locale: string = null;
 
     private static noneField: Field = null;
+
+    set type(type: DocumentType) {
+        this._type = type;
+        this.isPropertyOrConstant = type == DocumentType.CONSTANT || type == DocumentType.PROPERTY;
+    }
+
+    get type(): DocumentType {
+        return this._type;
+    }
 
     public getComplexField(classIdentifier: string): Field {
         return this.complexFieldsByClassIdentifier[classIdentifier];
@@ -129,22 +139,14 @@ export class DocumentDefinition {
     }
 
     public getName(includeType: boolean): string {
-        let name: string = this.shortName;
-        if (ConfigModel.getConfig().showTypes && !this.isPropertyOrConstant()) {
-            const type: string = this.type;
+        let name = this.shortName;
+        if (ConfigModel.getConfig().showTypes && !this.isPropertyOrConstant) {
+            const type = this.type;
             if (type) {
                 name += ' (' + type + ')';
             }
         }
         return name;
-    }
-
-    public isPropertyOrConstant(): boolean {
-        const type: DocumentType = this.type;
-        if (!type) {
-            return false;
-        }
-        return type == DocumentType.CONSTANT || type == DocumentType.PROPERTY;
     }
 
     public getNamespaceForAlias(alias: string): NamespaceModel {
@@ -247,7 +249,7 @@ export class DocumentDefinition {
         Field.alphabetizeFields(this.fields);
         if (field.parentField == null
             || field.parentField == DocumentDefinition.getNoneField()
-            || this.isPropertyOrConstant()) {
+            || this.isPropertyOrConstant) {
             this.populateFieldParentPaths(field, null, 0);
         } else {
             const pathSeparator: string = this.pathSeparator;
@@ -265,7 +267,7 @@ export class DocumentDefinition {
     public addField(field: Field): void {
         if (field.parentField == null
             || field.parentField == DocumentDefinition.getNoneField()
-            || this.isPropertyOrConstant()) {
+            || this.isPropertyOrConstant) {
             this.fields.push(field);
             Field.alphabetizeFields(this.fields);
             this.populateFieldParentPaths(field, null, 0);

--- a/ui/src/app/lib/atlasmap-data-mapper/models/document.definition.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/document.definition.model.ts
@@ -56,7 +56,14 @@ export class NamespaceModel {
     }
 }
 
-export enum DocumentTypes { JAVA, XML, JSON, CSV, CONSTANT, PROPERTY}
+export enum DocumentTypes {
+    JAVA = 'Java',
+    XML = 'XML',
+    JSON = 'JSON',
+    CSV = 'CSV',
+    CONSTANT = 'Constants',
+    PROPERTY = 'Property'
+}
 
 export class DocumentType {
     public type: DocumentTypes = DocumentTypes.JAVA;
@@ -169,8 +176,10 @@ export class DocumentDefinition {
     public getName(includeType: boolean): string {
         let name: string = this.name;
         if (ConfigModel.getConfig().showTypes && !this.initCfg.type.isPropertyOrConstant()) {
-            const type: string = this.initCfg.type.isJava() ? ' (Java)' : ' (XML)';
-            name += type;
+            const type: string = this.initCfg.type.type;
+            if (type) {
+                name += ' (' + type + ')';
+            }
         }
         return name;
     }

--- a/ui/src/app/lib/atlasmap-data-mapper/models/field.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/field.model.ts
@@ -15,7 +15,7 @@
 */
 
 import { DocumentDefinition } from './document.definition.model';
-import { ConfigModel } from '../models/config.model';
+import { DocumentType, ConfigModel } from '../models/config.model';
 
 export class EnumValue {
     name: string;
@@ -152,15 +152,15 @@ export class Field {
     }
 
     public isPropertyOrConstant(): boolean {
-        return (this.docDef == null) ? false : this.docDef.initCfg.type.isPropertyOrConstant();
+        return (this.docDef == null) ? false : this.docDef.isPropertyOrConstant();
     }
 
     public isProperty(): boolean {
-        return (this.docDef == null) ? false : this.docDef.initCfg.type.isProperty();
+        return (this.docDef == null) ? false : this.docDef.type == DocumentType.PROPERTY;
     }
 
     public isConstant(): boolean {
-        return (this.docDef == null) ? false : this.docDef.initCfg.type.isConstant();
+        return (this.docDef == null) ? false : this.docDef.type == DocumentType.CONSTANT;
     }
 
     public static fieldHasUnmappedChild(field: Field): boolean {

--- a/ui/src/app/lib/atlasmap-data-mapper/models/field.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/field.model.ts
@@ -152,7 +152,7 @@ export class Field {
     }
 
     public isPropertyOrConstant(): boolean {
-        return (this.docDef == null) ? false : this.docDef.isPropertyOrConstant();
+        return (this.docDef == null) ? false : this.docDef.isPropertyOrConstant;
     }
 
     public isProperty(): boolean {

--- a/ui/src/app/lib/atlasmap-data-mapper/models/mapping.definition.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/mapping.definition.model.ts
@@ -199,8 +199,8 @@ export class MappingDefinition {
             }
         }
         for (const doc of cfg.getAllDocs()) {
-            if (doc.initCfg.shortIdentifier == null) {
-                doc.initCfg.shortIdentifier = 'DOC.' + doc.name + '.' + Math.floor((Math.random() * 1000000) + 1).toString();
+            if (doc.id == null) {
+                doc.id = 'DOC.' + doc.shortName + '.' + Math.floor((Math.random() * 1000000) + 1).toString();
             }
         }
     }
@@ -215,11 +215,11 @@ export class MappingDefinition {
                 continue;
             }
 
-            const doc = DocumentDefinition.getDocumentByIdentifier(parsedDoc.initCfg.documentIdentifier, docs);
+            const doc = DocumentDefinition.getDocumentByIdentifier(parsedDoc.id, docs);
             if (doc == null) {
-                cfg.errorService.error("Could not find document with identifier '" + parsedDoc.initCfg.documentIdentifier
+                cfg.errorService.error("Could not find document with identifier '" + parsedDoc.id
                     + "' for namespace override.",
-                    { 'identifier': parsedDoc.initCfg.documentIdentifier, 'parsedDoc': parsedDoc, 'docs': docs });
+                    { 'identifier': parsedDoc.id, 'parsedDoc': parsedDoc, 'docs': docs });
                 continue;
             }
 
@@ -287,7 +287,7 @@ export class MappingDefinition {
                     cfg.errorService.error('Could not find doc ID for mapped field.', mappedField);
                     continue;
                 }
-                doc.initCfg.shortIdentifier = mappedField.parsedData.parsedDocID;
+                doc.id = mappedField.parsedData.parsedDocID;
             }
             mappedField.field = null;
             if (!mappedField.parsedData.userCreated) {

--- a/ui/src/app/lib/atlasmap-data-mapper/services/initialization.service.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/services/initialization.service.ts
@@ -20,7 +20,7 @@ import 'rxjs/add/observable/forkJoin';
 import { Subject } from 'rxjs/Subject';
 import { Observable } from 'rxjs/Observable';
 
-import { ConfigModel } from '../models/config.model';
+import { DocumentType, InspectionType, DocumentInitializationModel, ConfigModel } from '../models/config.model';
 import { DocumentDefinition } from '../models/document.definition.model';
 import { MappingDefinition } from '../models/mapping.definition.model';
 
@@ -82,68 +82,76 @@ export class InitializationService {
         }
 
         if (this.cfg.initCfg.addMockJavaSources || this.cfg.initCfg.addMockJavaSingleSource) {
-            this.cfg.addJavaDocument('twitter4j.Status', true);
+            this.addJavaDocument('twitter4j.Status', true);
             if (this.cfg.initCfg.addMockJavaSources) {
-                this.cfg.addJavaDocument('io.atlasmap.java.test.TargetTestClass', true);
-                this.cfg.addJavaDocument('io.atlasmap.java.test.SourceContact', true);
-                this.cfg.addJavaDocument('io.atlasmap.java.test.SourceAddress', true);
-                this.cfg.addJavaDocument('io.atlasmap.java.test.TestListOrders', true);
-                this.cfg.addJavaDocument('io.atlasmap.java.test.TargetOrderArray', true);
-                this.cfg.addJavaDocument('io.atlasmap.java.test.SourceFlatPrimitiveClass', true);
-                this.cfg.addJavaDocument('io.atlasmap.java.test.SourceOrder', true);
+                this.addJavaDocument('io.atlasmap.java.test.TargetTestClass', true);
+                this.addJavaDocument('io.atlasmap.java.test.SourceContact', true);
+                this.addJavaDocument('io.atlasmap.java.test.SourceAddress', true);
+                this.addJavaDocument('io.atlasmap.java.test.TestListOrders', true);
+                this.addJavaDocument('io.atlasmap.java.test.TargetOrderArray', true);
+                this.addJavaDocument('io.atlasmap.java.test.SourceFlatPrimitiveClass', true);
+                this.addJavaDocument('io.atlasmap.java.test.SourceOrder', true);
             }
         }
 
         if (this.cfg.initCfg.addMockJavaCachedSource) {
-            const docDef: DocumentDefinition = this.cfg.addJavaDocument('io.atlasmap.java.test.Name', true);
-            docDef.initCfg.inspectionResultContents = DocumentManagementService.generateMockJavaDoc();
+            const docDef: DocumentDefinition = this.addJavaDocument('io.atlasmap.java.test.Name', true);
+            docDef.inspectionResult = DocumentManagementService.generateMockJavaDoc();
         }
 
         if (this.cfg.initCfg.addMockXMLInstanceSources) {
-            this.cfg.addXMLInstanceDocument('XMLInstanceSource', DocumentManagementService.generateMockInstanceXMLDoc(), true);
+            this.addNonJavaDocument('XMLInstanceSource', DocumentType.XML, InspectionType.INSTANCE,
+                    DocumentManagementService.generateMockInstanceXMLDoc(), true);
         }
 
         if (this.cfg.initCfg.addMockXMLSchemaSources) {
-            this.cfg.addXMLSchemaDocument('XMLSchemaSource', DocumentManagementService.generateMockSchemaXMLDoc(), true);
+            this.addNonJavaDocument('XMLSchemaSource', DocumentType.XML, InspectionType.SCHEMA,
+                    DocumentManagementService.generateMockSchemaXMLDoc(), true);
         }
 
         if (this.cfg.initCfg.addMockJSONSources || this.cfg.initCfg.addMockJSONInstanceSources) {
-            this.cfg.addJSONInstanceDocument('JSONInstanceSource', DocumentManagementService.generateMockJSONInstanceDoc(), true);
+            this.addNonJavaDocument('JSONInstanceSource', DocumentType.JSON, InspectionType.INSTANCE,
+                    DocumentManagementService.generateMockJSONInstanceDoc(), true);
         }
 
         if (this.cfg.initCfg.addMockJSONSchemaSources) {
-            this.cfg.addJSONSchemaDocument('JSONSchemaSource', DocumentManagementService.generateMockJSONSchemaDoc(), true);
+            this.addNonJavaDocument('JSONSchemaSource', DocumentType.JSON, InspectionType.SCHEMA,
+                    DocumentManagementService.generateMockJSONSchemaDoc(), true);
         }
 
         if (this.cfg.initCfg.addMockJavaTarget) {
-            this.cfg.addJavaDocument('io.atlasmap.java.test.TargetTestClass', false);
-            this.cfg.addJavaDocument('io.atlasmap.java.test.SourceContact', false);
-            this.cfg.addJavaDocument('io.atlasmap.java.test.SourceAddress', false);
-            this.cfg.addJavaDocument('io.atlasmap.java.test.TestListOrders', false);
-            this.cfg.addJavaDocument('io.atlasmap.java.test.TargetOrderArray', false);
-            this.cfg.addJavaDocument('io.atlasmap.java.test.SourceFlatPrimitiveClass', false);
-            this.cfg.addJavaDocument('io.atlasmap.java.test.SourceOrder', false);
+            this.addJavaDocument('io.atlasmap.java.test.TargetTestClass', false);
+            this.addJavaDocument('io.atlasmap.java.test.SourceContact', false);
+            this.addJavaDocument('io.atlasmap.java.test.SourceAddress', false);
+            this.addJavaDocument('io.atlasmap.java.test.TestListOrders', false);
+            this.addJavaDocument('io.atlasmap.java.test.TargetOrderArray', false);
+            this.addJavaDocument('io.atlasmap.java.test.SourceFlatPrimitiveClass', false);
+            this.addJavaDocument('io.atlasmap.java.test.SourceOrder', false);
       }
 
         if (this.cfg.initCfg.addMockJavaCachedTarget) {
-            const docDef: DocumentDefinition = this.cfg.addJavaDocument('io.atlasmap.java.test.Name', false);
-            docDef.initCfg.inspectionResultContents = DocumentManagementService.generateMockJavaDoc();
+            const docDef: DocumentDefinition = this.addJavaDocument('io.atlasmap.java.test.Name', false);
+            docDef.inspectionResult = DocumentManagementService.generateMockJavaDoc();
         }
 
         if (this.cfg.initCfg.addMockXMLInstanceTarget) {
-            this.cfg.addXMLInstanceDocument('XMLInstanceTarget', DocumentManagementService.generateMockInstanceXMLDoc(), false);
+            this.addNonJavaDocument('XMLInstanceTarget', DocumentType.XML, InspectionType.INSTANCE,
+                    DocumentManagementService.generateMockInstanceXMLDoc(), false);
         }
 
         if (this.cfg.initCfg.addMockXMLSchemaTarget) {
-            this.cfg.addXMLSchemaDocument('XMLSchemaTarget', DocumentManagementService.generateMockSchemaXMLDoc(), false);
+            this.addNonJavaDocument('XMLSchemaTarget', DocumentType.XML, InspectionType.SCHEMA,
+                    DocumentManagementService.generateMockSchemaXMLDoc(), false);
         }
 
         if (this.cfg.initCfg.addMockJSONTarget || this.cfg.initCfg.addMockJSONInstanceTarget) {
-            this.cfg.addJSONInstanceDocument('JSONInstanceTarget', DocumentManagementService.generateMockJSONInstanceDoc(), false);
+            this.addNonJavaDocument('JSONInstanceTarget', DocumentType.JSON, InspectionType.INSTANCE,
+                    DocumentManagementService.generateMockJSONInstanceDoc(), false);
         }
 
         if (this.cfg.initCfg.addMockJSONSchemaTarget) {
-            this.cfg.addJSONSchemaDocument('JSONSchemaTarget', DocumentManagementService.generateMockJSONSchemaDoc(), false);
+            this.addNonJavaDocument('JSONSchemaTarget', DocumentType.JSON, InspectionType.SCHEMA,
+                    DocumentManagementService.generateMockJSONSchemaDoc(), false);
         }
 
         //load field actions
@@ -182,29 +190,51 @@ export class InitializationService {
         }
     }
 
+    private addJavaDocument(className: string, isSource: boolean): DocumentDefinition {
+        const model: DocumentInitializationModel = new DocumentInitializationModel();
+        model.id = className;
+        model.type = DocumentType.JAVA;
+        model.inspectionType = InspectionType.JAVA_CLASS;
+        model.inspectionSource = className;
+        model.isSource = isSource;
+        return this.cfg.addDocument(model);
+    }
+
+    private addNonJavaDocument(
+            name: string, documentType: DocumentType, inspectionType: InspectionType,
+            inspectionSource: string, isSource: boolean): DocumentDefinition {
+        const model: DocumentInitializationModel = new DocumentInitializationModel();
+        model.id = name;
+        model.type = documentType;
+        model.inspectionType = inspectionType;
+        model.inspectionSource = inspectionSource;
+        model.isSource = isSource;
+        return this.cfg.addDocument(model);
+    }
+
     private fetchDocuments(): void {
         this.updateLoadingStatus('Loading source/target documents.');
         for (const docDef of this.cfg.getAllDocs()) {
             if (docDef == this.cfg.propertyDoc || docDef == this.cfg.constantDoc) {
-                docDef.initCfg.initialized = true;
+                docDef.initialized = true;
                 continue;
             }
 
-            const docName: string = docDef.initCfg.shortIdentifier;
+            const docName: string = docDef.shortName;
 
-            if (docDef.initCfg.type.isJava() && this.cfg.initCfg.baseJavaInspectionServiceUrl == null) {
+            if (docDef.type == DocumentType.JAVA && this.cfg.initCfg.baseJavaInspectionServiceUrl == null) {
                 this.cfg.errorService.warn('Java inspection service is not configured. Document will not be loaded: ' + docName, docDef);
-                docDef.initCfg.initialized = true;
+                docDef.initialized = true;
                 this.updateStatus();
                 continue;
-            } else if (docDef.initCfg.type.isXML() && this.cfg.initCfg.baseXMLInspectionServiceUrl == null) {
+            } else if (docDef.type == DocumentType.XML && this.cfg.initCfg.baseXMLInspectionServiceUrl == null) {
                 this.cfg.errorService.warn('XML inspection service is not configured. Document will not be loaded: ' + docName, docDef);
-                docDef.initCfg.initialized = true;
+                docDef.initialized = true;
                 this.updateStatus();
                 continue;
-            } else if (docDef.initCfg.type.isJSON() && this.cfg.initCfg.baseJSONInspectionServiceUrl == null) {
+            } else if (docDef.type == DocumentType.JSON && this.cfg.initCfg.baseJSONInspectionServiceUrl == null) {
                 this.cfg.errorService.warn('JSON inspection service is not configured. Document will not be loaded: ' + docName, docDef);
-                docDef.initCfg.initialized = true;
+                docDef.initialized = true;
                 this.updateStatus();
                 continue;
             }
@@ -214,7 +244,7 @@ export class InitializationService {
                     this.updateStatus();
                 },
                 (error: any) => { this.handleError("Could not load document '"
-                    + docDef.initCfg.documentIdentifier + "'.", error); },
+                    + docDef.id + "'.", error); },
             );
         }
     }
@@ -260,7 +290,7 @@ export class InitializationService {
         const documentCount: number = this.cfg.getAllDocs().length;
         let finishedDocCount = 0;
         for (const docDef of this.cfg.getAllDocs()) {
-            if (docDef.initCfg.initialized || docDef.initCfg.errorOccurred) {
+            if (docDef.initialized || docDef.errorOccurred) {
                 finishedDocCount++;
             }
         }

--- a/ui/src/app/lib/atlasmap-data-mapper/services/mapping.serializer.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/services/mapping.serializer.ts
@@ -21,7 +21,7 @@ import { Field } from '../models/field.model';
 import { MappingDefinition } from '../models/mapping.definition.model';
 import { DocumentDefinition, NamespaceModel } from '../models/document.definition.model';
 import { LookupTable, LookupTableEntry } from '../models/lookup.table.model';
-import { ConfigModel } from '../models/config.model';
+import { DocumentType, ConfigModel } from '../models/config.model';
 
 export class MappingSerializer {
 
@@ -105,7 +105,7 @@ export class MappingSerializer {
             const docType: string = doc.isSource ? 'SOURCE' : 'TARGET';
             const serializedDoc: any = {
                 'jsonType' : 'io.atlasmap.v2.DataSource',
-                'id': doc.initCfg.shortIdentifier,
+                'id': doc.id,
                 'uri': doc.uri,
                 'dataSourceType': docType,
             };
@@ -115,7 +115,7 @@ export class MappingSerializer {
             if (doc.locale != null) {
                 serializedDoc['locale'] = doc.locale;
             }
-            if (doc.initCfg.type.isXML()) {
+            if (doc.type == DocumentType.XML) {
                 serializedDoc['jsonType'] = 'io.atlasmap.xml.v2.XmlDataSource';
                 const namespaces: any[] = [];
                 for (const ns of doc.namespaces) {
@@ -130,7 +130,7 @@ export class MappingSerializer {
                     serializedDoc['template'] = mappingDefinition.templateText;
                 }
                 serializedDoc['xmlNamespaces'] = { 'xmlNamespace': namespaces };
-            } else if (doc.initCfg.type.isJSON()) {
+            } else if (doc.type == DocumentType.JSON) {
                 if (!doc.isSource) {
                     serializedDoc['template'] = mappingDefinition.templateText;
                 }
@@ -196,9 +196,9 @@ export class MappingSerializer {
                 'path': field.path,
                 'fieldType': field.type,
                 'value': field.value,
-                'docId': field.docDef.initCfg.shortIdentifier,
+                'docId': field.docDef.id,
             };
-            if (field.docDef.initCfg.type.isXML() || field.docDef.initCfg.type.isJSON()) {
+            if (field.docDef.type == DocumentType.XML || field.docDef.type == DocumentType.JSON) {
                 serializedField['userCreated'] = field.userCreated;
             }
             if (field.isProperty()) {
@@ -277,8 +277,8 @@ export class MappingSerializer {
         for (const docRef of json.AtlasMapping.dataSource) {
             const doc: DocumentDefinition = new DocumentDefinition();
             doc.isSource = (docRef.dataSourceType == 'SOURCE');
-            doc.initCfg.documentIdentifier = docRef.uri;
-            doc.initCfg.shortIdentifier = docRef.id;
+            doc.uri = docRef.uri;
+            doc.id = docRef.id;
             if (docRef.xmlNamespaces && docRef.xmlNamespaces.xmlNamespace) {
                 for (const svcNS of docRef.xmlNamespaces.xmlNamespace) {
                     const ns: NamespaceModel = new NamespaceModel();


### PR DESCRIPTION
Introduced a `DocumentInitializationModel` which is a subset of `DocumentDefinition`
```TypeScript
export class DocumentInitializationModel {
    public id: string; // Document ID. Syndesis would put Step UUID.
    public type: DocumentType;
    public shortName: string; // Document label. Syndesis would put "Salesforce Contact (Step 1)" here
    public fullName: string; // Shown as a tooltip. Put a longer description for the document
    public isSource: boolean;
    public inspectionType: InspectionType;
    public inspectionSource: string;
    public inspectionResult: string;
}
```
and let `ConfigModel` accept it via
```TypeScript
addDocument(docInitModel: DocumentInitializationModel): DocumentDefinition
```
and
```TypeScript
addDocuments(docModels: DocumentInitializationModel[]): DocumentDefinition[]
``` 

Also
fix: Show correct document type (#88)