### PR TITLE
fix: Handle non-ascii unicode characters in schemas/ instance schemas.

### DIFF
--- a/ui/src/app/atlasmap-navbar.component.html
+++ b/ui/src/app/atlasmap-navbar.component.html
@@ -20,14 +20,14 @@
           </a>
           <ul class="dropdown-menu dropdown-menu-right" role="menu">
             <div>
-              <li role="menuitem" style="width:230px; text-align:left; font-size:14px; border: 1px solid #d1d1d1; margin-bottom:2px;">
+              <li role="menuitem" style="width:230px; text-align:left; font-size:14px; margin-left:4px; border: 1px solid #d1d1d1; margin-bottom:2px;">
                 <a  class="dropdown-item" href="#" style="position: relative">
                   <label for="usermappingsfile">AtlasMap Mappings</label>
 		          <input type="file" accept=".adm" name="usermappingsfile" style="display:none"
 		            id="usermappingsfile" (change)="processMappingsCatalog($event)">
 	            </a>
               </li>
-              <li role="menuitem" style="width:230px; text-align:left; font-size:14px; border: 1px solid #d1d1d1; margin-bottom:2px;">
+              <li role="menuitem" style="width:230px; text-align:left; font-size:14px;  margin-left:4px; border: 1px solid #d1d1d1; margin-bottom:2px;">
                 <a class="dropdown-item" href="#">
                   <label>Schema Document</label>
                   <div class="dropdown-content-schema" style="font-size:12px;">
@@ -60,7 +60,7 @@
                   </div>
 	            </a>
               </li>
-              <li role="menuitem" style="width:230px; text-align:left; font-size:14px; border: 1px solid #d1d1d1;">
+              <li role="menuitem" style="width:230px; text-align:left; font-size:14px;  margin-left:4px; border: 1px solid #d1d1d1;">
                 <a  class="dropdown-item" href="#">
                   <label>Instance Document</label>
                   <div class="dropdown-content-instance" style="font-size:12px;">

--- a/ui/src/app/lib/atlasmap-data-mapper/services/mapping-management.service.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/services/mapping-management.service.ts
@@ -815,7 +815,6 @@ export class MappingManagementService {
       // Start with the user mappings (XML).
       aggregateBuffer += DocumentManagementService.generateExportMappings(this.xmlBuffer[0]);
 
-      let buffer = '';
       let exportMeta = '   "exportMeta": [\n';
       let exportBlockData = '      "exportBlockData": [\n';
       let docCount = 0;
@@ -831,13 +830,7 @@ export class MappingManagementService {
             exportBlockData += ',\n';
           }
           exportMeta += DocumentManagementService.generateExportMetaStr(doc);
-
-          // Globally replace double-quotes embedded in the source docs.
-          buffer = doc.inspectionSource.replace(/\"/g, '\\\"');
-
-          // Globally replace new-lines with \n (JSON does not allow multi-line strings).
-          buffer = buffer.replace(/\n/g, '\\n');
-          exportBlockData += DocumentManagementService.generateExportBlockData(buffer);
+          exportBlockData += DocumentManagementService.generateExportBlockData(doc.inspectionSource);
           docCount++;
         }
       }


### PR DESCRIPTION
Fixes: #591 

Also catch valid schemas that don't specify any elements
