### PR TITLE
user doc: Removes an incorrect . from a command line

### DIFF
--- a/docs/src/main/asciidoc/user-guide/topics/quickstart.adoc
+++ b/docs/src/main/asciidoc/user-guide/topics/quickstart.adoc
@@ -27,7 +27,7 @@ $ java -jar atlasmap-standalone-${VERSION}.jar
 For example: 
 +
 ----
-$ java -jar atlasmap-standalone-.1.42.3.jar
+$ java -jar atlasmap-standalone-1.42.3.jar
 ----
 +
 [NOTE]


### PR DESCRIPTION
I noticed a typo in a file that I updated. This just corrects that typo. 