### PR TITLE
fix: Allow drag&drop unselected field

### DIFF
--- a/ui/src/app/lib/atlasmap-data-mapper/components/document-field-detail.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/document-field-detail.component.ts
@@ -85,7 +85,7 @@ export class DocumentFieldDetailComponent {
     this.isDragDropTarget = true;
   }
 
-  endDrag(event: any): void {
+  endDrag(event: MouseEvent): void {
     this.isDragDropTarget = false;
     if (!this.field.isTerminal() || (this.field.isSource() === this.cfg.currentDraggedField.isSource())) {
       return;
@@ -96,6 +96,9 @@ export class DocumentFieldDetailComponent {
       return;
     }
 
+    if (!this.cfg.currentDraggedField.selected) {
+      this.cfg.mappingService.fieldSelected(this.cfg.currentDraggedField, event.ctrlKey || event.metaKey);
+    }
     this.cfg.mappingService.fieldSelected(this.field, false);
   }
 


### PR DESCRIPTION
Also added support to drag&drop compound fields. This behavior needs a bit more polish, e.g. multiple source fields are already selected and start drag&drop one of them. Then that field is unexpectedly "unselected". We might need to skip the "unselect" action in this case. @pleacu WDYT?

Fixes: #770