### PR TITLE
fix: class cast when inspecting class with generics

### DIFF
--- a/lib/modules/java/core/src/main/java/io/atlasmap/java/inspect/ClassInspectionService.java
+++ b/lib/modules/java/core/src/main/java/io/atlasmap/java/inspect/ClassInspectionService.java
@@ -778,7 +778,12 @@ public class ClassInspectionService {
                 TypeVariable<?> tv = (TypeVariable<?>) t;
                 // TODO: no current need, but we may want to have treatment for 'T'
                 // tv.getTypeName()
-                pTypes.add(((Class<?>) tv.getAnnotatedBounds()[0].getType()).getName());
+                Type type = tv.getAnnotatedBounds()[0].getType();
+                if (type instanceof Class) {
+                    pTypes.add(((Class<?>) type).getName());
+                } else {
+                    pTypes.add(type.getTypeName());
+                }
             }
 
             if (!onlyClasses && t instanceof WildcardType) {


### PR DESCRIPTION
For Kudu connector in Syndesis there are protobuf shaded classes referenced from org.apache.kudu.client.KuduTable which use generics.

The code path leads to ParameterizedType describing a Comparable<T> which cannot be cast to a Class.

This is a super simple workaround for this issue, not sure if it's 100% proper. Please ask for refinements, I'm too lazy to create a unit test even though I know I ought to.