### PR TITLE
fix: Don't attempt to dereference null json object in deserializer if…

### DIFF
--- a/ui/src/app/lib/atlasmap-data-mapper/services/mapping-serializer.service.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/services/mapping-serializer.service.ts
@@ -504,7 +504,7 @@ export class MappingSerializer {
 
   private static deserializeDocs(json: any, mappingDefinition: MappingDefinition): DocumentDefinition[] {
     const docs: DocumentDefinition[] = [];
-    if (!json.AtlasMapping) {
+    if (!json || !json.AtlasMapping) {
       return;
     }
     for (const docRef of json.AtlasMapping.dataSource) {


### PR DESCRIPTION
… no mappings are present.

Fixes: #1161