### PR TITLE
fix: Change wording in UI code: Combine>manyToOne and Separate>OneToMany

### DIFF
--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-detail.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-detail.component.ts
@@ -141,7 +141,7 @@ export class MappingFieldDetailComponent implements OnInit {
     this.searchFilter = this.mappedField.field.getFieldLabel(this.cfg.showTypes, false);
     this.cfg.mappingService.transitionMode(this.mapping, this.mappedField.field);
 
-    if (this.mapping.transition.mode !== TransitionMode.MAP) {
+    if (this.mapping.transition.mode !== TransitionMode.ONE_TO_ONE) {
       this.mapping.updateTransition(this.mappedField.field.isSource(), true, false);
 
       this.cfg.mappingService.resequenceMappedField(this.mapping, this.mappedField,
@@ -165,7 +165,7 @@ export class MappingFieldDetailComponent implements OnInit {
 
   displaySeparator(): boolean {
     return (this.mappedField.isNoneField() && this.isSource &&
-      (this.mapping.transition.isSeparateMode() || this.mapping.transition.isCombineMode()));
+      (this.mapping.transition.isOneToManyMode() || this.mapping.transition.isManyToOneMode()));
   }
 
   displayFieldSearchBox(): boolean {
@@ -174,17 +174,17 @@ export class MappingFieldDetailComponent implements OnInit {
       return false;
     }
 
-    if ((this.mapping.transition.mode === TransitionMode.MAP) ||
+    if ((this.mapping.transition.mode === TransitionMode.ONE_TO_ONE) ||
         (this.mappedField.field.name.length > 0)) {
       return true;
     }
 
     if (this.isSource) {
-      if (this.mapping.transition.mode === TransitionMode.COMBINE) {
+      if (this.mapping.transition.mode === TransitionMode.MANY_TO_ONE) {
         return true;
       }
     } else {
-      if (this.mapping.transition.mode === TransitionMode.SEPARATE) {
+      if (this.mapping.transition.mode === TransitionMode.ONE_TO_MANY) {
         return true;
       }
     }

--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/simple-mapping.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/simple-mapping.component.ts
@@ -118,9 +118,9 @@ export class SimpleMappingComponent {
   }
 
   isAddButtonVisible(): boolean {
-    if (this.isSource && this.mapping.transition.isCombineMode()) {
+    if (this.isSource && this.mapping.transition.isManyToOneMode()) {
       return true;
-    } else if (!this.isSource && this.mapping.transition.isSeparateMode()) {
+    } else if (!this.isSource && this.mapping.transition.isOneToManyMode()) {
       return true;
     }
     return false;

--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/transition-selection.component.html
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/transition-selection.component.html
@@ -5,7 +5,7 @@
     <i class="fa fa-edit link" (click)="showLookupTable()"></i>
   </div>
 
-  <div *ngIf="mapping.transition.isCombineMode() || mapping.transition.isSeparateMode()">
+  <div *ngIf="mapping.transition.isManyToOneMode() || mapping.transition.isOneToManyMode()">
     <label tooltip="Enter a separator delimiter character" >Separator:
       <select class="combobox" name="separator" id="separator" [ngModel]="mapping.transition.delimiter">
         <ng-container *ngFor="let delimiter of delimiters" id="delimiter">

--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/transition-selection.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/transition-selection.component.ts
@@ -130,7 +130,7 @@ export class TransitionSelectionComponent implements OnInit {
     if (delimiterModel.delimiter === TransitionDelimiter.NONE) {
       return false;
     } else if (delimiterModel.delimiter === TransitionDelimiter.MULTI_SPACE) {
-      return this.mapping.transition.isSeparateMode();
+      return this.mapping.transition.isOneToManyMode();
     }
     return true;
   }

--- a/ui/src/app/lib/atlasmap-data-mapper/models/mapping-definition.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/mapping-definition.model.ts
@@ -427,8 +427,8 @@ export class MappingDefinition {
         }
       }
 
-      const isSeparate: boolean = mapping.transition.isSeparateMode();
-      const isCombine: boolean = mapping.transition.isCombineMode();
+      const isSeparate: boolean = mapping.transition.isOneToManyMode();
+      const isCombine: boolean = mapping.transition.isManyToOneMode();
       mappedField.index = +mappedField.parsedData.parsedIndex;
       mappedField.updateSeparateOrCombineFieldAction(isSeparate, isCombine, isSource, false, false);
     }

--- a/ui/src/app/lib/atlasmap-data-mapper/models/mapping.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/mapping.model.ts
@@ -109,8 +109,8 @@ export class MappedField {
       padField.field = DocumentDefinition.getPadField();
       padField.field.docDef = this.field.docDef;
       padField.setIsPadField();
-      padField.updateSeparateOrCombineFieldAction(mapping.transition.mode === TransitionMode.SEPARATE,
-        mapping.transition.mode === TransitionMode.COMBINE, i.toString(10), this.isSource(), true, false);
+      padField.updateSeparateOrCombineFieldAction(mapping.transition.mode === TransitionMode.ONE_TO_MANY,
+        mapping.transition.mode === TransitionMode.MANY_TO_ONE, i.toString(10), this.isSource(), true, false);
       if (this.isSource()) {
           mapping.sourceFields.push(padField);
       } else {
@@ -306,9 +306,9 @@ export class MappingModel {
     let combineMode = false;
 
     if (!lookupMode) {
-      mapMode = mapMode || this.transition.isMapMode();
-      separateMode = separateMode || this.transition.isSeparateMode();
-      combineMode = combineMode || this.transition.isCombineMode();
+      mapMode = mapMode || this.transition.isOneToOneMode();
+      separateMode = separateMode || this.transition.isOneToManyMode();
+      combineMode = combineMode || this.transition.isManyToOneMode();
     }
     if (mapMode || separateMode || combineMode) {
       // enums are not selectable in these modes
@@ -687,8 +687,8 @@ export class MappingModel {
       }
     }
 
-    let separateMode: boolean = (this.transition.mode === TransitionMode.SEPARATE);
-    let combineMode: boolean = (this.transition.mode === TransitionMode.COMBINE);
+    let separateMode: boolean = (this.transition.mode === TransitionMode.ONE_TO_MANY);
+    let combineMode: boolean = (this.transition.mode === TransitionMode.MANY_TO_ONE);
     let maxIndex = 0;
 
     if (combineMode || separateMode) {
@@ -701,7 +701,7 @@ export class MappingModel {
       maxIndex = this.processIndices(combineMode, fieldRemoved);
 
       if (maxIndex <= 1 && fieldRemoved) {
-        this.transition.mode = TransitionMode.MAP;
+        this.transition.mode = TransitionMode.ONE_TO_ONE;
         combineMode = false;
         separateMode = false;
         this.clearAllCombineSeparateActions();

--- a/ui/src/app/lib/atlasmap-data-mapper/models/transition.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/transition.model.ts
@@ -14,9 +14,8 @@
     limitations under the License.
 */
 import { ExpressionModel } from './expression.model';
-import { FieldActionDefinition } from './field-action.model';
 
-export enum TransitionMode { MAP, SEPARATE, ENUM, COMBINE }
+export enum TransitionMode { ONE_TO_ONE, ONE_TO_MANY, ENUM, MANY_TO_ONE, FOR_EACH }
 export enum TransitionDelimiter {
   NONE, AMPERSAND, AT_SIGN, BACKSLASH, COLON, COMMA, DASH, EQUAL, HASH,
   MULTI_SPACE, PERIOD, PIPE, SEMICOLON, SLASH, SPACE, UNDERSCORE, USER_DEFINED
@@ -40,7 +39,7 @@ export class TransitionDelimiterModel {
 export class TransitionModel {
   static delimiterModels: TransitionDelimiterModel[] = [];
 
-  mode: TransitionMode = TransitionMode.MAP;
+  mode: TransitionMode = TransitionMode.ONE_TO_ONE;
   delimiter: TransitionDelimiter = TransitionDelimiter.SPACE;
   userDelimiter = '';
   lookupTableName: string = null;
@@ -76,28 +75,32 @@ export class TransitionModel {
   }
 
   /**
-   * Translate an action mode number into a string.
+   * Translate a mapping mode number into a string.
    * @param mode
    */
-  static getActionName(mode: TransitionMode): string {
+  static getMappingModeName(mode: TransitionMode): string {
     let actionName: string;
 
     switch (mode) {
-      case TransitionMode.MAP: {
-         actionName = 'MAP';
-         break;
+      case TransitionMode.ONE_TO_ONE: {
+        actionName = 'One to One';
+        break;
       }
-      case TransitionMode.COMBINE: {
-         actionName = 'COMBINE';
-         break;
+      case TransitionMode.MANY_TO_ONE: {
+        actionName = 'Many to One';
+        break;
       }
-      case TransitionMode.SEPARATE: {
-          actionName = 'SEPARATE';
-          break;
+      case TransitionMode.ONE_TO_MANY: {
+        actionName = 'One to Many';
+        break;
       }
       case TransitionMode.ENUM: {
-          actionName = 'ENUM';
-          break;
+        actionName = 'ENUM';
+        break;
+      }
+      case TransitionMode.FOR_EACH: {
+        actionName = 'For Each';
+        break;
       }
       default: {
          actionName = '';
@@ -159,26 +162,30 @@ export class TransitionModel {
 
   getPrettyName() {
     const delimiterDesc: string = TransitionModel.getTransitionDelimiterPrettyName(this.delimiter);
-    if (this.mode === TransitionMode.SEPARATE) {
-      return 'Separate (' + delimiterDesc + ')';
-    } else if (this.mode === TransitionMode.COMBINE) {
-      return 'Combine (' + delimiterDesc + ')';
+    if (this.mode === TransitionMode.ONE_TO_MANY) {
+      return TransitionModel.getMappingModeName(this.mode) + ' (' + delimiterDesc + ')';
+    } else if (this.mode === TransitionMode.MANY_TO_ONE) {
+      return TransitionModel.getMappingModeName(this.mode) + ' (' + delimiterDesc + ')';
     } else if (this.mode === TransitionMode.ENUM) {
       return 'Enum (table: ' + this.lookupTableName + ')';
     }
-    return 'Map';
+    return TransitionModel.getMappingModeName(this.mode);
   }
 
-  isSeparateMode(): boolean {
-    return this.mode === TransitionMode.SEPARATE;
+  isOneToManyMode(): boolean {
+    return this.mode === TransitionMode.ONE_TO_MANY;
   }
 
-  isMapMode(): boolean {
-    return this.mode === TransitionMode.MAP;
+  isOneToOneMode(): boolean {
+    return this.mode === TransitionMode.ONE_TO_ONE;
   }
 
-  isCombineMode(): boolean {
-    return this.mode === TransitionMode.COMBINE;
+  isManyToOneMode(): boolean {
+    return this.mode === TransitionMode.MANY_TO_ONE;
+  }
+
+  isForEachMode(): boolean {
+    return this.mode === TransitionMode.FOR_EACH;
   }
 
   isEnumerationMode(): boolean {

--- a/ui/src/app/lib/atlasmap-data-mapper/services/mapping-management.service.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/services/mapping-management.service.ts
@@ -425,25 +425,27 @@ export class MappingManagementService {
     if (mapping.transition == null || field == null) {
       return;
     }
-    if (mapping.transition.mode === TransitionMode.COMBINE) {
+    if (mapping.transition.mode === TransitionMode.MANY_TO_ONE) {
 
-      // Compound source mapping when not in Combine mode
+      // Compound target mapping when not in ONE_TO_MANY mode
       if (!field.isSource()) {
-        this.cfg.errorService.info('The selected mapping details action ' + TransitionModel.getActionName(mapping.transition.mode) +
-                ' is not applicable from compound source selections (' + field.name +
-                ').  Recommend using field action \'Combine\'.', null);
+        this.cfg.errorService.info(`Cannot add target field '${field.name}' into mapping:
+        Multiple target fields cannot be added into
+          ${TransitionModel.getMappingModeName(mapping.transition.mode)}
+          mapping. Only one of Source field or Target field could be multiple.`, null);
         return;
       }
       if (mapping.sourceFields[mapping.sourceFields.length - 1].actions.length > 0) {
         suggestedValue = mapping.sourceFields[mapping.sourceFields.length - 1].index + 1;
       }
-    } else if (mapping.transition.mode === TransitionMode.SEPARATE) {
+    } else if (mapping.transition.mode === TransitionMode.ONE_TO_MANY) {
       if (field.isSource()) {
 
-        // Compound target mapping when not in Separate mode.
-        this.cfg.errorService.info('The selected mapping details action ' + TransitionModel.getActionName(mapping.transition.mode) +
-                ' is not applicable to compound target selections (' + field.name +
-                ').  Recommend using field action \'Separate\'.', null);
+        // Compound source mapping when not in MANY_TO_ONE mode.
+        this.cfg.errorService.info(`Cannot add source field '${field.name}' into mapping:
+          Multiple source fields cannot be added into
+          ${TransitionModel.getMappingModeName(mapping.transition.mode)}
+          mapping. Only one of Source field or Target field could be multiple.`, null);
         return;
       }
       if (mapping.targetFields[mapping.targetFields.length - 1].actions.length > 0) {
@@ -453,8 +455,8 @@ export class MappingManagementService {
     const newMField = new MappedField;
     newMField.field = field;
     newMField.index = suggestedValue;
-    newMField.updateSeparateOrCombineFieldAction(mapping.transition.mode === TransitionMode.SEPARATE,
-      mapping.transition.mode === TransitionMode.COMBINE, field.isSource(), true, false);
+    newMField.updateSeparateOrCombineFieldAction(mapping.transition.mode === TransitionMode.ONE_TO_MANY,
+      mapping.transition.mode === TransitionMode.MANY_TO_ONE, field.isSource(), true, false);
     if (field.isSource()) {
       mapping.sourceFields.push(newMField);
     } else {
@@ -477,18 +479,18 @@ export class MappingManagementService {
    * @param field
    */
   transitionMode(mapping: MappingModel, field: Field): void {
-    if (mapping.transition.mode === TransitionMode.MAP) {
+    if (mapping.transition.mode === TransitionMode.ONE_TO_ONE) {
       const mappedFields: MappedField[] = mapping.getMappedFields(field.isSource());
       if (mappedFields.length > 2) {
         if (field.isSource()) {
-          mapping.transition.mode = TransitionMode.COMBINE;
+          mapping.transition.mode = TransitionMode.MANY_TO_ONE;
           mappedFields[1].index = 1;
           mappedFields[1].updateSeparateOrCombineFieldAction(false, true, true, true, false);
           this.cfg.errorService.info(
             'Note: You\'ve selected multiple fields to combine.  ' +
             'You may want to examine the separator character in the \'Sources\' box of the Mapping Details section.', null);
         } else {
-          mapping.transition.mode = TransitionMode.SEPARATE;
+          mapping.transition.mode = TransitionMode.ONE_TO_MANY;
           mappedFields[1].index = 1;
           mappedFields[1].updateSeparateOrCombineFieldAction(true, false, false, true, false);
           this.cfg.errorService.info(


### PR DESCRIPTION
Fixes: #920

Also added FOR_EACH mode to use for collection<->collection mapping. See #918.
There're some more separate/combine words around field action model, but it has to be addressed as a part of #912.