### PR TITLE
feat: Handle FieldGroup contributed via mapping definition

### DIFF
--- a/docs/src/main/asciidoc/inc/swagger/core/definitions.adoc
+++ b/docs/src/main/asciidoc/inc/swagger/core/definitions.adoc
@@ -228,6 +228,41 @@ __optional__|object
 |===
 
 
+[[_atlas-service-core-fieldgroup]]
+=== FieldGroup
+
+[options="header", cols=".^3a,.^4a"]
+|===
+|Name|Schema
+|**actions** +
+__optional__|<<_atlas-service-core-actions,Actions>>
+|**arrayDimensions** +
+__optional__|integer (int32)
+|**arraySize** +
+__optional__|integer (int32)
+|**collectionType** +
+__optional__|enum (ALL, ARRAY, LIST, MAP, NONE)
+|**docId** +
+__optional__|string
+|**field** +
+__optional__|< <<_atlas-service-core-field,Field>> > array
+|**fieldType** +
+__optional__|enum (ANY, ANY_DATE, BIG_INTEGER, BOOLEAN, BYTE, BYTE_ARRAY, CHAR, COMPLEX, DATE, DATE_TIME, DATE_TIME_TZ, DATE_TZ, DECIMAL, DOUBLE, FLOAT, INTEGER, LONG, NONE, NUMBER, SHORT, STRING, TIME, TIME_TZ, UNSIGNED_BYTE, UNSIGNED_INTEGER, UNSIGNED_LONG, UNSIGNED_SHORT, UNSUPPORTED)
+|**format** +
+__optional__|string
+|**index** +
+__optional__|integer (int32)
+|**path** +
+__optional__|string
+|**required** +
+__optional__|boolean
+|**status** +
+__optional__|enum (SUPPORTED, UNSUPPORTED, CACHED, ERROR, NOT_FOUND, BLACK_LIST)
+|**value** +
+__optional__|object
+|===
+
+
 [[_atlas-service-core-lookupentry]]
 === LookupEntry
 
@@ -289,6 +324,8 @@ __optional__|string
 __optional__|string
 |**inputField** +
 __optional__|< <<_atlas-service-core-field,Field>> > array
+|**inputFieldGroup** +
+__optional__|<<_atlas-service-core-fieldgroup,FieldGroup>>
 |**lookupTableName** +
 __optional__|string
 |**mappingType** +

--- a/runtime/api/src/main/java/io/atlasmap/spi/AtlasModule.java
+++ b/runtime/api/src/main/java/io/atlasmap/spi/AtlasModule.java
@@ -20,6 +20,10 @@ import java.util.List;
 import io.atlasmap.api.AtlasException;
 import io.atlasmap.v2.Field;
 
+/**
+ * A SPI contract between AtlasMap core and modules. AtlasMap core engine invokes those
+ * methods while processing mappings.
+ */
 public interface AtlasModule {
 
     void init();
@@ -32,9 +36,30 @@ public interface AtlasModule {
 
     void processPreTargetExecution(AtlasInternalSession session) throws AtlasException;
 
-    void processSourceFieldMapping(AtlasInternalSession session) throws AtlasException;
+    /**
+     * Read source field value from source document and store into source field object.
+     *
+     * @param session current session
+     * @throws AtlasException failed to read source value
+     */
+    void readSourceValue(AtlasInternalSession session) throws AtlasException;
 
-    void processTargetFieldMapping(AtlasInternalSession session) throws AtlasException;
+    /**
+     * Populate target field value, usually by just copy from source field value.
+     * Also apply type converters where it's needed.
+     *
+     * @param session current session
+     * @throws AtlasException failed to populate target field value
+     */
+    void populateTargetField(AtlasInternalSession session) throws AtlasException;
+
+    /**
+     * Write target field value into target document.
+     *
+     * @param session current session
+     * @throws AtlasException faield to write target field value
+     */
+    void writeTargetValue(AtlasInternalSession session) throws AtlasException;
 
     void processPostSourceExecution(AtlasInternalSession session) throws AtlasException;
 

--- a/runtime/core/src/main/java/io/atlasmap/core/BaseAtlasModule.java
+++ b/runtime/core/src/main/java/io/atlasmap/core/BaseAtlasModule.java
@@ -67,7 +67,8 @@ public abstract class BaseAtlasModule implements AtlasModule, AtlasModuleMXBean 
         }
     }
 
-    protected void populateTargetFieldValue(AtlasInternalSession session) throws AtlasException {
+    @Override
+    public void populateTargetField(AtlasInternalSession session) throws AtlasException {
         Field sourceField = session.head().getSourceField();
         Field targetField = session.head().getTargetField();
         Object targetValue = null;

--- a/runtime/core/src/main/java/io/atlasmap/core/ConstantModule.java
+++ b/runtime/core/src/main/java/io/atlasmap/core/ConstantModule.java
@@ -60,7 +60,7 @@ public class ConstantModule implements AtlasModule {
     }
 
     @Override
-    public void processSourceFieldMapping(AtlasInternalSession session) throws AtlasException {
+    public void readSourceValue(AtlasInternalSession session) throws AtlasException {
         Field sourceField = session.head().getSourceField();
         if (!(sourceField instanceof ConstantField)) {
             return;
@@ -89,7 +89,12 @@ public class ConstantModule implements AtlasModule {
     }
 
     @Override
-    public void processTargetFieldMapping(AtlasInternalSession session) throws AtlasException {
+    public void populateTargetField(AtlasInternalSession session) throws AtlasException {
+        throw new UnsupportedOperationException("ConstantField cannot be placed as a target field");
+    }
+
+    @Override
+    public void writeTargetValue(AtlasInternalSession session) throws AtlasException {
         throw new UnsupportedOperationException("ConstantField cannot be placed as a target field");
     }
 

--- a/runtime/core/src/main/java/io/atlasmap/core/DefaultAtlasFieldActionService.java
+++ b/runtime/core/src/main/java/io/atlasmap/core/DefaultAtlasFieldActionService.java
@@ -280,7 +280,7 @@ public class DefaultAtlasFieldActionService implements AtlasFieldActionService {
             tmpSourceObject = processAction(action, detail, tmpSourceObject);
             currentType = detail.getTargetType();
             if (tmpSourceObject != null && tmpSourceObject.getClass().isArray()) {
-                tmpSourceObject = Arrays.asList(tmpSourceObject);
+                tmpSourceObject = Arrays.asList((Object[])tmpSourceObject);
             } else if ((tmpSourceObject instanceof java.util.Collection) && !(tmpSourceObject instanceof List)) {
                 tmpSourceObject = Arrays.asList(((java.util.Collection<?>)tmpSourceObject).toArray());
             }

--- a/runtime/core/src/main/java/io/atlasmap/core/PropertyModule.java
+++ b/runtime/core/src/main/java/io/atlasmap/core/PropertyModule.java
@@ -63,7 +63,7 @@ public class PropertyModule implements AtlasModule {
     }
 
     @Override
-    public void processSourceFieldMapping(AtlasInternalSession session) throws AtlasException {
+    public void readSourceValue(AtlasInternalSession session) throws AtlasException {
         Field sourceField = session.head().getSourceField();
         if (sourceField instanceof PropertyField) {
                 propertyStrategy.processPropertyField(session.getMapping(), (PropertyField) sourceField,
@@ -87,7 +87,12 @@ public class PropertyModule implements AtlasModule {
     }
 
     @Override
-    public void processTargetFieldMapping(AtlasInternalSession session) throws AtlasException {
+    public void populateTargetField(AtlasInternalSession session) throws AtlasException {
+        throw new UnsupportedOperationException("PropertyField cannot be placed as a target field");
+    }
+
+    @Override
+    public void writeTargetValue(AtlasInternalSession session) throws AtlasException {
         throw new UnsupportedOperationException("PropertyField cannot be placed as a target field");
     }
 

--- a/runtime/core/src/test/java/io/atlasmap/core/BaseDefaultAtlasContextTest.java
+++ b/runtime/core/src/test/java/io/atlasmap/core/BaseDefaultAtlasContextTest.java
@@ -74,7 +74,7 @@ public abstract class BaseDefaultAtlasContextTest {
                 field.setValue(reader.sources.get(field.getPath()));
                 return null;
             }
-        }).when(module).processSourceFieldMapping(any());
+        }).when(module).readSourceValue(any());
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocation) throws Throwable {
@@ -91,10 +91,17 @@ public abstract class BaseDefaultAtlasContextTest {
                     }
                 }
                 target.setValue(value);
+                return null;
+            }
+        }).when(module).populateTargetField(any());
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                AtlasInternalSession session = (AtlasInternalSession) invocation.getArguments()[0];
                 writer.write(session);
                 return null;
             }
-        }).when(module).processTargetFieldMapping(any());
+        }).when(module).writeTargetValue(any());
         return module;
     }
 

--- a/runtime/core/src/test/java/io/atlasmap/core/ConstantModuleTest.java
+++ b/runtime/core/src/test/java/io/atlasmap/core/ConstantModuleTest.java
@@ -50,7 +50,7 @@ public class ConstantModuleTest {
         when(atlasConversionService.fieldTypeFromClass(any(String.class))).thenReturn(FieldType.ANY);
 
         module.setConversionService(atlasConversionService);
-        module.processSourceFieldMapping(session);
+        module.readSourceValue(session);
     }
 
     @Test
@@ -65,7 +65,7 @@ public class ConstantModuleTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testProcessTargetFieldMapping() throws AtlasException {
-        module.processTargetFieldMapping(null);
+        module.writeTargetValue(null);
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/runtime/core/src/test/java/io/atlasmap/core/DefaultAtlasContextFactoryTest.java
+++ b/runtime/core/src/test/java/io/atlasmap/core/DefaultAtlasContextFactoryTest.java
@@ -297,12 +297,17 @@ public class DefaultAtlasContextFactoryTest {
         }
 
         @Override
-        public void processSourceFieldMapping(AtlasInternalSession session) throws AtlasException {
+        public void readSourceValue(AtlasInternalSession session) throws AtlasException {
             LOG.debug("processSourceFieldMapping method");
         }
 
         @Override
-        public void processTargetFieldMapping(AtlasInternalSession session) throws AtlasException {
+        public void populateTargetField(AtlasInternalSession session) throws AtlasException {
+            LOG.debug("populateTargetField method");
+        }
+
+        @Override
+        public void writeTargetValue(AtlasInternalSession session) throws AtlasException {
             LOG.debug("processTargetFieldMapping method");
         }
 

--- a/runtime/core/src/test/java/io/atlasmap/core/PropertyModuleTest.java
+++ b/runtime/core/src/test/java/io/atlasmap/core/PropertyModuleTest.java
@@ -49,7 +49,7 @@ public class PropertyModuleTest {
         when(atlasConversionService.fieldTypeFromClass(any(String.class))).thenReturn(FieldType.ANY);
 
         module.setConversionService(atlasConversionService);
-        module.processSourceFieldMapping(session);
+        module.readSourceValue(session);
     }
 
     @Test
@@ -64,7 +64,7 @@ public class PropertyModuleTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testProcessTargetFieldMapping() throws AtlasException {
-        module.processTargetFieldMapping(null);
+        module.writeTargetValue(null);
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/runtime/itests/core/src/test/java/io/atlasmap/core/ConcatenateSplitTest.java
+++ b/runtime/itests/core/src/test/java/io/atlasmap/core/ConcatenateSplitTest.java
@@ -1,0 +1,49 @@
+package io.atlasmap.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.net.URL;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.atlasmap.api.AtlasContext;
+import io.atlasmap.api.AtlasSession;
+import io.atlasmap.core.AtlasMappingService.AtlasMappingFormat;
+import io.atlasmap.core.issue.SourceClass;
+import io.atlasmap.core.issue.TargetClass;
+import io.atlasmap.v2.AtlasMapping;
+
+public class ConcatenateSplitTest {
+
+    private AtlasMappingService mappingService;
+
+    @Before
+    public void before() {
+        mappingService = DefaultAtlasContextFactory.getInstance().getMappingService();
+    }
+
+    @Test
+    public void test() throws Exception {
+        URL url = Thread.currentThread().getContextClassLoader().getResource("mappings/atlasmapping-concatenate-split.xml");
+        AtlasMapping mapping = mappingService.loadMapping(url, AtlasMappingFormat.XML);
+        AtlasContext context = DefaultAtlasContextFactory.getInstance().createContext(mapping);
+        AtlasSession session = context.createSession();
+        SourceClass source = new SourceClass()
+                .setSourceFirstName("Manjiro")
+                .setSourceLastName("Nakahama")
+                .setSourceName("Manjiro,Nakahama");
+        session.setSourceDocument("io.atlasmap.core.issue.SourceClass", source);
+        context.process(session);
+        assertFalse(TestHelper.printAudit(session), session.hasErrors());
+        assertFalse(TestHelper.printAudit(session), session.hasWarns());
+        Object output = session.getTargetDocument("io.atlasmap.core.issue.TargetClass");
+        assertEquals(TargetClass.class, output.getClass());
+        TargetClass target = TargetClass.class.cast(output);
+        assertEquals("Manjiro", target.getTargetFirstName());
+        assertEquals("Nakahama", target.getTargetLastName());
+        assertEquals("Manjiro,Nakahama", target.getTargetName());
+    }
+
+}

--- a/runtime/itests/core/src/test/java/io/atlasmap/core/issue/CollectionComplexTest.java
+++ b/runtime/itests/core/src/test/java/io/atlasmap/core/issue/CollectionComplexTest.java
@@ -41,7 +41,12 @@ public class CollectionComplexTest {
         assertFalse(TestHelper.printAudit(session), session.hasErrors());
         Object targetJava = session.getTargetDocument("TargetClass");
         assertEquals(TargetClass.class, targetJava.getClass());
-        assertEquals("xml3", ((TargetClass)targetJava).getTargetName());
+        TargetClass targetClass = (TargetClass)targetJava;
+        assertEquals("xml3", targetClass.getTargetName());
+        assertEquals(3, targetClass.getTargetList().size());
+        assertEquals("json1", targetClass.getTargetList().get(0).getName());
+        assertEquals("json2", targetClass.getTargetList().get(1).getName());
+        assertEquals("json3", targetClass.getTargetList().get(2).getName());
         Object targetJson = session.getTargetDocument("TargetJson");
         assertEquals("{\"javaList\":[{\"name\":\"java1\"},{\"name\":\"java2\"},{\"name\":\"java3\"}],\"xmlList\":[\"xml1\",\"xml2\",\"xml3\"]}",
                 targetJson);

--- a/runtime/itests/core/src/test/resources/mappings/atlasmapping-concatenate-split.xml
+++ b/runtime/itests/core/src/test/resources/mappings/atlasmapping-concatenate-split.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<AtlasMapping xmlns="http://atlasmap.io/v2" xmlns:ns2="http://atlasmap.io/java/v2"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="core-unit-test">
+  <DataSource dataSourceType="Source" id="io.atlasmap.core.issue.SourceClass"
+    uri="atlas:java?className=io.atlasmap.core.issue.SourceClass" />
+  <DataSource dataSourceType="Target" id="io.atlasmap.core.issue.TargetClass"
+    uri="atlas:java?className=io.atlasmap.core.issue.TargetClass" />
+  <Mappings>
+    <Mapping xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="Mapping">
+      <InputFieldGroup xsi:type="ns2:FieldGroup"> 
+        <Field xsi:type="ns2:JavaField" name="sourceFirstName" docId="io.atlasmap.core.issue.SourceClass" path="/sourceFirstName" fieldType="String" index="0" />
+        <Field xsi:type="ns2:JavaField" name="sourceLastName" docId="io.atlasmap.core.issue.SourceClass" path="/sourceLastName" fieldType="String" index="1" />
+        <Actions>
+          <Concatenate delimiter="&#44;"/>
+        </Actions>
+      </InputFieldGroup>
+      <OutputField xsi:type="ns2:JavaField" name="targetName" docId="io.atlasmap.core.issue.TargetClass" path="/targetName" fieldType="String"/>
+    </Mapping>
+    <Mapping xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="Mapping">
+      <InputField xsi:type="ns2:JavaField" name="sourceName" docId="io.atlasmap.core.issue.SourceClass" path="/sourceName" fieldType="String">
+        <Actions>
+          <Split delimiter="&#44;" />
+        </Actions>
+      </InputField>
+      <OutputField xsi:type="ns2:JavaField" name="targetFirstName" docId="io.atlasmap.core.issue.TargetClass" path="/targetFirstName" fieldType="String" index="0" />
+      <OutputField xsi:type="ns2:JavaField" name="targetLastName" docId="io.atlasmap.core.issue.TargetClass" path="/targetLastName" fieldType="String" index="1" />
+    </Mapping>
+  </Mappings>
+</AtlasMapping>

--- a/runtime/itests/core/src/test/resources/mappings/issue/collection-complex-mapping.xml
+++ b/runtime/itests/core/src/test/resources/mappings/issue/collection-complex-mapping.xml
@@ -24,7 +24,7 @@
         </Mapping>
 
         <Mapping xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="Mapping" mappingType="Map">
-          <InputField xsi:type="ns3:JsonField" name="sourceList" docId="SourceJson" path="/sourceList&lt;&gt;/name" fieldType="String"/>
+          <InputField xsi:type="ns3:JsonField" name="sourceList" docId="SourceJson" path="/sourceList&lt;&gt;" fieldType="String"/>
           <OutputField xsi:type="ns2:JavaField" name="targetList" docId="TargetClass" path="/targetList&lt;&gt;/name" fieldType="String"/>
         </Mapping>
         <Mapping xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="Mapping" mappingType="Map">

--- a/runtime/model/src/main/resources/atlas-model-v2.xjb
+++ b/runtime/model/src/main/resources/atlas-model-v2.xjb
@@ -109,5 +109,8 @@
       <annox:annotate><annox:annotate annox:class="javax.xml.bind.annotation.XmlRootElement" name="TargetDocument" /></annox:annotate>
       <annox:annotate><annox:annotate annox:class="com.fasterxml.jackson.annotation.JsonRootName">TargetDocument</annox:annotate></annox:annotate>
     </jaxb:bindings>   
+    <jaxb:bindings node="xs:simpleType[@name='MappingType']">
+      <annox:annotate><annox:annotate annox:class="java.lang.Deprecated" /></annox:annotate>
+    </jaxb:bindings>   
   </jaxb:bindings>
 </jaxb:bindings>

--- a/runtime/model/src/main/resources/atlas-model-v2.xsd
+++ b/runtime/model/src/main/resources/atlas-model-v2.xsd
@@ -91,8 +91,12 @@
     <complexContent>
       <extension base="atlas:BaseMapping">
         <sequence>
-          <element name="InputField" type="atlas:Field"
-            minOccurs="0" maxOccurs="unbounded" />
+          <choice>
+            <element name="InputFieldGroup" type="atlas:FieldGroup"
+              minOccurs="0" maxOccurs="1" />
+            <element name="InputField" type="atlas:Field"
+              minOccurs="0" maxOccurs="unbounded" />
+          </choice>
           <element name="OutputField" type="atlas:Field"
             minOccurs="0" maxOccurs="unbounded" />
         </sequence>
@@ -121,6 +125,7 @@
     </restriction>
   </simpleType>
 
+  <!-- DEPRECATED -->
   <complexType name="Collection">
     <complexContent>
       <extension base="atlas:BaseMapping">

--- a/runtime/modules/json/module/src/main/java/io/atlasmap/json/module/JsonModule.java
+++ b/runtime/modules/json/module/src/main/java/io/atlasmap/json/module/JsonModule.java
@@ -96,7 +96,7 @@ public class JsonModule extends BaseAtlasModule {
     }
 
     @Override
-    public void processSourceFieldMapping(AtlasInternalSession session) throws AtlasException {
+    public void readSourceValue(AtlasInternalSession session) throws AtlasException {
         Field sourceField = session.head().getSourceField();
         JsonFieldReader reader = session.getFieldReader(getDocId(), JsonFieldReader.class);
         if (reader == null) {
@@ -106,8 +106,6 @@ public class JsonModule extends BaseAtlasModule {
             return;
         }
         reader.read(session);
-        sourceField = applySourceFieldActions(session);
-        session.head().setSourceField(sourceField);
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("{}: processSourceFieldMapping completed: SourceField:[docId={}, path={}, type={}, value={}]",
@@ -117,7 +115,7 @@ public class JsonModule extends BaseAtlasModule {
     }
 
     @Override
-    public void processTargetFieldMapping(AtlasInternalSession session) throws AtlasException {
+    public void populateTargetField(AtlasInternalSession session) throws AtlasException {
         Field sourceField = session.head().getSourceField();
         Field targetField = session.head().getTargetField();
         AtlasPath path = new AtlasPath(targetField.getPath());
@@ -136,12 +134,25 @@ public class JsonModule extends BaseAtlasModule {
             if (sourceField instanceof FieldGroup) {
                 List<Field> subFields = ((FieldGroup)sourceField).getField();
                 if (subFields != null && subFields.size() > 0) {
-                    // The last one wins for compatibility
-                    sourceField = subFields.get(subFields.size() - 1);
+                    Integer index = targetField.getIndex();
+                    if (index != null) {
+                        if (subFields.size() > index) {
+                            sourceField = subFields.get(index);
+                        } else {
+                            AtlasUtil.addAudit(session, getDocId(), String.format(
+                                    "The number of source fields (%s) is smaller than target index (%s) - ignoring",
+                                    subFields.size(), index),
+                                    null, AuditStatus.WARN, null);
+                            return;
+                        }
+                    } else {
+                        // The last one wins for compatibility
+                        sourceField = subFields.get(subFields.size() - 1);
+                    }
                     session.head().setSourceField(sourceField);
                 }
             }
-            populateTargetFieldValue(session);
+            super.populateTargetField(session);
         } else if (sourceField instanceof FieldGroup) {
             for (int i=0; i<((FieldGroup)sourceField).getField().size(); i++) {
                 Field sourceSubField = ((FieldGroup)sourceField).getField().get(i);
@@ -153,7 +164,7 @@ public class JsonModule extends BaseAtlasModule {
                 targetFieldGroup.getField().add(targetSubField);
                 session.head().setSourceField(sourceSubField);
                 session.head().setTargetField(targetSubField);
-                populateTargetFieldValue(session);
+                super.populateTargetField(session);
             }
             session.head().setSourceField(sourceField);
             session.head().setTargetField(targetFieldGroup);
@@ -164,20 +175,8 @@ public class JsonModule extends BaseAtlasModule {
             targetSubField.setPath(path.toString());
             targetFieldGroup.getField().add(targetSubField);
             session.head().setTargetField(targetSubField);
-            populateTargetFieldValue(session);
+            super.populateTargetField(session);
             session.head().setTargetField(targetFieldGroup);
-        }
-
-        session.head().setTargetField(applyTargetFieldActions(session));
-
-        JsonFieldWriter writer = session.getFieldWriter(getDocId(), JsonFieldWriter.class);
-        if (targetFieldGroup != null) {
-            for (Field f : targetFieldGroup.getField()) {
-                session.head().setTargetField(f);
-                writer.write(session);
-            }
-        } else {
-            writer.write(session);
         }
 
         if (LOG.isDebugEnabled()) {
@@ -186,6 +185,19 @@ public class JsonModule extends BaseAtlasModule {
                     getDocId(), sourceField.getDocId(), sourceField.getPath(), sourceField.getFieldType(),
                     sourceField.getValue(), targetField.getDocId(), targetField.getPath(), targetField.getFieldType(),
                     targetField.getValue());
+        }
+    }
+
+    public void writeTargetValue(AtlasInternalSession session) throws AtlasException {
+        JsonFieldWriter writer = session.getFieldWriter(getDocId(), JsonFieldWriter.class);
+        if (session.head().getTargetField() instanceof FieldGroup) {
+            FieldGroup targetFieldGroup = (FieldGroup) session.head().getTargetField();
+            for (Field f : targetFieldGroup.getField()) {
+                session.head().setTargetField(f);
+                writer.write(session);
+            }
+        } else {
+            writer.write(session);
         }
     }
 


### PR DESCRIPTION
Fixes: #550

This allows transformations to change multiplicity, which is supposed to replace `COMBINE`/`SEPARATE` mode eventually. UI needs to add `Concatenate`/`Split` transformation instead of using `COMBINE`/`SEPARATE` mode, and for `Concatenate` case the source fields needs to be wrapped with `FieldGroup`, so that the `Concatenate` transformation is placed on a `FieldGroup` level.
[An example mapping is here](https://github.com/atlasmap/atlasmap/pull/602/files#diff-11b53e171519d064b287692ae917660e)

This also allows transformations like `Add` mentioned in #461, which consumes multiple number fields and sum up. In combination with #338 we can also apply it for collection field.

At this point we don't support to have a collection field as a part of grouping, i.e. put collection field and non-collection field into a same group, so UI should keep prohibiting it. We can revisit it at some point.