### PR TITLE
ENTESB-10411 Merge prod changes back to dev branch

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -66,64 +66,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.github.eirslett</groupId>
-        <artifactId>frontend-maven-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>install yarn</id>
-              <phase>compile</phase>
-              <goals>
-                <goal>install-node-and-yarn</goal>
-              </goals>
-              <configuration>
-                <nodeVersion>${node.version}</nodeVersion>
-                <npmVersion>${npm.version}</npmVersion>
-                <yarnVersion>${yarn.version}</yarnVersion>
-              </configuration>
-            </execution>
-            <execution>
-              <id>yarn install</id>
-              <phase>compile</phase>
-              <goals>
-                <goal>yarn</goal>
-              </goals>
-              <configuration>
-                <arguments>install -s --no-progress</arguments>
-              </configuration>
-            </execution>
-            <execution>
-              <id>yarn build</id>
-              <phase>compile</phase>
-              <goals>
-                <goal>yarn</goal>
-              </goals>
-              <configuration>
-                <arguments>build:app</arguments>
-              </configuration>
-            </execution>
-            <execution>
-              <id>yarn lint</id>
-              <phase>test</phase>
-              <goals>
-                <goal>yarn</goal>
-              </goals>
-              <configuration>
-                <arguments>lint</arguments>
-              </configuration>
-            </execution>
-            <execution>
-              <id>yarn test</id>
-              <phase>test</phase>
-              <goals>
-                <goal>yarn</goal>
-              </goals>
-              <configuration>
-                <arguments>test</arguments>
-              </configuration>
-            </execution>
-          </executions>
-      </plugin>
-      <plugin>
         <groupId>io.atlasmap</groupId>
         <artifactId>atlasmap-maven-plugin</artifactId>
         <version>${project.version}</version>
@@ -167,6 +109,171 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>noproxy</id>
+      <activation>
+          <property>
+              <name>!productization</name>
+          </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>install yarn</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>install-node-and-yarn</goal>
+                </goals>
+                <configuration>
+                  <nodeVersion>${node.version}</nodeVersion>
+                  <npmVersion>${npm.version}</npmVersion>
+                  <yarnVersion>${yarn.version}</yarnVersion>
+                </configuration>
+              </execution>
+              <execution>
+                <id>yarn install</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <arguments>install -s --no-progress</arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>yarn build</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <arguments>build:app</arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>yarn lint</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <arguments>lint</arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>yarn test</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <arguments>test</arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>productization</id>
+      <activation>
+        <property>
+          <name>productization</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <executions>
+              <!-- Install Node and Yarn -->
+              <execution>
+                <id>install node and yarn</id>
+                <goals>
+                  <goal>install-node-and-yarn</goal>
+                </goals>
+                <configuration>
+                  <nodeVersion>v6.11.2</nodeVersion>
+                  <yarnVersion>v1.3.2</yarnVersion>
+                </configuration>
+              </execution>
+              <execution>
+                <id>set https proxy</id>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <arguments>config set https-proxy http://${buildContentId}+tracking:${accessToken}@${proxyServer}:${proxyPort}</arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>set http proxy</id>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <arguments>config set proxy http://${buildContentId}+tracking:${accessToken}@${proxyServer}:${proxyPort}</arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>set maxconn</id>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <arguments>config set maxsockets 2</arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>yarn set registry</id>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <arguments>config set registry ${npmRegistryURL2}</arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>yarn set no-strict ssl</id>
+                <goals>
+                   <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <arguments>config set strict-ssl false</arguments>
+                </configuration>
+              </execution>
+              <!-- Install npm/yarn dependencies -->
+              <execution>
+                <id>yarn install</id>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <arguments>install</arguments>
+                </configuration>
+              </execution>
+              <!-- Build the app -->
+              <execution>
+                <id>ng build</id>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <arguments>build</arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>release</id>
       <build>

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1448,9 +1448,9 @@ bower-endpoint-parser@~0.2.2:
   resolved "https://registry.yarnpkg.com/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz#00b565adbfab6f2d35addde977e97962acbcb3f6"
   integrity sha1-ALVlrb+rby01rd3pd+l5Yqy8s/Y=
 
-"bower-installer@git://github.com/bessdsv/bower-installer.git#temp":
+bower-installer@~0.8.4:
   version "0.8.4"
-  resolved "git://github.com/bessdsv/bower-installer.git#7f9cece1e6fada50f44dc0851e1d85815cd1b4a7"
+  resolved "https://registry.npmjs.org/bower-installer/-/bower-installer-0.8.4.tgz#f24ff11df1e5d38a294073bf03527fd2f348c1e3"
   dependencies:
     async "~0.2.9"
     bower "~1.3.8"
@@ -5153,7 +5153,7 @@ karma-jasmine-jquery@^0.1.1:
   integrity sha1-icG3VP6kElsfiTghOSwRuc5ddFY=
   dependencies:
     bower "^1.3.9"
-    bower-installer "git://github.com/bessdsv/bower-installer.git#temp"
+    bower-installer "^0.8.4"
 
 karma-jasmine@^1.0.2, karma-jasmine@~1.1.0:
   version "1.1.2"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1448,9 +1448,9 @@ bower-endpoint-parser@~0.2.2:
   resolved "https://registry.yarnpkg.com/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz#00b565adbfab6f2d35addde977e97962acbcb3f6"
   integrity sha1-ALVlrb+rby01rd3pd+l5Yqy8s/Y=
 
-bower-installer@~0.8.4:
+bower-installer@^0.8.4:
   version "0.8.4"
-  resolved "https://registry.npmjs.org/bower-installer/-/bower-installer-0.8.4.tgz#f24ff11df1e5d38a294073bf03527fd2f348c1e3"
+  resolved "https://registry.yarnpkg.com/bower-installer/-/bower-installer-0.8.4.tgz#f24ff11df1e5d38a294073bf03527fd2f348c1e3"
   dependencies:
     async "~0.2.9"
     bower "~1.3.8"


### PR DESCRIPTION
@igarashitm : I'm creating two profiles here - one for normal use (noproxy) and a productization profile that allows us to operate behind the PNC proxy.      

There's one more change here too - I've think I've changed bower-installer to use the binary rather than github - I had issues building atlasmap in prod with github location, but if I changed to the binary, it worked fine.   Can you check that that looks okay?   I don't know angular real well so I don't know if what I did was the right way to do it, but it did seem to work.