### PR TITLE
feat: Add Split FieldAction

### DIFF
--- a/runtime/core/src/main/java/io/atlasmap/actions/StringComplexFieldActions.java
+++ b/runtime/core/src/main/java/io/atlasmap/actions/StringComplexFieldActions.java
@@ -37,6 +37,7 @@ import io.atlasmap.v2.PadStringRight;
 import io.atlasmap.v2.Prepend;
 import io.atlasmap.v2.ReplaceAll;
 import io.atlasmap.v2.ReplaceFirst;
+import io.atlasmap.v2.Split;
 import io.atlasmap.v2.StartsWith;
 import io.atlasmap.v2.SubString;
 import io.atlasmap.v2.SubStringAfter;
@@ -241,6 +242,21 @@ public class StringComplexFieldActions implements AtlasFieldAction {
 
         String newString = replaceFirst.getNewString();
         return input == null ? null : input.replaceFirst(match, newString == null ? "" : newString);
+    }
+
+    @AtlasFieldActionInfo(name = "Split", sourceType = FieldType.STRING, targetType = FieldType.ANY, sourceCollectionType = CollectionType.NONE, targetCollectionType = CollectionType.ALL)
+    public static String[] split(Action action, String input) {
+        if (!(action instanceof Split)) {
+            throw new IllegalArgumentException("Action must be an Split action");
+        }
+
+        Split split = (Split) action;
+
+        if (split.getDelimiter() == null) {
+            throw new IllegalArgumentException("Split must be specified with a delimiter");
+        }
+
+        return input == null ? null : input.split(split.getDelimiter());
     }
 
     @AtlasFieldActionInfo(name = "StartsWith", sourceType = FieldType.STRING, targetType = FieldType.BOOLEAN, sourceCollectionType = CollectionType.NONE, targetCollectionType = CollectionType.NONE)

--- a/runtime/core/src/test/java/io/atlasmap/actions/StringComplexFieldActionsTest.java
+++ b/runtime/core/src/test/java/io/atlasmap/actions/StringComplexFieldActionsTest.java
@@ -15,6 +15,7 @@
  */
 package io.atlasmap.actions;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -41,6 +42,7 @@ import io.atlasmap.v2.PadStringRight;
 import io.atlasmap.v2.Prepend;
 import io.atlasmap.v2.ReplaceAll;
 import io.atlasmap.v2.ReplaceFirst;
+import io.atlasmap.v2.Split;
 import io.atlasmap.v2.StartsWith;
 import io.atlasmap.v2.SubString;
 import io.atlasmap.v2.SubStringAfter;
@@ -386,6 +388,20 @@ public class StringComplexFieldActionsTest {
     public void testReplaceAllNullOldString() {
         ReplaceAll replaceAll = new ReplaceAll();
         StringComplexFieldActions.replaceAll(replaceAll, " ");
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testSplitNoDelimiter() {
+        Split action = new Split();
+        StringComplexFieldActions.split(action, "foobar");
+    }
+
+    @Test
+    public void testSplit() {
+        Split action = new Split();
+        action.setDelimiter(",");
+        assertArrayEquals(null, StringComplexFieldActions.split(action, null));
+        assertArrayEquals(new String[] {"1", "2", "3"}, StringComplexFieldActions.split(action, "1,2,3"));
     }
 
     @Test

--- a/runtime/model/src/main/java/io/atlasmap/v2/ActionsJsonDeserializer.java
+++ b/runtime/model/src/main/java/io/atlasmap/v2/ActionsJsonDeserializer.java
@@ -149,6 +149,8 @@ public class ActionsJsonDeserializer extends JsonDeserializer<Actions> {
                 return new SeparateByDash();
             case "SeparateByUnderscore":
                 return new SeparateByUnderscore();
+            case "Split":
+                return processSplitWithJsonToken(jsonToken);
             case "StartsWith":
                 return processStartsWithJsonToken(jsonToken);
             case "SubString":
@@ -694,6 +696,33 @@ public class ActionsJsonDeserializer extends JsonDeserializer<Actions> {
                 case ActionsJsonSerializer.NEW_STRING:
                     jsonToken.nextToken();
                     action.setNewString(jsonToken.getValueAsString());
+                    break;
+                default:
+                    break;
+            }
+
+            nextToken = jsonToken.nextToken();
+        } while (!JsonToken.END_ARRAY.equals(nextToken) && !JsonToken.END_OBJECT.equals(nextToken));
+        return action;
+    }
+
+    protected Split processSplitWithJsonToken(JsonParser jsonToken) throws IOException {
+        Split action = new Split();
+
+        if (JsonToken.END_ARRAY.equals(jsonToken.currentToken())
+                || JsonToken.END_OBJECT.equals(jsonToken.currentToken())) {
+            return action;
+        }
+
+        JsonToken nextToken = null;
+        do {
+            if (JsonToken.START_OBJECT.equals(jsonToken.currentToken())) {
+                jsonToken.nextToken();
+            }
+            switch (jsonToken.getCurrentName()) {
+                case ActionsJsonSerializer.DELIMITER:
+                    jsonToken.nextToken();
+                    action.setDelimiter(jsonToken.getValueAsString());
                     break;
                 default:
                     break;

--- a/runtime/model/src/main/java/io/atlasmap/v2/ActionsJsonSerializer.java
+++ b/runtime/model/src/main/java/io/atlasmap/v2/ActionsJsonSerializer.java
@@ -122,6 +122,9 @@ public class ActionsJsonSerializer extends JsonSerializer<Actions> {
             case "ReplaceFirst":
                 writeReplaceFirst(gen, (ReplaceFirst) action);
                 break;
+            case "Split":
+                writeSplit(gen, (Split) action);
+                break;
             case "StartsWith":
                 writeStartsWith(gen, (StartsWith) action);
                 break;
@@ -356,6 +359,15 @@ public class ActionsJsonSerializer extends JsonSerializer<Actions> {
         gen.writeStartObject();
         gen.writeStringField(MATCH, action.getMatch());
         gen.writeStringField(NEW_STRING, action.getNewString());
+        gen.writeEndObject();
+        gen.writeEndObject();
+    }
+
+    protected void writeSplit(JsonGenerator gen, Split action) throws IOException {
+        gen.writeStartObject();
+        gen.writeFieldName("Split");
+        gen.writeStartObject();
+        gen.writeStringField(STRING, action.getDelimiter());
         gen.writeEndObject();
         gen.writeEndObject();
     }

--- a/runtime/model/src/main/resources/atlas-actions-v2.xsd
+++ b/runtime/model/src/main/resources/atlas-actions-v2.xsd
@@ -442,6 +442,16 @@
     </complexType>
   </element>
 
+  <element name="Split">
+    <complexType>
+      <complexContent>
+        <extension base="atlas:Action">
+          <attribute name="delimiter" type="string" />
+        </extension>
+      </complexContent>
+    </complexType>
+  </element>
+
   <element name="StartsWith">
     <complexType>
       <complexContent>
@@ -585,6 +595,7 @@
         <element ref="atlas:Round" />
         <element ref="atlas:SeparateByDash" />
         <element ref="atlas:SeparateByUnderscore" />
+        <element ref="atlas:Split" />
         <element ref="atlas:StartsWith" />
         <element ref="atlas:SubString" />
         <element ref="atlas:SubStringAfter" />


### PR DESCRIPTION
Fixes: #549 

We already have `Concatenate` doing same with `COMBINE`. Since there're some `separate*` FieldAction already which does something different, added `Split` as an alternative to `SEPARATE`.