### PR TITLE
Fix #422: On OSX control-click means right click

### DIFF
--- a/ui/src/app/lib/atlasmap-data-mapper/components/document-field-detail.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/document-field-detail.component.ts
@@ -175,7 +175,7 @@ export class DocumentFieldDetailComponent {
    * @param event
    */
   handleMouseClick(event: MouseEvent): void {
-    this.cfg.mappingService.fieldSelected(this.field, event.ctrlKey);
+    this.cfg.mappingService.fieldSelected(this.field, event.ctrlKey || event.metaKey);
     if (this.lineMachine != null) {
       this.lineMachine.redrawLinesForMappings();
     }


### PR DESCRIPTION
Sorry, thought I checked this in over a week ago.

Fixes #422 