### PR TITLE
Fix locale specific test failure

### DIFF
--- a/lib/core/src/main/java/io/atlasmap/actions/NumberFieldActions.java
+++ b/lib/core/src/main/java/io/atlasmap/actions/NumberFieldActions.java
@@ -231,7 +231,7 @@ public class NumberFieldActions implements AtlasFieldAction {
 
         if (action == null || !(action instanceof ConvertMassUnit) || ((ConvertMassUnit) action).getFromUnit() == null
                 || ((ConvertMassUnit) action).getToUnit() == null) {
-            throw new IllegalArgumentException("ConvertMassUnit must be specfied  with fromUnit and toUnit");
+            throw new IllegalArgumentException("ConvertMassUnit must be specified  with fromUnit and toUnit");
         }
 
         MassUnitType fromUnit = ((ConvertMassUnit) action).getFromUnit();
@@ -249,7 +249,7 @@ public class NumberFieldActions implements AtlasFieldAction {
         if (action == null || !(action instanceof ConvertDistanceUnit)
                 || ((ConvertDistanceUnit) action).getFromUnit() == null
                 || ((ConvertDistanceUnit) action).getToUnit() == null) {
-            throw new IllegalArgumentException("ConvertDistanceUnit must be specfied  with fromUnit and toUnit");
+            throw new IllegalArgumentException("ConvertDistanceUnit must be specified  with fromUnit and toUnit");
         }
 
         DistanceUnitType fromUnit = ((ConvertDistanceUnit) action).getFromUnit();
@@ -266,7 +266,7 @@ public class NumberFieldActions implements AtlasFieldAction {
 
         if (action == null || !(action instanceof ConvertAreaUnit) || ((ConvertAreaUnit) action).getFromUnit() == null
                 || ((ConvertAreaUnit) action).getToUnit() == null) {
-            throw new IllegalArgumentException("ConvertAreaUnit must be specfied  with fromUnit and toUnit");
+            throw new IllegalArgumentException("ConvertAreaUnit must be specified  with fromUnit and toUnit");
         }
 
         AreaUnitType fromUnit = ((ConvertAreaUnit) action).getFromUnit();
@@ -284,7 +284,7 @@ public class NumberFieldActions implements AtlasFieldAction {
         if (action == null || !(action instanceof ConvertVolumeUnit)
                 || ((ConvertVolumeUnit) action).getFromUnit() == null
                 || ((ConvertVolumeUnit) action).getToUnit() == null) {
-            throw new IllegalArgumentException("ConvertVolumeUnit must be specfied  with fromUnit and toUnit");
+            throw new IllegalArgumentException("ConvertVolumeUnit must be specified  with fromUnit and toUnit");
         }
 
         VolumeUnitType fromUnit = ((ConvertVolumeUnit) action).getFromUnit();

--- a/lib/core/src/main/java/io/atlasmap/actions/StringComplexFieldActions.java
+++ b/lib/core/src/main/java/io/atlasmap/actions/StringComplexFieldActions.java
@@ -102,7 +102,7 @@ public class StringComplexFieldActions implements AtlasFieldAction {
         EndsWith endsWith = (EndsWith) action;
 
         if (endsWith.getString() == null) {
-            throw new IllegalArgumentException("EndsWith must be specfied with a string");
+            throw new IllegalArgumentException("EndsWith must be specified with a string");
         }
 
         return input == null ? false : input.endsWith(endsWith.getString());
@@ -117,7 +117,7 @@ public class StringComplexFieldActions implements AtlasFieldAction {
         Format format = (Format) action;
 
         if (format.getTemplate() == null) {
-            throw new IllegalArgumentException("Format must be specfied with a template");
+            throw new IllegalArgumentException("Format must be specified with a template");
         }
 
         return String.format(Locale.ROOT, format.getTemplate(), input);
@@ -137,7 +137,7 @@ public class StringComplexFieldActions implements AtlasFieldAction {
         IndexOf indexOf = (IndexOf) action;
 
         if (indexOf.getString() == null) {
-            throw new IllegalArgumentException("IndexOf must be specfied with a string");
+            throw new IllegalArgumentException("IndexOf must be specified with a string");
         }
 
         return input == null ? -1 : input.indexOf(indexOf.getString());
@@ -152,7 +152,7 @@ public class StringComplexFieldActions implements AtlasFieldAction {
         LastIndexOf lastIndexOf = (LastIndexOf) action;
 
         if (lastIndexOf.getString() == null) {
-            throw new IllegalArgumentException("LastIndexOf must be specfied with a string");
+            throw new IllegalArgumentException("LastIndexOf must be specified with a string");
         }
 
         return input == null ? -1 : input.lastIndexOf(lastIndexOf.getString());
@@ -162,7 +162,7 @@ public class StringComplexFieldActions implements AtlasFieldAction {
     public static String padStringRight(Action action, String input) {
         if (!(action instanceof PadStringRight) || ((PadStringRight) action).getPadCharacter() == null
                 || ((PadStringRight) action).getPadCount() == null) {
-            throw new IllegalArgumentException("PadStringRight must be specfied with padCharacter and padCount");
+            throw new IllegalArgumentException("PadStringRight must be specified with padCharacter and padCount");
         }
 
         PadStringRight padStringRight = (PadStringRight) action;
@@ -182,7 +182,7 @@ public class StringComplexFieldActions implements AtlasFieldAction {
     public static String padStringLeft(Action action, String input) {
         if (!(action instanceof PadStringLeft) || ((PadStringLeft) action).getPadCharacter() == null
                 || ((PadStringLeft) action).getPadCount() == null) {
-            throw new IllegalArgumentException("PadStringLeft must be specfied with padCharacter and padCount");
+            throw new IllegalArgumentException("PadStringLeft must be specified with padCharacter and padCount");
         }
 
         PadStringLeft padStringLeft = (PadStringLeft) action;
@@ -269,7 +269,7 @@ public class StringComplexFieldActions implements AtlasFieldAction {
         StartsWith startsWith = (StartsWith) action;
 
         if (startsWith.getString() == null) {
-            throw new IllegalArgumentException("StartsWith must be specfied with a string");
+            throw new IllegalArgumentException("StartsWith must be specified with a string");
         }
 
         return input == null ? false : input.startsWith(startsWith.getString());

--- a/lib/core/src/main/java/io/atlasmap/actions/StringComplexFieldActions.java
+++ b/lib/core/src/main/java/io/atlasmap/actions/StringComplexFieldActions.java
@@ -17,6 +17,7 @@ package io.atlasmap.actions;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -119,7 +120,7 @@ public class StringComplexFieldActions implements AtlasFieldAction {
             throw new IllegalArgumentException("Format must be specfied with a template");
         }
 
-        return String.format(format.getTemplate(), input);
+        return String.format(Locale.ROOT, format.getTemplate(), input);
     }
 
     @AtlasFieldActionInfo(name = "GenerateUUID", sourceType = FieldType.NONE, targetType = FieldType.STRING, sourceCollectionType = CollectionType.NONE, targetCollectionType = CollectionType.NONE)


### PR DESCRIPTION
Unit tests were failing on my machine as I have another default Locale setting.

Failing test:
https://github.com/atlasmap/atlasmap/blob/master/lib/core/src/test/java/io/atlasmap/actions/StringComplexFieldActionsTest.java#L141

Different local setting returns `"1.234,00"` and assertion fails.

I explicitly added root locale to String format in https://github.com/atlasmap/atlasmap/compare/master...christophd:fix/locale-specific-test-failure?expand=1#diff-e8deec4e7a8840412fdb2406fb2a66b5R123 so the Locale specific adjustments are disabled. 

Also fixed some typos ;-)