### PR TITLE
fix: [UI] Clean up transition&index handling

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -92,7 +92,17 @@
               </configuration>
             </execution>
             <execution>
-              <id>yarn build</id>
+              <id>yarn build lib</id>
+              <phase>compile</phase>
+              <goals>
+                <goal>yarn</goal>
+              </goals>
+              <configuration>
+                <arguments>build:lib</arguments>
+              </configuration>
+            </execution>
+            <execution>
+              <id>yarn build app</id>
               <phase>compile</phase>
               <goals>
                 <goal>yarn</goal>

--- a/ui/src/app/lib/atlasmap-data-mapper/components/expression.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/expression.component.ts
@@ -15,7 +15,6 @@ limitations under the License.
 */
 import { Component, ViewChild, Input, HostListener, ElementRef, OnInit, OnDestroy, OnChanges } from '@angular/core';
 import { ConfigModel } from '../models/config.model';
-import { DocumentDefinition } from '../models/document-definition.model';
 import { MappingModel, MappedField } from '../models/mapping.model';
 import { ExpressionModel, FieldNode, ExpressionUpdatedEvent, TextNode } from '../models/expression.model';
 import { Field } from '../models/field.model';
@@ -55,6 +54,8 @@ export class ExpressionComponent implements OnInit, OnDestroy, OnChanges {
   private expressionUpdatedSubscription: Subscription;
 
   ngOnInit() {
+    // Padding fields don't make sense for expression mapping
+    this.mapping.getMappedFields(true).filter(mf => mf.isPadField()).forEach(mf => this.mapping.removeMappedField(mf));
     if (!this.getExpression()) {
       this.mapping.transition.expression = new ExpressionModel(this.mapping, this.configModel);
       this.getExpression().generateInitialExpression();
@@ -344,7 +345,7 @@ export class ExpressionComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   private addConditionalExpressionNode(mappedField: MappedField, nodeId: string, offset: number): void {
-    this.getExpression().insertNodes([new FieldNode(mappedField)], nodeId, offset);
+    this.getExpression().insertNodes([new FieldNode(this.mapping, mappedField)], nodeId, offset);
   }
 
   private updateExpressionMarkup() {
@@ -454,8 +455,8 @@ export class ExpressionComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   private reflectRemovedField = (removed: MappedField) => {
-    this.mapping.removeMappedField(removed, true);
-    this.configModel.mappingService.updateMappedField(this.mapping, true, true);
+    this.mapping.removeMappedField(removed);
+    this.configModel.mappingService.updateMappedField(this.mapping);
   }
 
   private updateSearchMode(): void {

--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-action.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-action.component.ts
@@ -56,7 +56,6 @@ export class MappingFieldActionComponent {
   removeAction(action: FieldAction): void {
     this.mappedField.removeAction(action);
     this.cfg.mappingService.saveCurrentMapping();
-    this.mappedField.reduceTransformationCount();
     this.cfg.mappingService.notifyMappingUpdated();
   }
 

--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-container.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-container.component.ts
@@ -120,9 +120,9 @@ export class MappingFieldContainerComponent implements OnInit {
       return;
     }
 
-    if (insertBeforeMappedField != null && insertBeforeMappedField.actions[0] != null) {
-      this.cfg.mappingService.resequenceMappedField(this.mapping, droppedMappedField,
-        insertBeforeMappedField.index);
+    if (insertBeforeMappedField != null) {
+      this.cfg.mappingService.moveMappedFieldTo(this.mapping, droppedMappedField,
+        this.mapping.getIndexForMappedField(insertBeforeMappedField));
 
       // Update indexing in any conditional mapping expressions.
       if (this.mapping.transition && this.mapping.transition.enableExpression) {
@@ -134,7 +134,7 @@ export class MappingFieldContainerComponent implements OnInit {
   }
 
   displaySeparator(): boolean {
-    return (this.isSource &&
+    return (this.isSource && !this.mapping.transition.enableExpression &&
       (this.mapping.transition.isOneToManyMode() || this.mapping.transition.isManyToOneMode()));
   }
 
@@ -222,7 +222,7 @@ export class MappingFieldContainerComponent implements OnInit {
   }
 
   removeMappedField(mappedField: MappedField): void {
-    this.mapping.removeMappedField(mappedField, this.isSource);
-    this.cfg.mappingService.updateMappedField(this.mapping, this.isSource, true);
+    this.mapping.removeMappedField(mappedField);
+    this.cfg.mappingService.updateMappedField(this.mapping);
   }
 }

--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-detail.component.html
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-detail.component.html
@@ -34,19 +34,19 @@
   <!-- Index: -->
   <label style="display: inline-block; text-align: right; margin-right: 10px; font-style: italic;"
     tooltip="To change the index ordinal value, drag and drop to the desired position."
-    *ngIf="mappedField.hasIndex()">Index: </label>
+    *ngIf="displayIndex()">Index: </label>
 
   <div style="display: inline-block; text-align: right; font-size: 100%; margin-right: 5px; font-weight: bold; color: green; width: 35px;"
-	*ngIf="mappedField.hasIndex()">
+	*ngIf="displayIndex()">
     <div *ngIf="mappedField.isPadField(); else textInput">
       <label style="font-size: 110%; color: dark-gray;
         text-align: right;"
-        tooltip="This pad field has been automatically created to represent indexing gaps.">{{ mappedField.index }}</label>
+        tooltip="This pad field has been automatically created to represent indexing gaps.">{{ mapping.getIndexForMappedField(mappedField) }}</label>
     </div>
     <ng-template #textInput>
       <input type="text" id="{{inputId}}" placement="top"
 	    style="font-size: 110%; font-weight: bold; color: green; text-align: right; height: 20px"
-        [ngModel]="mappedField.index" typeaheadWaitMs="400"
+        [ngModel]="mapping.getIndexForMappedField(mappedField)" typeaheadWaitMs="400"
         (change)="indexSelectionChanged($event, mappedField)"
         tooltip="You may edit the index for this element directly.  Placeholders may be automatically inserted to account for any gaps in the indexing.">
     </ng-template>

--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-detail.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-detail.component.ts
@@ -17,7 +17,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 
 import { ConfigModel } from '../../models/config.model';
-import { DocumentDefinition } from '../../models/document-definition.model';
 import { MappingModel, MappedField } from '../../models/mapping.model';
 import { FieldAction } from '../../models/field-action.model';
 
@@ -84,6 +83,10 @@ export class MappingFieldDetailComponent implements OnInit {
     return true;
   }
 
+  displayIndex(): boolean {
+    return this.mapping.getMappedFields(this.isSource).length > 1 && !this.mapping.transition.enableExpression;
+  }
+
   /**
    * The user has hand-edited the index value of a mapped field.  Perform the following:
    *   - Add place-holders for each index value between the updated value and its previous value.
@@ -98,22 +101,17 @@ export class MappingFieldDetailComponent implements OnInit {
       return;
     }
     const mappedFields = this.mapping.getMappedFields(mappedField.isSource());
-    const maxIndex = this.mapping.getMaxIndex(mappedFields);
-
-    if (insertionIndex > maxIndex) {
+    if (insertionIndex > mappedFields.length - 2) {
       // Add place-holders for each index value between the previous max index and the insertion index.
-      mappedField.addPlaceholders(maxIndex, insertionIndex, this.mapping);
+      this.cfg.mappingService.addPlaceholders(insertionIndex - mappedFields.length + 2, this.mapping, mappedField.field.isSource());
     }
-    this.mapping.resequenceFieldIndices(mappedFields, mappedField, insertionIndex, false);
-
-    // Sort the mapped fields array to get then back into numerical order.
-    this.mapping.sortFieldsByIndex(mappedFields);
+    this.cfg.mappingService.moveMappedFieldTo(this.mapping, mappedField, insertionIndex);
     this.cfg.mappingService.saveCurrentMapping();
   }
 
   removeMappedField(mappedField: MappedField): void {
-    this.mapping.removeMappedField(mappedField, this.isSource);
-    this.cfg.mappingService.updateMappedField(this.mapping, this.isSource, true);
+    this.mapping.removeMappedField(mappedField);
+    this.cfg.mappingService.updateMappedField(this.mapping);
   }
 
   private updateTemplateValues(): void {

--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-detail.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-detail.component.ts
@@ -58,7 +58,6 @@ export class MappingFieldDetailComponent implements OnInit {
     actionDefinition.populateFieldAction(action);
     this.mappedField.actions.push(action);
     this.cfg.mappingService.saveCurrentMapping();
-    this.mappedField.incTransformationCount();
     this.cfg.mappingService.notifyMappingUpdated();
   }
 

--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-list-field.component.html
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-list-field.component.html
@@ -15,7 +15,7 @@
       <div class="float-left">
         <label class="fieldPath" [tooltip]="tolTemplate" placement="right" [isDisabled]="!displayParentObject()">
           {{ getFieldPath() }}
-          <i class="fa fa-bolt" *ngIf="mappedField.getTransformationCount() > 0"></i>
+          <i class="fa fa-bolt" *ngIf="mappedField.actions.length > 0"></i>
         </label>
       </div>
     </td>

--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/transition-selection.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/transition-selection.component.ts
@@ -55,7 +55,7 @@ export class TransitionSelectionComponent implements OnInit {
 
         if (selectedValue) {
           that.mapping.transition.delimiter = parseInt(selectedValue, 10);
-          that.cfg.mappingService.updateMappedField(that.mapping, false, false);
+          that.cfg.mappingService.notifyMappingUpdated();
           return;
         }
         const inputValue: any = $(this).val();
@@ -63,7 +63,7 @@ export class TransitionSelectionComponent implements OnInit {
         if (inputValue) {
           that.mapping.transition.delimiter = TransitionDelimiter.USER_DEFINED;
           that.mapping.transition.userDelimiter = inputValue;
-          that.cfg.mappingService.updateMappedField(that.mapping, false, false);
+          that.cfg.mappingService.notifyMappingUpdated();
           return;
         }
       });

--- a/ui/src/app/lib/atlasmap-data-mapper/components/toolbar.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/toolbar.component.ts
@@ -20,6 +20,7 @@ import { ConfigModel } from '../models/config.model';
 import { ModalWindowComponent } from './modal-window.component';
 import { TemplateEditComponent } from './template-edit.component';
 import { ExpressionComponent } from './expression.component';
+import { TransitionMode } from '../models/transition.model';
 
 @Component({
   selector: 'toolbar',
@@ -165,9 +166,15 @@ export class ToolbarComponent implements OnInit {
       this.resetAll();
     } else if ('enableExpression') {
       if (this.cfg.mappings && this.cfg.mappings.activeMapping && this.cfg.mappings.activeMapping
-        && this.cfg.mappings.activeMapping.transition) {
-        this.cfg.mappings.activeMapping.transition.enableExpression
-          = !this.cfg.mappings.activeMapping.transition.enableExpression;
+          && this.cfg.mappings.activeMapping.transition) {
+        if (this.cfg.mappings.activeMapping.transition.mode === TransitionMode.ONE_TO_MANY) {
+          this.cfg.errorService.warn(
+            `Cannot enable conditional mapping when multiple target fields are selected.
+             Please select only one target field and try again.`, null);
+        } else {
+          this.cfg.mappings.activeMapping.transition.enableExpression
+            = !this.cfg.mappings.activeMapping.transition.enableExpression;
+        }
       } else {
         this.cfg.errorService.info('Please select a mapping first.', null);
       }

--- a/ui/src/app/lib/atlasmap-data-mapper/models/document-definition.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/document-definition.model.ts
@@ -369,17 +369,13 @@ export class DocumentDefinition {
     for (const mapping of mappingDefinition.getAllMappings(true)) {
       const mappingIsActive: boolean = (mapping === mappingDefinition.activeMapping);
 
-      let partOfTransformation = false;
-      if (mapping.hasTransformation()) {
-        partOfTransformation = true;
-        break;
-      }
-      for (const field of mapping.getAllFields()) {
-        let parentField: Field = field;
+      for (const field of mapping.getAllMappedFields()) {
+        let parentField = field;
+        const partOfTransformation = parentField.actions.length > 0;
         while (parentField != null) {
-          parentField.partOfMapping = true;
-          parentField.partOfTransformation = parentField.partOfTransformation || partOfTransformation;
-          parentField = parentField.parentField;
+          parentField.field.partOfMapping = true;
+          parentField.field.partOfTransformation = parentField.field.partOfTransformation || partOfTransformation;
+          parentField = mapping.getMappedFieldForField(parentField.field.parentField);
         }
       }
     }

--- a/ui/src/app/lib/atlasmap-data-mapper/models/document-definition.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/document-definition.model.ts
@@ -57,6 +57,22 @@ export class NamespaceModel {
   }
 }
 
+export class PaddingField extends Field {
+  constructor(private _isSource: boolean) {
+    super();
+    this.name = '<padding field>';
+    this.classIdentifier = '<padding field>';
+    this.type = '';
+    this.displayName = '<padding field>';
+    this.path = '';
+  }
+
+  isSource(): boolean {
+    return this._isSource;
+  }
+
+}
+
 export class DocumentDefinition {
   private static padField: Field = null;
 
@@ -92,21 +108,6 @@ export class DocumentDefinition {
   namespaces: NamespaceModel[] = [];
   characterEncoding: string = null;
   locale: string = null;
-
-  /**
-   * Return a generic padding field for use in combine/separate modes.
-   */
-  static getPadField(): Field {
-    if (DocumentDefinition.padField == null) {
-      DocumentDefinition.padField = new Field();
-      DocumentDefinition.padField.name = '<padding field>';
-      DocumentDefinition.padField.classIdentifier = '<padding field>';
-      DocumentDefinition.padField.type = '';
-      DocumentDefinition.padField.displayName = '<padding field>';
-      DocumentDefinition.padField.path = '';
-    }
-    return DocumentDefinition.padField;
-  }
 
   static getDocumentByIdentifier(documentId: string, docs: DocumentDefinition[]): DocumentDefinition {
     if (documentId == null || docs == null || !docs.length) {
@@ -369,13 +370,13 @@ export class DocumentDefinition {
     for (const mapping of mappingDefinition.getAllMappings(true)) {
       const mappingIsActive: boolean = (mapping === mappingDefinition.activeMapping);
 
-      for (const field of mapping.getAllMappedFields()) {
+      for (const field of mapping.getAllFields()) {
         let parentField = field;
-        const partOfTransformation = parentField.actions.length > 0;
+        const partOfTransformation = mapping.getMappedFieldForField(field).actions.length > 0;
         while (parentField != null) {
-          parentField.field.partOfMapping = true;
-          parentField.field.partOfTransformation = parentField.field.partOfTransformation || partOfTransformation;
-          parentField = mapping.getMappedFieldForField(parentField.field.parentField);
+          parentField.partOfMapping = true;
+          parentField.partOfTransformation = parentField.partOfTransformation || partOfTransformation;
+          parentField = parentField.parentField;
         }
       }
     }

--- a/ui/src/app/lib/atlasmap-data-mapper/models/expression.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/expression.model.ts
@@ -60,16 +60,18 @@ export class FieldNode extends ExpressionNode {
 
   static readonly PREFIX = 'expression-field-';
 
-  constructor(public field?: MappedField, private index?: number, private mapping?: MappingModel) {
+  constructor(private mapping: MappingModel, public field?: MappedField, private index?: number) {
     super(FieldNode.PREFIX);
     if (!field) {
       this.field = mapping.getMappedFieldForIndex((index + 1).toString(), true);
     }
+    if (!index) {
+      this.index = this.mapping.getIndexForMappedField(this.field) - 1;
+    }
   }
 
   toText(): string {
-    const index = this.field ? this.field.index - 1 : this.index;
-    return '${' + index + '}';
+    return '${' + this.index + '}';
   }
 
   toHTML(): string {
@@ -432,7 +434,7 @@ export class ExpressionModel {
     for (const mfield of mappedFields) {
       if (!fieldNodes.find(n => n.field === mfield)) {
         if (insertPosition) {
-          this.insertNodes([new FieldNode(mfield)], insertPosition, offset);
+          this.insertNodes([new FieldNode(this.mapping, mfield)], insertPosition, offset);
         } else {
           this.appendFieldNode(mfield);
         }
@@ -475,7 +477,7 @@ export class ExpressionModel {
         answer.push(new TextNode(text.substring(0, position)));
       }
       const index = parseInt(text.substring(position + 2, text.indexOf('}')), 10);
-      fn = new FieldNode(null, index, this.mapping);
+      fn = new FieldNode(this.mapping, null, index);
       if (fn.field === null) {
         this.cfg.errorService.error('Unable to map expression index to field node.', index);
       } else {
@@ -500,7 +502,7 @@ export class ExpressionModel {
         this._nodes.push(lastNode);
       }
     }
-    this._nodes.push(new FieldNode(mfield));
+    this._nodes.push(new FieldNode(this.mapping, mfield));
   }
 
 }

--- a/ui/src/app/lib/atlasmap-data-mapper/models/field-action.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/field-action.model.ts
@@ -217,9 +217,9 @@ export class FieldAction {
   static createSeparateCombineFieldAction(separateMode: boolean) {
     if (FieldAction.combineActionConfig == null) {
       FieldAction.combineActionConfig = new FieldActionDefinition();
-      FieldAction.combineActionConfig.name = 'Combine';
+      FieldAction.combineActionConfig.name = 'Concatenate';
       FieldAction.separateActionConfig = new FieldActionDefinition();
-      FieldAction.separateActionConfig.name = 'Separate';
+      FieldAction.separateActionConfig.name = 'Split';
     }
 
     const fieldAction: FieldAction = new FieldAction();

--- a/ui/src/app/lib/atlasmap-data-mapper/models/mapping-definition.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/mapping-definition.model.ts
@@ -272,7 +272,10 @@ export class MappingDefinition {
     for (const mapping of this.getAllMappings(true)) {
       const mappedField: MappedField = mapping.getMappedFieldForField(field);
       if (mappedField != null) {
-        mapping.removeMappedField(mappedField, field.isSource());
+        mapping.removeMappedField(mappedField);
+        if (mapping.isEmpty()) {
+          this.removeMapping(mapping);
+        }
       }
     }
   }
@@ -294,7 +297,7 @@ export class MappingDefinition {
   }
 
   updateMappedFieldsFromDocuments(mapping: MappingModel, cfg: ConfigModel, docMap: any, isSource: boolean): void {
-    const mappedFields: MappedField[] = mapping.getMappedFields(isSource);
+    let mappedFields: MappedField[] = mapping.getMappedFields(isSource);
 
     for (const mappedField of mappedFields) {
       let doc: DocumentDefinition = null;
@@ -389,10 +392,14 @@ export class MappingDefinition {
         }
       }
 
-      const isSeparate: boolean = mapping.transition.isOneToManyMode();
-      const isCombine: boolean = mapping.transition.isManyToOneMode();
-      mappedField.index = +mappedField.parsedData.parsedIndex;
-      mappedField.updateSeparateOrCombineFieldAction(isSeparate, isCombine, isSource, false, false);
+      const zeroBasedIndex = +mappedField.parsedData.parsedIndex - 1;
+      mappedFields = mapping.getMappedFields(isSource);
+      if (zeroBasedIndex <   mappedFields.length) {
+        mappedFields[zeroBasedIndex] = mappedField;
+      } else {
+        cfg.mappingService.addPlaceholders(zeroBasedIndex - mappedFields.length, mapping, isSource);
+        mappedFields.push(mappedField);
+      }
     }
   }
 

--- a/ui/src/app/lib/atlasmap-data-mapper/models/mapping-definition.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/mapping-definition.model.ts
@@ -386,7 +386,6 @@ export class MappingDefinition {
           }
           actionDefinition.populateFieldAction(action);
           mappedField.actions.push(action);
-          mappedField.incTransformationCount();
         }
       }
 

--- a/ui/src/app/lib/atlasmap-data-mapper/models/mapping.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/mapping.model.ts
@@ -74,20 +74,6 @@ export class MappedField {
     this.padField = true;
   }
 
-  incTransformationCount(): void {
-    this.transformationCount++;
-  }
-
-  reduceTransformationCount(): void {
-    if (this.transformationCount > 0) {
-      this.transformationCount--;
-    }
-  }
-
-  getTransformationCount(): number {
-    return this.transformationCount;
-  }
-
   /**
    * Given an index range, fill in the field-pair mappings gap with place-holder fields.
    *
@@ -393,7 +379,7 @@ export class MappingModel {
   hasTransformation(): boolean {
     const mappedFields: MappedField[] = this.getAllMappedFields();
     for (const mappedField of mappedFields) {
-      if (mappedField.getTransformationCount() > 0) {
+      if (mappedField.actions.length > 0) {
         return true;
       }
     }

--- a/ui/src/app/lib/atlasmap-data-mapper/models/mapping.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/mapping.model.ts
@@ -15,12 +15,12 @@
 */
 import { ConfigModel } from '../models/config.model';
 import { Field } from './field.model';
-import { TransitionModel, TransitionMode } from './transition.model';
-import { DocumentDefinition } from '../models/document-definition.model';
+import { TransitionModel } from './transition.model';
 import { ErrorInfo, ErrorLevel } from '../models/error.model';
 
 import { DataMapperUtil } from '../common/data-mapper-util';
 import { FieldAction } from './field-action.model';
+import { PaddingField } from './document-definition.model';
 
 export class MappedFieldParsingData {
   parsedName: string = null;
@@ -39,10 +39,7 @@ export class MappedFieldParsingData {
 export class MappedField {
   parsedData: MappedFieldParsingData = new MappedFieldParsingData();
   field: Field;
-  index = -1;
   actions: FieldAction[] = [];
-  private padField = false;
-  private transformationCount = 0;
 
   static sortMappedFieldsByPath(mappedFields: MappedField[]): MappedField[] {
     if (mappedFields == null || mappedFields.length === 0) {
@@ -67,89 +64,15 @@ export class MappedField {
   }
 
   isPadField(): boolean {
-    return this.padField;
-  }
-
-  setIsPadField(): void {
-    this.padField = true;
-  }
-
-  /**
-   * Given an index range, fill in the field-pair mappings gap with place-holder fields.
-   *
-   * @param lowIndex
-   * @param highIndex
-   * @param fieldPair
-   */
-  addPlaceholders(lowIndex: number, highIndex: number, mapping: MappingModel) {
-    let padField = null;
-    for (let i = lowIndex; i < highIndex; i++) {
-      padField = new MappedField;
-      padField.field = DocumentDefinition.getPadField();
-      padField.field.docDef = this.field.docDef;
-      padField.setIsPadField();
-      padField.updateSeparateOrCombineFieldAction(mapping.transition.mode === TransitionMode.ONE_TO_MANY,
-        mapping.transition.mode === TransitionMode.MANY_TO_ONE, i.toString(10), this.isSource(), true, false);
-      if (this.isSource()) {
-          mapping.sourceFields.push(padField);
-      } else {
-          mapping.targetFields.push(padField);
-      }
-    }
+    return this.field instanceof PaddingField;
   }
 
   isSource(): boolean {
     return this.field.isSource();
   }
 
-  /**
-   * Given a selection or de-selection of a component, update the appropriate field action.
-   *
-   * @param separateMode
-   * @param combineMode
-   * @param suggestedValue
-   * @param isSource
-   * @param compoundSelection
-   * @param fieldRemoved
-   */
-  updateSeparateOrCombineFieldAction(separateMode: boolean, combineMode: boolean,
-                               isSource: boolean, compoundSelection: boolean, fieldRemoved: boolean): void {
-
-    // Remove field actions where appropriate.
-    if ((!separateMode && !combineMode) || (separateMode && isSource && compoundSelection)) {
-      this.removeSeparateOrCombineAction();
-      return;
-    }
-
-    let firstFieldAction: FieldAction = (this.actions.length > 0) ? this.actions[0] : null;
-    if (firstFieldAction == null || !firstFieldAction.isSeparateOrCombineMode) {
-
-      // Create a new separate/combine field action if there isn't one.
-      firstFieldAction = FieldAction.createSeparateCombineFieldAction(separateMode);
-      this.actions = [firstFieldAction].concat(this.actions);
-      return;
-    }
-
-    // Given a compound selection (ctrl/cmd-M1) create a new field action based on the suggested value.
-    if (compoundSelection && !fieldRemoved) {
-      const currentFieldAction: FieldAction = FieldAction.createSeparateCombineFieldAction(separateMode);
-      this.actions = [currentFieldAction];
-    }
-  }
-
-  removeSeparateOrCombineAction(): void {
-    const firstFieldAction: FieldAction = (this.actions.length > 0) ? this.actions[0] : null;
-    if (firstFieldAction != null && firstFieldAction.isSeparateOrCombineMode) {
-      DataMapperUtil.removeItemFromArray(firstFieldAction, this.actions);
-    }
-  }
-
   removeAction(action: FieldAction): void {
     DataMapperUtil.removeItemFromArray(action, this.actions);
-  }
-
-  hasIndex() {
-    return this.index != null && this.index >= 0;
   }
 
 }
@@ -269,8 +192,8 @@ export class MappingModel {
     this.getMappedFields(isSource).push(mappedField);
   }
 
-  removeMappedField(mappedField: MappedField, isSource: boolean): void {
-    DataMapperUtil.removeItemFromArray(mappedField, this.getMappedFields(isSource));
+  removeMappedField(mappedField: MappedField): void {
+    DataMapperUtil.removeItemFromArray(mappedField, this.getMappedFields(mappedField.field.isSource()));
   }
 
   getMappedFieldForField(field: Field): MappedField {
@@ -286,12 +209,18 @@ export class MappingModel {
     if (!index) {
       return null;
     }
-    for (const mappedField of this.getMappedFields(isSource)) {
-      if (+index === mappedField.index) {
-        return mappedField;
-      }
+    const mappedFields = this.getMappedFields(isSource);
+    if (+index - 1 > mappedFields.length - 1) {
+      return null;
     }
-    return null;
+    return mappedFields[+index - 1];
+  }
+
+  getIndexForMappedField(mappedField: MappedField): number {
+    if (!mappedField) {
+      return null;
+    }
+    return this.getMappedFields(mappedField.field.isSource()).indexOf(mappedField) + 1;
   }
 
   /**
@@ -387,184 +316,6 @@ export class MappingModel {
   }
 
   /**
-   * Return the maximum assigned index value in the specified mapped fields.
-   *
-   * @param mappedFields
-   */
-  getMaxIndex(mappedFields: MappedField[]): number {
-    let maxIndex = 0;
-    for (const mField of mappedFields) {
-      if (mField.actions != null && mField.actions.length > 0) {
-        if (+mField.index > maxIndex) {
-          maxIndex = +mField.index;
-        }
-      }
-    }
-    return maxIndex;
-  }
-
-  /**
-   * Given an array of mapped fields, re-sequence the field indices accounting for any gaps
-   * due to user index editing or element removal.  An optional mapped field may be specified to be
-   * inserted at a designated index.
-   *
-   * @param mappedFields
-   * @param insertedMappedField - optional user-selected mapped field which was just dragged/dropped
-   * @param inIndex - drop index location
-   * @param fieldRemoved
-   */
-  resequenceFieldIndices(mappedFields: MappedField[], insertedMappedField: MappedField,
-                               inIndex: number, fieldRemoved: boolean): number {
-    let returnIndex = 0;
-
-    if (insertedMappedField != null) {
-      let startIndex = insertedMappedField.index;
-      mappedFields.splice(startIndex - 1, 1);
-      startIndex = inIndex;
-      mappedFields.splice(startIndex - 1, 0, insertedMappedField);
-
-      // Now re-sequence the index on the ordinal position within the mapped fields array.
-      let index = 1;
-      for (const mField of mappedFields) {
-        mField.index = index;
-        index++;
-      }
-      returnIndex = index - 1;
-    } else {
-      const maxIndex = this.getMaxIndex(mappedFields);
-      let lastIndex = 0;
-      while (lastIndex < maxIndex) {
-        lastIndex = this.resequenceRemovalsAndGaps(mappedFields, fieldRemoved);
-        if (fieldRemoved) {
-          break;
-        }
-      }
-      returnIndex = lastIndex;
-    }
-
-    // Clear any trailing padding fields.
-    this.clearTrailingPaddingFields(mappedFields);
-
-    return returnIndex;
-  }
-
-  /**
-   * Remove any trailing padding fields for the mapped field array.  This occurs when a user moves
-   * a mapped element above the last padding field.
-   *
-   * @param mappedFields
-   */
-  clearTrailingPaddingFields(mappedFields: MappedField[]): void {
-    let index = 0;
-    let mField = null;
-
-    for (index = mappedFields.length - 1; index >= 0; index--) {
-      mField = mappedFields[index];
-      if (mField.isPadField()) {
-        DataMapperUtil.removeItemFromArray(mField, mappedFields);
-        continue;
-      }
-      break;
-    }
-  }
-
-  /**
-   * Given an array of mapped fields, sort the fields themselves. based on their index.
-   *
-   * @param mappedFields
-   */
-  sortFieldsByIndex(mappedFields: MappedField[]): void {
-    let done = false;
-
-    while (!done) {
-      let tempField: MappedField = null;
-      let lastField: MappedField = null;
-      let index = 0;
-      done = true;
-
-      for (const mField of mappedFields) {
-        if (lastField != null) {
-          if (!mField.hasIndex()) {
-            break;
-          }
-
-          if (mField.index < lastField.index) {
-            tempField = mappedFields[index - 1];
-            mappedFields[index - 1] = mField;
-            mappedFields[index] = tempField;
-            done = false;
-          }
-        }
-        index++;
-        lastField = mField;
-      }
-    }
-  }
-
-  updateTransition(isSource: boolean, compoundSelection: boolean, fieldRemoved: boolean, position?: string, offset?: number): void {
-    for (const field of this.getAllFields()) {
-      if (field.enumeration) {
-        this.transition.mode = TransitionMode.ENUM;
-        break;
-      }
-    }
-
-    let mappedFields: MappedField[] = this.getMappedFields(false);
-    for (const mappedField of mappedFields) {
-      const actionsToRemove: FieldAction[] = [];
-      for (const action of mappedField.actions) {
-        const actionConfig = this.cfg.fieldActionService.getActionDefinitionForName(action.name);
-        if (actionConfig != null && !actionConfig.appliesToField(this, false)) {
-          actionsToRemove.push(action);
-        }
-      }
-      for (const action of actionsToRemove) {
-        mappedField.removeAction(action);
-      }
-    }
-
-    let separateMode: boolean = (this.transition.mode === TransitionMode.ONE_TO_MANY);
-    let combineMode: boolean = (this.transition.mode === TransitionMode.MANY_TO_ONE);
-    let maxIndex = 0;
-
-    if (combineMode || separateMode) {
-
-      maxIndex = this.processIndices(combineMode, fieldRemoved);
-
-      if (maxIndex <= 1 && fieldRemoved) {
-        this.transition.mode = TransitionMode.ONE_TO_ONE;
-        combineMode = false;
-        separateMode = false;
-        this.clearAllCombineSeparateActions();
-        this.getMappedFields(isSource).forEach(mf => mf.index = null);
-      } else {
-        mappedFields = this.getMappedFields(combineMode);
-        if (mappedFields != null && mappedFields.length > 1) {
-          let mappedField: MappedField = mappedFields[1];
-
-          // In case the user made a compound mapping, then reverted back to single mapping, then back to compound.
-          if (mappedField.actions.length === 0) {
-            mappedField.index = 1;
-            mappedField.updateSeparateOrCombineFieldAction(separateMode, combineMode, isSource,
-              compoundSelection, fieldRemoved);
-          }
-          mappedField = mappedFields[mappedFields.length - 1];
-          mappedField.index = maxIndex;
-          mappedField.updateSeparateOrCombineFieldAction(separateMode, combineMode, isSource,
-            compoundSelection, fieldRemoved);
-        }
-      }
-    } else {
-      this.clearAllCombineSeparateActions();
-    }
-
-    // Update conditional expression field references if enabled.
-    if (this.transition.enableExpression && this.transition.expression) {
-      this.transition.expression.updateFieldReference(this, position, offset);
-    }
-  }
-
-  /**
    * Walk all target field mappings and return one of corresponding source field name
    * if the specified field is already the target of a previous mapping, null otherwise.
    *
@@ -590,61 +341,6 @@ export class MappingModel {
         }
       }
     }
-  }
-
-  /**
-   * Normalize index fields for combine/ separate modes.
-   * @param combineMode
-   */
-  private processIndices(combineMode: boolean, fieldRemoved: boolean): number {
-
-    // Remove indices from target fields in combine-mode if they exist or remove indices from
-    // source fields in separate-mode if they exist.
-    for (const mField of this.getMappedFields(!combineMode)) {
-      mField.removeSeparateOrCombineAction();
-    }
-
-    // Gather mapped fields.
-    const mappedFields = this.getMappedFields(combineMode);
-    return this.resequenceFieldIndices(mappedFields, null, -1, fieldRemoved);
-  }
-
-  private clearAllCombineSeparateActions(): void {
-    for (const mappedField of this.getAllMappedFields()) {
-      mappedField.removeSeparateOrCombineAction();
-    }
-  }
-
-  /**
-   * Given an array of mapped fields, fill the gaps in the action indices by adding place-holders.
-   * If a field was removed just re-sequence the indices based on their existing position.
-   * @param mappedFields
-   * @param fieldRemoved
-   */
-  private resequenceRemovalsAndGaps(mappedFields: MappedField[], fieldRemoved: boolean): number {
-      let lastIndex = 0;
-      let tempIndex = 0;
-      for (const mField of mappedFields) {
-        if (mField.actions != null && mField.actions.length > 0) {
-          if (fieldRemoved) {
-            mField.index = ++lastIndex;
-            continue;
-          }
-          tempIndex = mField.index;
-          if (tempIndex > lastIndex + 1) {
-            mField.addPlaceholders(++lastIndex, tempIndex, this);
-            break;
-          } else if (tempIndex === lastIndex) {
-            const newIndex = ++tempIndex;
-            mField.index = newIndex;
-          }
-          lastIndex = mField.index;
-        } else {
-          lastIndex++;
-        }
-      }
-      this.sortFieldsByIndex(mappedFields);
-      return lastIndex;
   }
 
 }

--- a/ui/src/app/lib/atlasmap-data-mapper/models/transition.model.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/models/transition.model.ts
@@ -46,6 +46,8 @@ export class TransitionModel {
   lookupTableName: string = null;
   expression: ExpressionModel;
   enableExpression = false;
+  // TODO Support multiplicity transformations other than Concatenate and Split
+  // https://github.com/atlasmap/atlasmap/issues/912
   transitionFieldAction: FieldAction;
 
   constructor() {


### PR DESCRIPTION
fix: [UI] Remove multiplicity transformation from MappedField
    ATM Concatenate/Split transformation is hardcoded in serializer, so we only have to maintain delimiter. We'll have to keep the multiplicity transformation in TransitionModel when we address #912
Fixes: #1060
    
fix: [UI] Disable delimiter and index edit if expression is enabled
Fixes: #1103
    
fix: [UI] Remove padding field if expression is enabled
Fixes: #1108
    
fix: [UI] Disable field search input in Mapping Detail pane when inappropriate
Fixes: #1109
    
fix: [UI] Remove MappedField.index property and just use array index
Fixes: #1110
    
fix: [UI] Clean up transition&index handling
Fixes: #1111

fix: mapped/transformation icons disappear once transformation is added
Fixes: #1093