### PR TITLE
Fix the wrong url from runtime to lib

### DIFF
--- a/docs/src/main/asciidoc/inc/_internal_design.adoc
+++ b/docs/src/main/asciidoc/inc/_internal_design.adoc
@@ -13,7 +13,7 @@ When data formats are provided into Data Mapper UI, it requests an inspection to
 
 AtlasMap Document object defines a tree of fields. Defining a set of field-to-field mapping is all about the mappings in AtlasMap.
 
-Another thing to know for AtlasMap internal is the modules located https://github.com/atlasmap/atlasmap/tree/master/runtime/modules[here] in repository. Module in AtlasMap is a facility to plug-in an individual data format support like Java, JSON and XML. Each module implements roughly following 2 parts:
+Another thing to know for AtlasMap internal is the modules located https://github.com/atlasmap/atlasmap/tree/master/lib/modules[here] in repository. Module in AtlasMap is a facility to plug-in an individual data format support like Java, JSON and XML. Each module implements roughly following 2 parts:
 
 * Inspection Design Time Service to convert the format specific metadata into AtlasMap Document object
 * Runtime SPI to achieve actual mappings

--- a/docs/src/main/asciidoc/inc/_tips_for_ui_developer.adoc
+++ b/docs/src/main/asciidoc/inc/_tips_for_ui_developer.adoc
@@ -45,7 +45,7 @@ These flags control the UI automatically adding the specified mock documents to 
 
 The code that initializes these mock documents is in the https://github.com/atlasmap/atlasmap/blob/master/ui/src/app/lib/atlasmap-data-mapper/services/initialization.service.ts[InitializationService].
 That service calls various static methods in the https://github.com/atlasmap/atlasmap/blob/master/ui/src/app/lib/atlasmap-data-mapper/services/document-management.service.ts[DocumentManagementService] to create example XML instance, XML schema, and JSON documents.
-Mock Java documents referenced are from the AtlasMap Services' https://github.com/atlasmap/atlasmap/tree/master/runtime/modules/java/test-model/src/main/java/io/atlasmap/java/test[Atlas Java Test Model Maven Module].
+Mock Java documents referenced are from the AtlasMap Services' https://github.com/atlasmap/atlasmap/tree/master/lib/modules/java/test-model/src/main/java/io/atlasmap/java/test[Atlas Java Test Model Maven Module].
 
 ==== Additional Debug Configuration
 

--- a/docs/src/main/asciidoc/inc/internal/_design_time_service.adoc
+++ b/docs/src/main/asciidoc/inc/internal/_design_time_service.adoc
@@ -4,25 +4,25 @@
 Design Time Service is a set of REST API which provide background services to be used by the Data Mapper UI behind the scene. There are 4 types of Design Time Service:
 
 === Core Service
-* Code Location: https://github.com/atlasmap/atlasmap/blob/master/runtime/service
+* Code Location: https://github.com/atlasmap/atlasmap/blob/master/lib/service
 * API Reference: <<inc/swagger/index#core,Core Service>>
 
 Core Service provides basic operations which is not specific to the individual data formats, Create/Get/Update/Remove mapping definition stored in Design Time Service local storage, validate mapping, retrieve metadata for available field actions and etc. 
 
 === Java Service
-* Code Location: https://github.com/atlasmap/atlasmap/blob/master/runtime/modules/java/service
+* Code Location: https://github.com/atlasmap/atlasmap/blob/master/lib/modules/java/service
 * API Reference: <<inc/swagger/index#java,Java Service>>
 
 Java Service provides Java inspection service which generate an AtlasMap Document object from Java class name.
 
 === JSON Service
-* Code Location: https://github.com/atlasmap/atlasmap/blob/master/runtime/modules/json/service
+* Code Location: https://github.com/atlasmap/atlasmap/blob/master/lib/modules/json/service
 * API Reference: <<inc/swagger/index#json,JSON Service>>
 
 JSON Service provides JSON inspection service which generate an AtlasMap Document object from JSON instance or JSON schema.
 
 === XML Service
-* Code Location: https://github.com/atlasmap/atlasmap/blob/master/runtime/modules/xml/service
+* Code Location: https://github.com/atlasmap/atlasmap/blob/master/lib/modules/xml/service
 * API Reference: <<inc/swagger/index#xml,XML Service>>
 
 XML Service provides XML inspection service which generate an AtlasMap Document object from XML instance or XML schema.

--- a/docs/src/main/asciidoc/inc/internal/_runtime.adoc
+++ b/docs/src/main/asciidoc/inc/internal/_runtime.adoc
@@ -1,7 +1,7 @@
 [[internal-runtime-engine]]
 == Runtime Engine
 
-* Code Location: https://github.com/atlasmap/atlasmap/blob/master/runtime/
+* Code Location: https://github.com/atlasmap/atlasmap/blob/master/lib/
 
 AtlasMap runtime engine consumes mapping definition file created via <<internal-ui,Data Mapper UI>> as well as actual data payload and perform mapping.
 
@@ -15,9 +15,9 @@ session.setSourceDocument("myJsonSourceDoc", "{...}"); // <4>
 context.process(session); // <5>
 Object targetDoc = session.getTargetDocument("myXmlTargetDoc"); // <6>
 --------------------------------------------------------------------
-<1> https://github.com/atlasmap/atlasmap/blob/master/runtime/api/src/main/java/io/atlasmap/api/AtlasContextFactory.java[AtlasContextFactory] is a singleton instance on JVM, which holds global configuration for the AtlasMap.
-<2> `AtlasContextFactory#createContext(File)` creates https://github.com/atlasmap/atlasmap/blob/master/runtime/api/src/main/java/io/atlasmap/api/AtlasContext.java[AtlasContext] which represents an AtlasMap mapping context for each mapping definitions by feeding a mapping definition file.
-<3> https://github.com/atlasmap/atlasmap/blob/master/runtime/api/src/main/java/io/atlasmap/api/AtlasSession.java[AtlasSession] represents a mapping processing session. `AtlasSession` should be created for each execution and should *NOT* be shared among multiple threads.
+<1> https://github.com/atlasmap/atlasmap/blob/master/lib/api/src/main/java/io/atlasmap/api/AtlasContextFactory.java[AtlasContextFactory] is a singleton instance on JVM, which holds global configuration for the AtlasMap.
+<2> `AtlasContextFactory#createContext(File)` creates https://github.com/atlasmap/atlasmap/blob/master/lib/api/src/main/java/io/atlasmap/api/AtlasContext.java[AtlasContext] which represents an AtlasMap mapping context for each mapping definitions by feeding a mapping definition file.
+<3> https://github.com/atlasmap/atlasmap/blob/master/lib/api/src/main/java/io/atlasmap/api/AtlasSession.java[AtlasSession] represents a mapping processing session. `AtlasSession` should be created for each execution and should *NOT* be shared among multiple threads.
 <4> Put a source Document with a corresponding Document ID. Make sure Document ID matches with what is specified in the mapping definition.
 <5> Process a mapping by `AtlasContext#process(AtlasSession)`. This invocation also triggers <<internal-runtime-validation,mapping validation>> prior to actually perform a mapping.
 <6> Finally take the transformed document out from `AtlasSession` by specifying target Document ID.
@@ -25,10 +25,10 @@ Object targetDoc = session.getTargetDocument("myXmlTargetDoc"); // <6>
 [[internal-runtime-atlasmodule]]
 === AtlasModule and mapping process
 
-https://github.com/atlasmap/atlasmap/blob/master/runtime/api/src/main/java/io/atlasmap/spi/AtlasModule.java[AtlasModule] is a SPI to be implemented by each modules like
-https://github.com/atlasmap/atlasmap/tree/master/runtime/modules/java[Java], 
-https://github.com/atlasmap/atlasmap/tree/master/runtime/modules/json[JSON] and
-https://github.com/atlasmap/atlasmap/tree/master/runtime/modules/xml[XML]. The methods defined in `AtlasModule` are invoked from `AtlasContext` while `AtlasContext#process(AtlasSession)` is in progress.
+https://github.com/atlasmap/atlasmap/blob/master/lib/api/src/main/java/io/atlasmap/spi/AtlasModule.java[AtlasModule] is a SPI to be implemented by each modules like
+https://github.com/atlasmap/atlasmap/tree/master/lib/modules/java[Java], 
+https://github.com/atlasmap/atlasmap/tree/master/lib/modules/json[JSON] and
+https://github.com/atlasmap/atlasmap/tree/master/lib/modules/xml[XML]. The methods defined in `AtlasModule` are invoked from `AtlasContext` while `AtlasContext#process(AtlasSession)` is in progress.
 
 `AtlasContext#process(AtlasSession)` goes on in following order:
 
@@ -54,13 +54,13 @@ https://github.com/atlasmap/atlasmap/tree/master/runtime/modules/xml[XML]. The m
 === TypeConverter
 
 TypeConverter converts one field value to the expected field type. This is automatically invoked during mapping when the actual value is not in expected type. AtlasMap runtime provides OOTB converters for the AtlasMap primitive types 
-https://github.com/atlasmap/atlasmap/tree/master/runtime/core/src/main/java/io/atlasmap/converters[here].
+https://github.com/atlasmap/atlasmap/tree/master/lib/core/src/main/java/io/atlasmap/converters[here].
 
 [[internal-runtime-fieldaction]]
 === FieldAction (Transformation)
 
 FieldAction is a function you can apply on a field value as a part of mapping. AtlasMap provides a variety of FieldActions you can apply in the middle of processing mappings
-https://github.com/atlasmap/atlasmap/tree/master/runtime/core/src/main/java/io/atlasmap/actions[here].
+https://github.com/atlasmap/atlasmap/tree/master/lib/core/src/main/java/io/atlasmap/actions[here].
 Also There is a <<fieldAction,Reference>> for all available FieldAction.
 
 [[internal-runtime-fieldreader]]


### PR DESCRIPTION
Hi team,
I found some broker URL by reading "AtlasMap Developer Guide". I could not find the broker url in https://github.com/atlasmap/atlasmap.io but this repo, so decided to PR here. Could you take a look at it please?