### PR TITLE
fix: Correct base image name to java-jboss-openjdk8-jdk

### DIFF
--- a/standalone/pom.xml
+++ b/standalone/pom.xml
@@ -34,7 +34,7 @@
     <failOnMissingWebXml>false</failOnMissingWebXml>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
     <!-- Controls Docker Image Generation -->
-    <from.image>fabric8/java-centos-openjdk8-jdk</from.image>
+    <from.image>fabric8/java-jboss-openjdk8-jdk</from.image>
     <docker.image>atlasmap/atlasmap:%l</docker.image>
     <from.image.version>1.3</from.image.version>
     <fabric8.mode>kubernetes</fabric8.mode>


### PR DESCRIPTION
Relates to #913.

Tweak to the base image used as the original isn't so OpenShift friendly OOTB. 