### PR TITLE
fix: Correct modal reset to not automatically clear errors.

### DIFF
--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-detail.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-detail.component.ts
@@ -85,6 +85,7 @@ export class MappingDetailComponent implements OnInit, OnDestroy {
     };
     this.modalWindow.nestedComponentType = MappingSelectionComponent;
     this.modalWindow.okButtonHandler = (mw: ModalWindowComponent) => {
+      this.cfg.errorService.clearValidationErrors();
       const c: MappingSelectionComponent = mw.nestedComponent as MappingSelectionComponent;
       const mapping: MappingModel = c.getSelectedMapping();
       self.cfg.mappingService.selectMapping(mapping);

--- a/ui/src/app/lib/atlasmap-data-mapper/components/modal-window.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/modal-window.component.ts
@@ -125,7 +125,6 @@ export class ModalWindowComponent implements AfterViewInit, OnDestroy {
   }
 
   reset(): void {
-    this.cfg.errorService.clearValidationErrors();
     this.nestedComponentInitializedCallback = null;
     this.confirmButtonDisabled = false;
     this.confirmButtonText = 'OK';

--- a/ui/src/app/lib/atlasmap-data-mapper/components/toolbar.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/toolbar.component.ts
@@ -197,7 +197,7 @@ export class ToolbarComponent implements OnInit {
     this.modalWindow.headerText = 'Reset All Mappings and Imports?';
     this.modalWindow.message = 'Are you sure you want to reset all mappings and clear all imported documents?';
     this.modalWindow.okButtonHandler = (mw: ModalWindowComponent) => {
-
+      this.cfg.errorService.clearValidationErrors();
       this.cfg.fileService.resetAll().toPromise().then( async(result: boolean) => {
         this.cfg.initCfg.initialized = false;
         this.cfg.initCfg.mappingInitialized = false;


### PR DESCRIPTION
Fixes: #981

The specific overlap error was corrected with a previous fix.  This is we shouldn't clear out the error window if the user selects 'Cancel' in a dialog, etc.