### PR TITLE
fix: UI is missing namespace prefix in XML field path

### DIFF
--- a/camel/pom.xml
+++ b/camel/pom.xml
@@ -129,6 +129,11 @@
             <artifactId>twitter4j-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-matchers</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/camel/src/test/java/org/apache/camel/component/atlasmap/AtlasMapMultiNSTest.java
+++ b/camel/src/test/java/org/apache/camel/component/atlasmap/AtlasMapMultiNSTest.java
@@ -1,0 +1,64 @@
+package org.apache.camel.component.atlasmap;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.spring.CamelSpringRunner;
+import org.apache.camel.test.spring.CamelTestContextBootstrapper;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.BootstrapWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.builder.Input;
+import org.xmlunit.diff.Diff;
+
+import io.atlasmap.java.test.SourceContact;
+
+@RunWith(CamelSpringRunner.class)
+@BootstrapWith(CamelTestContextBootstrapper.class)
+@ContextConfiguration
+public class AtlasMapMultiNSTest {
+
+    private static final String XML_EXPECTED =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                    "<tns:request xmlns:tns=\"http://syndesis.io/v1/swagger-connector-template/request\">\n" +
+                    "  <tns:body>\n" +
+                    "    <Pet>\n" +
+                    "      <name>Jackson</name>\n" +
+                    "    </Pet>\n" +
+                    "  </tns:body>\n" +
+                    "</tns:request>";
+
+    @Autowired
+    protected CamelContext camelContext;
+
+    @EndpointInject(uri = "mock:result")
+    protected MockEndpoint result;
+
+    @Test
+    @DirtiesContext
+    public void test() throws Exception {
+        result.setExpectedCount(1);
+
+        ProducerTemplate producerTemplate = camelContext.createProducerTemplate();
+        SourceContact c = new SourceContact();
+        c.setFirstName("Jackson");
+        producerTemplate.sendBody("direct:start", c);
+
+        MockEndpoint.assertIsSatisfied(camelContext);
+        Exchange exchange = result.getExchanges().get(0);
+        String out = exchange.getIn().getBody(String.class);
+        Assert.assertNotNull(out);
+        Diff d = DiffBuilder.compare(Input.fromString(XML_EXPECTED).build())
+                .withTest(Input.fromString(out).build())
+                .ignoreWhitespace().build();
+        Assert.assertFalse(d.toString() + ": " + out, d.hasDifferences());
+    }
+
+}

--- a/camel/src/test/resources/atlasmapping-multins.xml
+++ b/camel/src/test/resources/atlasmapping-multins.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<AtlasMapping xmlns="http://atlasmap.io/v2" xmlns:ns2="http://atlasmap.io/java/v2" xmlns:ns3="http://atlasmap.io/xml/v2" xmlns:ns4="http://atlasmap.io/json/v2" name="UI.860284">
+    <DataSource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ns2:JavaDataSource" id="SourceContact" uri="atlas:java:SourceContact?className=io.atlasmap.java.test.SourceContact" dataSourceType="Source" />
+    <DataSource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ns3:XmlDataSource" id="XMLSchemaTarget" uri="atlas:xml:XMLSchemaTarget" dataSourceType="Target">
+        <ns3:XmlNamespaces>
+            <ns3:XmlNamespace alias="tns" uri="http://syndesis.io/v1/swagger-connector-template/request"/>
+        </ns3:XmlNamespaces>
+    </DataSource>
+    <Mappings>
+        <Mapping xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="Mapping" id="mapping.222691" mappingType="Map">
+            <InputField xsi:type="ns2:JavaField" name="firstName" getMethod="getFirstName" docId="SourceContact" path="/firstName" fieldType="String"/>
+            <OutputField xsi:type="ns3:XmlField" name="name" userCreated="false" docId="XMLSchemaTarget" path="/tns:request/tns:body/Pet/name" fieldType="String"/>
+        </Mapping>
+    </Mappings>
+    <LookupTables/>
+    <Properties/>
+</AtlasMapping>

--- a/camel/src/test/resources/org/apache/camel/component/atlasmap/AtlasMapMultiNSTest-context.xml
+++ b/camel/src/test/resources/org/apache/camel/component/atlasmap/AtlasMapMultiNSTest-context.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+    <camelContext xmlns="http://camel.apache.org/schema/spring">
+        <route>
+            <from uri="direct:start" />
+            <to uri="atlas:atlasmapping-multins.xml" />
+            <to uri="mock:result" />
+        </route>
+    </camelContext>
+
+</beans>

--- a/ui/src/app/lib/atlasmap-data-mapper/models/field.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/field.model.ts
@@ -58,7 +58,7 @@ export class Field {
     }
 
     getNameWithNamespace(): string {
-        if (!this.docDef || !this.namespaceAlias) {
+        if (!this.namespaceAlias) {
             return this.name;
         }
         return this.namespaceAlias + ':' + this.name;

--- a/ui/src/app/lib/atlasmap-data-mapper/services/document.management.service.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/services/document.management.service.ts
@@ -577,6 +577,68 @@ export class DocumentManagementService {
             </xs:schema>
         `;
 
+        mockDoc = `
+        <d:SchemaSet xmlns:d="http://atlasmap.io/xml/schemaset/v2" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+          <xsd:schema targetNamespace="http://syndesis.io/v1/swagger-connector-template/request" elementFormDefault="qualified">
+            <xsd:element name="request">
+              <xsd:complexType>
+                <xsd:sequence>
+                  <xsd:element name="body">
+                    <xsd:complexType>
+                      <xsd:sequence>
+                        <xsd:element ref="Pet" />
+                      </xsd:sequence>
+                    </xsd:complexType>
+                  </xsd:element>
+                </xsd:sequence>
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:schema>
+          <d:AdditionalSchemas>
+            <xsd:schema>
+              <xsd:element name="Pet">
+                <xsd:complexType>
+                  <xsd:sequence>
+                    <xsd:element name="id" type="xsd:decimal" />
+                    <xsd:element name="Category">
+                      <xsd:complexType>
+                        <xsd:sequence>
+                          <xsd:element name="id" type="xsd:decimal" />
+                          <xsd:element name="name" type="xsd:string" />
+                        </xsd:sequence>
+                      </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="name" type="xsd:string" />
+                    <xsd:element name="photoUrl">
+                      <xsd:complexType>
+                        <xsd:sequence>
+                          <xsd:element name="photoUrl" type="xsd:string" maxOccurs="unbounded" minOccurs="0" />
+                        </xsd:sequence>
+                      </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="tag">
+                      <xsd:complexType>
+                        <xsd:sequence>
+                          <xsd:element name="Tag" maxOccurs="unbounded" minOccurs="0">
+                            <xsd:complexType>
+                              <xsd:sequence>
+                                <xsd:element name="id" type="xsd:decimal" />
+                                <xsd:element name="name" type="xsd:string" />
+                              </xsd:sequence>
+                            </xsd:complexType>
+                          </xsd:element>
+                        </xsd:sequence>
+                      </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="status" type="xsd:string" />
+                  </xsd:sequence>
+                </xsd:complexType>
+              </xsd:element>
+            </xsd:schema>
+          </d:AdditionalSchemas>
+        </d:SchemaSet>
+        `;
+
         return mockDoc;
     }
 


### PR DESCRIPTION
Fixes: #290 

Bug fix is just this one line change. No idea why it was looking at `this.docDef` at first place.
https://github.com/atlasmap/atlasmap/compare/master...igarashitm:290-ui?expand=1#diff-32bc31d431be77cf4e612663bb4cccee

Also added a mock XML schema doc in UI and a test case for camel-atlasmap.