### PR TITLE
fix: Cannot read property 'expressionUpdated$' of undefined

### DIFF
--- a/ui/src/app/lib/atlasmap-data-mapper/components/expression.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/expression.component.ts
@@ -65,6 +65,10 @@ export class ExpressionComponent implements OnInit, OnDestroy, OnChanges {
 
   ngOnChanges() {
     this.mapping = this.configModel.mappings.activeMapping.getCurrentFieldMapping();
+    if (!this.getExpression()) {
+      this.mapping.transition.expression = new ExpressionModel(this.mapping);
+      this.getExpression().generateInitialExpression();
+    }
     if (this.expressionUpdatedSubscription) {
       this.expressionUpdatedSubscription.unsubscribe();
     }


### PR DESCRIPTION
Fixes: #973

Not sure how ngOnChanges() is invoked while ExpressionModel object is not yet initialized, but this prevents the error anyway.