### PR TITLE
feat: [UI] Show short field label in the expression

### DIFF
--- a/ui/src/app/lib/atlasmap-data-mapper/components/data-mapper-app.component.css
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/data-mapper-app.component.css
@@ -469,5 +469,17 @@
 }
 
 /* conditional mapping */
-.DataMapperUI .expressionTextarea { width:100%; height:29px; }
+.DataMapperUI .expressionMarkup {
+  width:100%;
+  height:29px;
+  display: inline-block;
+  position: absolute;
+}
+.DataMapperUI .expressionTextarea {
+  width:100%;
+  height:29px;
+  display: inline-block;
+  border: none;
+  outline: none;
+}
 

--- a/ui/src/app/lib/atlasmap-data-mapper/components/expression.component.html
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/expression.component.html
@@ -1,0 +1,6 @@
+<div id="expressionMarkup" class="form-control expressionMarkup" [innerHTML]="generateExpressionMarkup()">
+</div>
+<textarea id="expressionTextarea" cols="80" #expressionTextareaRef autofocus class="expressionTextarea"
+  [(ngModel)]="this.configModel.mappings.activeMapping.getCurrentFieldMapping().transition.expression"
+  tooltip="FIXME: field ref like \${0} shows a label">
+</textarea>

--- a/ui/src/app/lib/atlasmap-data-mapper/components/expression.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/expression.component.ts
@@ -1,0 +1,53 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { Component, ViewChild, Input, HostListener, ElementRef } from '@angular/core';
+import { ConfigModel } from '../models/config.model';
+
+@Component({
+  selector: 'expression',
+  templateUrl: 'expression.component.html'
+})
+
+export class ExpressionComponent {
+
+  @Input()
+  configModel: ConfigModel;
+
+  @ViewChild('expressionTextareaRef')
+  textarea: ElementRef;
+
+  @HostListener('click')
+  onClick() {
+    this.textarea.nativeElement.focus();
+  }
+
+  @HostListener('keyup', ['$event'])
+  onkeyup(event: KeyboardEvent) {
+    // TODO handle deleting field refs... just one [backspace] should delete a ref entirely, but not only a closing bracket
+    // TODO show a cursor
+    // TODO text selection
+  }
+
+  generateExpressionMarkup(): string {
+    const expression = this.configModel.mappings.activeMapping.getCurrentFieldMapping().transition.expression;
+    if (!expression) {
+      return '';
+    }
+    // TODO show field name instead and put a full path as a tooltip
+    return expression.replace(/\$\{[0-9]+\}/g, '<span class="inline-block label label-default">$&</span>');
+  }
+
+}

--- a/ui/src/app/lib/atlasmap-data-mapper/components/toolbar.component.html
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/toolbar.component.html
@@ -2,21 +2,15 @@
 
   <div class="toolbar-icons pull-right">
 
-    <!-- TODO Apply UXD outcome https://github.com/atlasmap/atlasmap/issues/852 -->
     <i class="dropdown inline-block" [attr.class]="getCSSClass('enableExpression')" (click)="toolbarButtonClicked('enableExpression', $event);"
       tooltip='Enable/ Disable conditional mapping expression' placement="bottom"
       style="float:left;font-weight:bold;margin-top:-6px;">f<sub>(x)</sub>
     </i>
 
-    <!-- TODO Apply UXD outcome https://github.com/atlasmap/atlasmap/issues/852 -->
     <div *ngIf="conditionalMappingExpressionEnabled()"
       class="dropdown inline-block pull-left" (drop)="endDrag($event)" (dragover)="allowDrop($event)" >
-
       <div class="dropdown inline-block pull-left" style="margin-left:8px;" >
-        <textarea rows="1" cols="80" id="expression" class="form-control expressionTextarea"
-          [(ngModel)]='cfg.mappings.activeMapping.getCurrentFieldMapping().transition.expression'
-          (blur)="cfg.mappingService.notifyMappingUpdated()" placeholder="Enter mapping expression">
-        </textarea>
+        <expression [configModel]="cfg"></expression>
       </div>
     </div>
 

--- a/ui/src/app/lib/atlasmap-data-mapper/data-mapper.module.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/data-mapper.module.ts
@@ -57,6 +57,7 @@ import { MappingSelectionSectionComponent } from './components/mapping/mapping-s
 import { LookupTableComponent } from './components/mapping/lookup-table.component';
 import { TransitionSelectionComponent } from './components/mapping/transition-selection.component';
 import { FocusDirective } from './common/focus.directive';
+import { ExpressionComponent } from './components/expression.component';
 
 // export services/types for consumers of this module
 export { ApiXsrfInterceptor, ApiHttpXsrfTokenExtractor } from './services/api-xsrf.service';
@@ -126,6 +127,7 @@ export const alertModuleForRoot: ModuleWithProviders = AlertModule.forRoot();
     MappingListFieldComponent,
     NamespaceListComponent,
     TemplateEditComponent,
+    ExpressionComponent,
     FocusDirective,
     ToErrorIconClassPipe
   ],


### PR DESCRIPTION
Submitting a wip PR - it's not yet really functioning, but shows an initial idea of how it will look like.
![expression-label](https://user-images.githubusercontent.com/265462/57342110-46540080-710b-11e9-8ab9-f0c281ff4371.gif)

There're still many things left to do:
1. Restore a cursor
1. Restore highlighting text selection
1. Show field name instead of `$[n}` ref
1. Show field full path as a tooltip
1. Support removing field ref entirely with single `[backspace]` instead of removing just closing bracket