### PR TITLE
fix: Correct bug in refactoring - make isSource a parameter.

### DIFF
--- a/ui/src/app/lib/atlasmap-data-mapper/components/expression.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/expression.component.ts
@@ -240,7 +240,7 @@ export class ExpressionComponent implements OnInit, OnDestroy, OnChanges {
     if (this.searchMode) {
       if (event.key.match(/[a-z0-9]/i)) {
         this.searchFilter += event.key;
-        this.mappedFieldCandidates = this.configModel.mappingService.executeFieldSearch(this.configModel, this.searchFilter);
+        this.mappedFieldCandidates = this.configModel.mappingService.executeFieldSearch(this.configModel, this.searchFilter, true);
       }
     } else {
       this.searchMode = (event.key === '@') ? true : false;
@@ -248,7 +248,7 @@ export class ExpressionComponent implements OnInit, OnDestroy, OnChanges {
         this.atContainer = window.getSelection().getRangeAt(0).startContainer;
         this.atIndex = window.getSelection().getRangeAt(0).startOffset;
         this.searchFilter = '';
-        this.mappedFieldCandidates = this.configModel.mappingService.executeFieldSearch(this.configModel, this.searchFilter);
+        this.mappedFieldCandidates = this.configModel.mappingService.executeFieldSearch(this.configModel, this.searchFilter, true);
       }
     }
 
@@ -515,7 +515,7 @@ export class ExpressionComponent implements OnInit, OnDestroy, OnChanges {
       this.searchMode = false;
     } else {
       this.searchFilter = this.searchFilter.substr(0, this.searchFilter.length - 1);
-      this.mappedFieldCandidates = this.configModel.mappingService.executeFieldSearch(this.configModel, this.searchFilter);
+      this.mappedFieldCandidates = this.configModel.mappingService.executeFieldSearch(this.configModel, this.searchFilter, true);
     }
   }
 }

--- a/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-container.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/mapping/mapping-field-container.component.ts
@@ -46,7 +46,7 @@ export class MappingFieldContainerComponent implements OnInit {
 
   constructor() {
     this.dataSource = Observable.create((observer: any) => {
-      observer.next(this.cfg.mappingService.executeFieldSearch(this.cfg, this.searchFilter));
+      observer.next(this.cfg.mappingService.executeFieldSearch(this.cfg, this.searchFilter, this.isSource));
     });
   }
 

--- a/ui/src/app/lib/atlasmap-data-mapper/services/mapping-management.service.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/services/mapping-management.service.ts
@@ -750,11 +750,11 @@ export class MappingManagementService {
    *
    * @param filter
    */
-  executeFieldSearch(configModel: ConfigModel, filter: string): any[] {
+  executeFieldSearch(configModel: ConfigModel, filter: string, isSource: boolean): any[] {
     const activeMapping = configModel.mappings.activeMapping;
     const formattedFields: any[] = [];
     let fields: Field[] = [];
-    for (const docDef of configModel.getDocs(true)) {
+    for (const docDef of configModel.getDocs(isSource)) {
       fields = fields.concat(docDef.getTerminalFields());
     }
     let documentName = '';


### PR DESCRIPTION
Fixes: #1271

Apologies for this one.  The only real difference between the two refactored executeSearch() methods was one needed isSource.