### PR TITLE
fix: Issue an error if the user attempts to create a property with th…

### DIFF
--- a/ui/src/app/lib/atlasmap-data-mapper/components/document-definition.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/document-definition.component.ts
@@ -184,11 +184,29 @@ export class DocumentDefinitionComponent implements OnInit {
     this.modalWindow.nestedComponentType = isProperty ? PropertyFieldEditComponent
       : (isConstant ? ConstantFieldEditComponent : FieldEditComponent);
     this.modalWindow.okButtonHandler = (mw: ModalWindowComponent) => {
+      let candidateField: Field = null;
+
       if (isProperty) {
         const propertyComponent = mw.nestedComponent as PropertyFieldEditComponent;
+
+        // check if field name already exists in docDef
+        candidateField = propertyComponent.getField();
+        if (docDef.fieldExists(candidateField, DocumentType.PROPERTY)) {
+            this.cfg.errorService.error("Property name '" + candidateField.getFieldLabel(false, false) +
+              "' already exists.  Please select a unique name.", '');
+            return;
+        }
         docDef.addField(propertyComponent.getField());
       } else if (isConstant) {
         const constantComponent = mw.nestedComponent as ConstantFieldEditComponent;
+
+        // check if field name already exists in docDef
+        candidateField = constantComponent.getField();
+        if (docDef.fieldExists(candidateField, DocumentType.CONSTANT)) {
+            this.cfg.errorService.error("Constant '" + candidateField.getFieldLabel(false, false) +
+              "' already exists.", '');
+            return;
+        }
         docDef.addField(constantComponent.getField());
       } else {
         const fieldComponent = mw.nestedComponent as FieldEditComponent;

--- a/ui/src/app/lib/atlasmap-data-mapper/models/document-definition.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/document-definition.model.ts
@@ -119,6 +119,22 @@ export class DocumentDefinition {
     return DocumentDefinition.noneField;
   }
 
+  /**
+   * Return true is the specified field name already exists in the specified document definition,
+   * false otherwise.
+   * @param targetField
+   * @param targetFieldDocDefType
+   */
+  fieldExists(targetField: Field, targetFieldDocDefType: DocumentType): boolean {
+
+    for (const field of this.getAllFields()) {
+      if (field.name == targetField.name && field.docDef.type == targetFieldDocDefType) {
+          return true;
+      }
+    }
+    return false;
+  }
+
   isFieldsExist(fields: Field[]): boolean {
     if (fields == null || fields.length == 0) {
       return true;


### PR DESCRIPTION
…e same name or a constant with the same value.

Fixes: #104 
@igarashitm - this is what the error diagnostic looks like when I attempt to add another property 'cat' and another constant '3.14159':

![atlas1](https://user-images.githubusercontent.com/2981421/37305967-915e41f8-260c-11e8-942f-686118556675.png)
