### PR TITLE
fix: Correct action field parameter input text field processing

### DIFF
--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-action.component.html
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-action.component.html
@@ -16,7 +16,7 @@
     </div>
     <div class="form-group argument" *ngFor="let argConfig of action.config.arguments; let argValIndex = index">
       <label style="">{{ getLabel(argConfig.name) }}</label>
-      <div *ngIf="argConfig.values != null; else textInput">
+      <div *ngIf="argConfig.values != null && argConfig.values.length > 0; else textInput">
         <select (change)="actionConfigParamSelectionChanged($event);" [ngModel]="getActionConfigParamVDefault(argConfig, actionIndex, argValIndex)">
           <option *ngFor="let actionConfigParamVal of getActionConfigParamValues(argConfig)" [attr.argValIndex]="argValIndex"
                          [attr.actionIndex]="actionIndex" [attr.value]="actionConfigParamVal">{{ actionConfigParamVal }}</option>
@@ -25,7 +25,7 @@
       <ng-template #textInput>
         <label style="">{{ argConfig.name }}</label>
         <input type="text" class="input-{{argConfig.name}}" [(ngModel)]="action.getArgumentValue(argConfig.name).value" 
-          (change)="selectionChanged($event)"/>
+          (change)="actionConfigParamSelectionChanged($event)"/>
       </ng-template>
       <div class="clear"></div>
     </div>

--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-action.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-action.component.ts
@@ -89,18 +89,23 @@ export class MappingFieldActionComponent {
   }
 
   /**
-   * A mapping field action parameter selection has been made from a pull-down menu.
+   * A mapping field action parameter selection has been made either from a pull-down menu
+   * or from user input to a text field.
    * @param event
    */
   actionConfigParamSelectionChanged(event: any): void {
     this.mappedField.parsedData.userCreated = true;
-    const attributes: any = event.target.selectedOptions.item(0).attributes;
-    const selectedArgValName: any = attributes.getNamedItem('value').value;
-    const argValIndex: any = attributes.getNamedItem('argValIndex').value;
-    const actionIndex: any = attributes.getNamedItem('actionIndex').value;
-    const action: FieldAction = this.mappedField.actions[actionIndex];
-    action.argumentValues[argValIndex].value = selectedArgValName;
-    this.validateActionConfigParamSelection(action.argumentValues);
+
+    // Identify the pull-down
+    if (event.target.selectedOptions != null) {
+      const attributes: any = event.target.selectedOptions.item(0).attributes;
+      const selectedArgValName: any = attributes.getNamedItem('value').value;
+      const argValIndex: any = attributes.getNamedItem('argValIndex').value;
+      const actionIndex: any = attributes.getNamedItem('actionIndex').value;
+      const action: FieldAction = this.mappedField.actions[actionIndex];
+      action.argumentValues[argValIndex].value = selectedArgValName;
+      this.validateActionConfigParamSelection(action.argumentValues);
+    }
     this.cfg.mappingService.saveCurrentMapping();
   }
 
@@ -130,9 +135,9 @@ export class MappingFieldActionComponent {
       const fieldActionConfig: FieldActionConfig = TransitionModel.getActionConfigForName(selectedActionName);
       fieldActionConfig.populateFieldAction(action);
 
-      // If the field action configuration defines 2 or more choices then populate the fields with
+      // If the field action configuration predefines argument values then populate the fields with
       // default values.  Needed to support pull-down menus in action argument definitions.
-      if (action.argumentValues.length > 1 && fieldActionConfig.arguments.length > 1) {
+      if (action.argumentValues.length > 0 && fieldActionConfig.arguments[0].values.length > 0) {
         for (let i = 0; i < action.argumentValues.length; i++) {
           action.argumentValues[i].value = fieldActionConfig.arguments[i].values[i];
         }


### PR DESCRIPTION
Fixes: #420 
I've gone through each transformation text input parameter and corrected an issue with the field action parameter processing function. It was following a pull-down path when it shouldn't.  Hopefully this is the last of these...