### PR TITLE
fix: Modify the actions JSON deserializer to support XML generation f…

### DIFF
--- a/runtime/model/src/main/java/io/atlasmap/v2/ActionsJsonDeserializer.java
+++ b/runtime/model/src/main/java/io/atlasmap/v2/ActionsJsonDeserializer.java
@@ -387,13 +387,33 @@ public class ActionsJsonDeserializer extends JsonDeserializer<Actions> {
 
     }
 
-    protected ConvertVolumeUnit processConvertVolumeUnitJsonToken(JsonParser jsonToken) {
+    protected ConvertVolumeUnit processConvertVolumeUnitJsonToken(JsonParser jsonToken)  throws IOException {
         ConvertVolumeUnit action = new ConvertVolumeUnit();
-
         if (JsonToken.END_ARRAY.equals(jsonToken.currentToken())
                 || JsonToken.END_OBJECT.equals(jsonToken.currentToken())) {
             return action;
         }
+
+        JsonToken nextToken = null;
+        do {
+            if (JsonToken.START_OBJECT.equals(jsonToken.currentToken())) {
+                jsonToken.nextToken();
+            }
+            switch (jsonToken.getCurrentName()) {
+            case ActionsJsonSerializer.FROM_UNIT:
+                jsonToken.nextToken();
+                action.setFromUnit(VolumeUnitType.fromValue(jsonToken.getValueAsString()));
+                break;
+            case ActionsJsonSerializer.TO_UNIT:
+                jsonToken.nextToken();
+                action.setToUnit(VolumeUnitType.fromValue(jsonToken.getValueAsString()));
+                break;
+            default:
+                break;
+            }
+
+            nextToken = jsonToken.nextToken();
+        } while (!JsonToken.END_ARRAY.equals(nextToken) && !JsonToken.END_OBJECT.equals(nextToken));
 
         return action;
     }

--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-action.component.html
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-action.component.html
@@ -17,7 +17,7 @@
     <div class="form-group argument" *ngFor="let argConfig of action.config.arguments; let argValIndex = index">
       <label style="">{{ getLabel(argConfig.name) }}</label>
 
-      <select (change)="actionConfigParamSelectionChanged($event);" [ngModel]="argConfig.values[argValIndex]">
+      <select (change)="actionConfigParamSelectionChanged($event);" [ngModel]="getActionConfigParamVDefault(argConfig, actionIndex, argValIndex)">
         <option *ngFor="let actionConfigParamVal of getActionConfigParamValues(argConfig)" [attr.argValIndex]="argValIndex"
                        [attr.actionIndex]="actionIndex" [attr.value]="actionConfigParamVal">{{ actionConfigParamVal }}</option>
       </select>

--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-action.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-action.component.ts
@@ -152,4 +152,22 @@ export class MappingFieldActionComponent {
       default: return '';
     }
   }
+
+  /**
+   * Return a string representing the default value for the field action argument pull-down.  If a mapped
+   * field already exists for this component then use that to determine the displayed valued in the
+   * pull-down; otherwise use the sequential configuration value based on the argument value index.
+   *
+   * @param argConfig - argument configuration used if no mapped field exists
+   * @param actionIndex - used when multiple actions are specified
+   * @param argValIndex - index into the argument values for any one specific action.
+   */
+  getActionConfigParamVDefault(argConfig: FieldActionArgument, actionIndex: number, argValIndex: number): String {
+    const action: FieldAction = this.getMappedFieldActions()[actionIndex];
+    if (action != null && action.argumentValues.length > 0) {
+      return action.argumentValues[argValIndex].value;
+    } else {
+      return argConfig.values[argValIndex];
+    }
+  }
 }


### PR DESCRIPTION
…or the ConvertVolumeUnit transformation
Also correct an issue with the default value for the field action argument pull-down.  If a mapped field already exists for this component then use that to determine the displayed valued in the pull-down; otherwise use the sequential configuration value based on the argument value index.

Fixes: #401