### PR TITLE
Fix for #368 (2nd try): [NumberFieldActions] java.lang.NoSuchMethodEx…

### DIFF
--- a/ui/src/app/lib/atlasmap-data-mapper/models/transition.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/transition.model.ts
@@ -100,28 +100,23 @@ export class FieldActionConfig {
     const sourceField: Field = fieldPair.getFields(true)[0];
     const targetField: Field = fieldPair.getFields(false)[0];
 
-    if ((sourceField == null) || (targetField == null)) {
+    if (sourceField == null || targetField == null) {
       return false;
     }
 
-    // Check if source/target collection types match
+    // Check if target collection type matches action collection type (since currently all actions are performed on target)
     // Note, specifically not handling array, list, or map here since I don't believe we'll ever have functions that only apply to
-    // arrays or lists exclusively, and we don't currently see anyway to determine whether a map is even involved
-    if (this.serviceObject.sourceCollectionType == 'NONE' && sourceField.getCollectionType() != null) {
-      return false;
-    }
+    // arrays or lists exclusively, and I don't currently see anyway to determine whether a map is even involved
     if (this.serviceObject.sourceCollectionType == 'ALL'
         && this.sourceType != 'ANY'
-        && ['ARRAY', 'LIST'].indexOf(sourceField.getCollectionType()) == -1
-        && sourceField.type != 'STRING') {
-      return false;
-    }
-    if (this.serviceObject.targetCollectionType == 'NONE' && targetField.getCollectionType() != null) {
-      return false;
-    }
-    if (this.serviceObject.targetCollectionType == 'ALL'
         && ['ARRAY', 'LIST'].indexOf(targetField.getCollectionType()) == -1
         && targetField.type != 'STRING') {
+      return false;
+    }
+    if (this.serviceObject.sourceCollectionType == 'NONE' && targetField.getCollectionType() != null) {
+      return false;
+    }
+    if (this.sourceType != 'ANY' && this.serviceObject.sourceCollectionType != this.serviceObject.targetCollectionType) {
       return false;
     }
 
@@ -140,7 +135,7 @@ export class FieldActionConfig {
     }
 
     // All other types must match the mapped field types with the field action types.
-    return ((this.sourceType == 'ANY' || sourceField.type == this.sourceType) && (targetField.type == this.targetType));
+    return ((this.sourceType == 'ANY' || targetField.type == this.sourceType) && (targetField.type == this.targetType));
   }
 
   populateFieldAction(action: FieldAction): void {


### PR DESCRIPTION
…ception during Collection<Number> -> Number mapping field actions

Fixes #368 

This is overrides the previous PR with a similar name (#384) as it missed taking into consideration that since all actions are currently applied to the target field only, the type and collection type must match between the target field, action source, and action target.