### PR TITLE
fix: when comparing XPaths, namespace uris should be used instead of …

### DIFF
--- a/camel/src/test/java/org/apache/camel/component/atlasmap/AtlasMapComponentXmlToXmlDefaultNsTest.java
+++ b/camel/src/test/java/org/apache/camel/component/atlasmap/AtlasMapComponentXmlToXmlDefaultNsTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.atlasmap;
+
+import java.io.ByteArrayInputStream;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.spring.CamelSpringRunner;
+import org.apache.camel.test.spring.CamelTestContextBootstrapper;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.BootstrapWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.builder.Input;
+import org.xmlunit.diff.Diff;
+
+@RunWith(CamelSpringRunner.class)
+@BootstrapWith(CamelTestContextBootstrapper.class)
+@ContextConfiguration(value = {"AtlasMapComponentXmlToXmlTest-context.xml"})
+public class AtlasMapComponentXmlToXmlDefaultNsTest {
+
+    private static final String XML_EXPECTED = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><tns:Patient xmlns:tns=\"http://hl7.org/fhir\"><tns:id value=\"101138\"/></tns:Patient>";
+
+    @Autowired
+    protected CamelContext camelContext;
+
+    @EndpointInject(uri = "mock:result")
+    protected MockEndpoint result;
+
+    @Test
+    @DirtiesContext
+    public void testMocksAreValid() throws Exception {
+        result.setExpectedCount(1);
+
+        final ProducerTemplate producerTemplate = camelContext.createProducerTemplate();
+        producerTemplate.sendBody("direct:start", new ByteArrayInputStream("<Patient xmlns=\"http://hl7.org/fhir\"><id value=\"101138\"></id></Patient>".getBytes()));
+
+        MockEndpoint.assertIsSatisfied(camelContext);
+        final String body = result.getExchanges().get(0).getIn().getBody(String.class);
+
+        Assert.assertNotNull(body);
+
+        Diff d = DiffBuilder.compare(Input.fromString(XML_EXPECTED).build())
+                .withTest(Input.fromString(body).build())
+                .ignoreWhitespace().build();
+        Assert.assertFalse(d.toString() + ": " + body, d.hasDifferences());
+    }
+
+}

--- a/runtime/modules/xml/core/src/main/java/io/atlasmap/xml/core/XmlIOHelper.java
+++ b/runtime/modules/xml/core/src/main/java/io/atlasmap/xml/core/XmlIOHelper.java
@@ -18,6 +18,7 @@ package io.atlasmap.xml.core;
 import java.io.StringWriter;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -48,6 +49,26 @@ public final class XmlIOHelper {
         return children;
     }
 
+    public static List<Element> getChildrenWithNameStripAlias(String name, Optional<String> namespace, Element parentNode) {
+        List<Element> children = new LinkedList<>();
+        if (parentNode == null) {
+            return children;
+        }
+        NodeList nodeChildren = parentNode.getChildNodes();
+        for (int i = 0; i < nodeChildren.getLength(); i++) {
+            Node child = nodeChildren.item(i);
+            String nodeName = getNodeNameWithoutNamespaceAlias(child);
+            if ((child instanceof Element) && nodeName.equals(name)) {
+                if (!namespace.isPresent()) {
+                    children.add((Element) child);
+                } else if (namespace.get().equals(child.getNamespaceURI())) {
+                    children.add((Element) child);
+                }
+            }
+        }
+        return children;
+    }
+
     public static String writeDocumentToString(boolean stripSpaces, Node node) throws AtlasException {
         try {
             if (node == null) {
@@ -68,6 +89,15 @@ public final class XmlIOHelper {
         } catch (Exception e) {
             throw new AtlasException(e);
         }
+    }
+
+    private static String getNodeNameWithoutNamespaceAlias(Node child) {
+        String nodeName = child.getNodeName();
+        int index = nodeName.indexOf(":");
+        if (index >= 0) {
+            nodeName = nodeName.substring(index + 1);
+        }
+        return nodeName;
     }
 
 }


### PR DESCRIPTION
…namespace aliases

Fixes: #618 

This fix modifies the behavior of the XmlReader. When reading an AtlasPath (i.e XPath), instead of comparing namespace aliases, it will compare the namespace URI to which the alias is attached to.

Let me know what you think! Thanks!