### PR TITLE
Change the directory we are copying the ipaas licenses to.

### DIFF
--- a/runtime/runtime/src/main/resources/license-custom-assembly.xml
+++ b/runtime/runtime/src/main/resources/license-custom-assembly.xml
@@ -6,7 +6,7 @@
   <fileSets>
     <fileSet>
       <directory>${project.basedir}/src/main/resources/licenses</directory>
-      <outputDirectory>/opt/licenses</outputDirectory>
+      <outputDirectory>/opt/ipaas/licenses</outputDirectory>
       <filtered>true</filtered>
       <includes>
         <include>**</include>


### PR DESCRIPTION
For the rest of the syndesis projects we are copying the ipaas licenses to /opt/ipaas/licenses.   