### PR TITLE
fix: Deliver possible values for enum field action parameters

### DIFF
--- a/runtime/core/src/test/java/io/atlasmap/core/DefaultAtlasFieldActionsServiceTest.java
+++ b/runtime/core/src/test/java/io/atlasmap/core/DefaultAtlasFieldActionsServiceTest.java
@@ -16,10 +16,10 @@ import io.atlasmap.api.AtlasException;
 import io.atlasmap.v2.AbsoluteValue;
 import io.atlasmap.v2.Action;
 import io.atlasmap.v2.ActionDetail;
+import io.atlasmap.v2.ActionParameter;
 import io.atlasmap.v2.Actions;
 import io.atlasmap.v2.FieldType;
 import io.atlasmap.v2.GenerateUUID;
-import io.atlasmap.v2.Property;
 import io.atlasmap.v2.SimpleField;
 import io.atlasmap.v2.Trim;
 
@@ -52,9 +52,9 @@ public class DefaultAtlasFieldActionsServiceTest {
         for (ActionDetail d : actionDetails) {
             if (d.getParameters() != null) {
                 System.out.println("Action: " + d.getName());
-                for (Property prop : d.getParameters().getProperty()) {
-                    System.out.println("\t param: " + prop.getName());
-                    System.out.println("\t type: " + prop.getFieldType().value());
+                for (ActionParameter param : d.getParameters().getParameter()) {
+                    System.out.println("\t param: " + param.getName());
+                    System.out.println("\t type: " + param.getFieldType().value());
                 }
             }
         }

--- a/runtime/model/src/main/resources/atlas-model-v2.xsd
+++ b/runtime/model/src/main/resources/atlas-model-v2.xsd
@@ -343,7 +343,7 @@
 
   <simpleType name="MassUnitType">
     <restriction base="string">
-      <enumeration value="KiloGram" />
+      <enumeration value="Kilo Gram" />
       <enumeration value="Pound" />
     </restriction>
   </simpleType>
@@ -360,18 +360,18 @@
 
   <simpleType name="AreaUnitType">
     <restriction base="string">
-      <enumeration value="SquareMeter" />
-      <enumeration value="SquareMile" />
-      <enumeration value="SquareFoot" />
+      <enumeration value="Square Meter" />
+      <enumeration value="Square Mile" />
+      <enumeration value="Square Foot" />
     </restriction>
   </simpleType>
 
   <simpleType name="VolumeUnitType">
     <restriction base="string">
-      <enumeration value="CubicMeter" />
+      <enumeration value="Cubic Meter" />
       <enumeration value="Litter" />
-      <enumeration value="CubicFoot" />
-      <enumeration value="Gallon_US_Fluid" />
+      <enumeration value="Cubic Foot" />
+      <enumeration value="Gallon US Fluid" />
     </restriction>
   </simpleType>
 
@@ -422,7 +422,7 @@
 
   <complexType name="ActionDetail">
     <sequence>
-      <element name="Parameters" type="atlas:Properties"
+      <element name="Parameters" type="atlas:ActionParameters"
         minOccurs="0" maxOccurs="1" />
     </sequence>
     <attribute name="name" type="string" use="required" />
@@ -437,6 +437,24 @@
     <attribute name="targetCollectionType" type="atlas:CollectionType"
       use="optional" />
   </complexType>
+
+  <complexType name="ActionParameters">
+    <sequence>
+      <element name="parameter" type="atlas:ActionParameter"
+        minOccurs="0" maxOccurs="unbounded" />
+    </sequence>
+  </complexType>
+
+  <complexType name="ActionParameter">
+    <sequence>
+      <element name="values" type="string" minOccurs="0" maxOccurs="unbounded" />
+    </sequence>
+    <attribute name="name" type="string" use="required" />
+    <attribute name="displayName" type="string" use="optional" />
+    <attribute name="description" type="string" use="optional" />
+    <attribute name="fieldType" type="atlas:FieldType" use="optional" />
+  </complexType>
+
 
   <complexType name="ActionDetails">
     <sequence>

--- a/ui/src/app/lib/atlasmap-data-mapper/models/transition.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/transition.model.ts
@@ -20,6 +20,7 @@ import { FieldMappingPair } from './mapping.model';
 export class FieldActionArgument {
   name: string = null;
   type = 'STRING';
+  values = null;
   serviceObject: any = new Object();
 }
 

--- a/ui/src/app/lib/atlasmap-data-mapper/services/mapping-management.service.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/services/mapping-management.service.ts
@@ -447,13 +447,14 @@ export class MappingManagementService {
               fieldActionConfig.method = svcConfig.method;
               fieldActionConfig.serviceObject = svcConfig;
 
-              if (svcConfig.parameters && svcConfig.parameters.property
-                && svcConfig.parameters.property.length) {
-                for (const svcProperty of svcConfig.parameters.property) {
+              if (svcConfig.parameters && svcConfig.parameters.parameter
+                && svcConfig.parameters.parameter.length) {
+                for (const svcParameter of svcConfig.parameters.parameter) {
                   const argumentConfig: FieldActionArgument = new FieldActionArgument();
-                  argumentConfig.name = svcProperty.name;
-                  argumentConfig.type = svcProperty.fieldType;
-                  argumentConfig.serviceObject = svcProperty;
+                  argumentConfig.name = svcParameter.name;
+                  argumentConfig.type = svcParameter.fieldType;
+                  argumentConfig.values = svcParameter.values;
+                  argumentConfig.serviceObject = svcParameter;
                   fieldActionConfig.arguments.push(argumentConfig);
                 }
               }


### PR DESCRIPTION
Partially addresses #386
Now FieldActionArgument.values can be used to show possible values