### PR TITLE
 fix: don't allocate memory exponentially in collection mappings

### DIFF
--- a/runtime/core/src/main/java/io/atlasmap/core/DefaultAtlasContext.java
+++ b/runtime/core/src/main/java/io/atlasmap/core/DefaultAtlasContext.java
@@ -488,7 +488,7 @@ public class DefaultAtlasContext implements AtlasContext, AtlasContextMXBean {
         }
     }
 
-    private List<Mapping> extractCollectionMappings(DefaultAtlasSession session, BaseMapping baseMapping)
+    protected final List<Mapping> extractCollectionMappings(DefaultAtlasSession session, BaseMapping baseMapping)
             throws AtlasException {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Generating Source Mappings from mapping: {}", baseMapping);
@@ -552,8 +552,6 @@ public class DefaultAtlasContext implements AtlasContext, AtlasContextMXBean {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Generated {} mappings from mapping: {}", mappings.size(), baseMapping);
         }
-        ((Collection) baseMapping).getMappings().getMapping().clear();
-        ((Collection) baseMapping).getMappings().getMapping().addAll(mappings);
 
         return mappings;
     }

--- a/runtime/itests/core/src/test/java/io/atlasmap/core/DefaultAtlasContextCollectionExpansionTest.java
+++ b/runtime/itests/core/src/test/java/io/atlasmap/core/DefaultAtlasContextCollectionExpansionTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atlasmap.core;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+import io.atlasmap.api.AtlasException;
+import io.atlasmap.json.module.JsonModule;
+import io.atlasmap.json.v2.JsonField;
+import io.atlasmap.v2.AtlasMapping;
+import io.atlasmap.v2.Collection;
+import io.atlasmap.v2.Mapping;
+import io.atlasmap.v2.MappingType;
+import io.atlasmap.v2.Mappings;
+
+
+public class DefaultAtlasContextCollectionExpansionTest {
+
+    @Test
+    public void shouldNotExponentialyGrowExpandedCollectionMappings() throws AtlasException {
+        final AtlasMapping mapping = new AtlasMapping();
+
+        final DefaultAtlasContext context = new DefaultAtlasContext(new DefaultAtlasContextFactory(), mapping);
+        context.setSourceModules(Collections.singletonMap("source", new JsonModule()));
+
+        final DefaultAtlasSession session = new DefaultAtlasSession(mapping);
+        session.setSourceDocument("source", "{ \"array\": [ { \"property\": 1 }, { \"property\": 2 }, { \"property\": 3 } ] }");
+
+        final Collection baseMapping = new Collection();
+        baseMapping.setMappingType(MappingType.COLLECTION);
+
+        final Mappings mappings = new Mappings();
+        final Mapping singleMapping = new Mapping();
+        singleMapping.setMappingType(MappingType.MAP);
+        final JsonField nestedArrayField = new JsonField();
+        nestedArrayField.setDocId("source");
+        nestedArrayField.setPath("/array<>/property");
+        singleMapping.getInputField().add(nestedArrayField);
+        mappings.getMapping().add(singleMapping);
+        baseMapping.setMappings(mappings);
+
+        assertEquals(3, context.extractCollectionMappings(session, baseMapping).size());
+        assertEquals(3, context.extractCollectionMappings(session, baseMapping).size());
+        assertEquals(3, context.extractCollectionMappings(session, baseMapping).size());
+    }
+
+}

--- a/runtime/modules/json/module/src/main/java/io/atlasmap/json/module/JsonModule.java
+++ b/runtime/modules/json/module/src/main/java/io/atlasmap/json/module/JsonModule.java
@@ -22,7 +22,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -50,6 +49,8 @@ import io.atlasmap.v2.Validations;
         "json" }, configPackages = { "io.atlasmap.json.v2" })
 public class JsonModule extends BaseAtlasModule {
     private static final Logger LOG = LoggerFactory.getLogger(JsonModule.class);
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     @Override
     public void processPreValidation(AtlasInternalSession atlasSession) throws AtlasException {
@@ -213,10 +214,8 @@ public class JsonModule extends BaseAtlasModule {
         Object document = session.getSourceDocument(getDocId());
         // make this a JSON document
         JsonFactory jsonFactory = new JsonFactory();
-        ObjectMapper objectMapper = new ObjectMapper();
         try {
-            JsonParser parser = jsonFactory.createParser(document.toString());
-            JsonNode rootNode = objectMapper.readTree(parser);
+            JsonNode rootNode = MAPPER.readTree(document.toString());
             ObjectNode parentNode = (ObjectNode) rootNode;
             String parentSegment = "[root node]";
             for (SegmentContext sc : new AtlasPath(field.getPath()).getSegmentContexts(false)) {


### PR DESCRIPTION
`DefaultAtlasContext::extractCollectionMappings` has the a side effect
of modifying the mapping, thus for already expanded collection mappings
it expands again and replaces the mapping.

For example, given source document of:
```json
{ "array":
  [
    { "property": 1 },
    { "property": 2 },
    { "property": 3 }
  ]
}
```

And mapping containing a JSON field with path like `/array<>/property`.

First invocation modifies the mapping to contain three mappings:
 1. `/array<0>/property`
 2. `/array<2>/property`
 3. `/array<3>/property`

Since this is now replacing the previous mapping on the next invocation
this expands to:

 1. `/array<0>/property`
 2. `/array<1>/property`
 3. `/array<2>/property`
...
 9. `/array<8>/property`

This removes the mapping mutation side effect, though I'm not entirely
sure why it was there to begin with, could be for optimization?

Fixes #508