### PR TITLE
fix: Capture trailing text into generated amppings expressions.

### DIFF
--- a/ui/src/app/lib/atlasmap-data-mapper/components/expression.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/expression.component.ts
@@ -78,6 +78,12 @@ export class ExpressionComponent implements OnInit, OnDestroy, OnChanges {
     this.expressionUpdatedSubscription = this.getExpression().expressionUpdated$.subscribe((updatedEvent) => {
       this.updateExpressionMarkup();
       this.restoreCaretPosition(updatedEvent);
+
+      // Only validate for inserted or appended text nodes.
+      if ((!updatedEvent && this.getExpression().getLastNode() instanceof TextNode) ||
+          (updatedEvent && updatedEvent.node instanceof TextNode)) {
+        this.configModel.mappingService.validateMappings();
+      }
     });
     this.updateExpressionMarkup();
     this.moveCaretToEnd();


### PR DESCRIPTION
Fixes: #994

It's necessary to call validateMappings() within the expression update observer
in the event a text node is added.  Field nodes are ultimately 'fieldSelected()'
so they get validateMappings() that way.