### PR TITLE
Update the quick start instructions.

### DIFF
--- a/docs/src/main/asciidoc/inc/_quickstart.adoc
+++ b/docs/src/main/asciidoc/inc/_quickstart.adoc
@@ -21,14 +21,14 @@ $ git clone https://github.com/atlasmap/atlasmap ${ATLASMAP}
 +
 ```
 $ cd ${ATLASMAP}
-$ sh build.sh --skip-tests
+$ ./mvnw clean install -DskipTests
 ```
 +
-3. Run AtlasMap Design Service
+3. Run AtlasMap standalone
 +
 ```
-$ cd ${ATLASMAP}/runtime/runtime
-$ ../../mvnw -Pitests spring-boot:run
+$ cd ${ATLASMAP}/standalone
+$ ../mvnw -Pitests spring-boot:run
 ```
 +
 4. https://yarnpkg.com/lang/en/docs/install/[Install Yarn]


### PR DESCRIPTION
Update the quick start instruction as README showed.
NOTE: We may also need to updated the section of Running AtlasMap full build as the build.sh is moved.