### PR TITLE
fix: Correct show/hide mapping details.

### DIFF
--- a/ui/src/app/lib/atlasmap-data-mapper/components/toolbar.component.ts
+++ b/ui/src/app/lib/atlasmap-data-mapper/components/toolbar.component.ts
@@ -138,10 +138,10 @@ export class ToolbarComponent implements OnInit {
   toolbarButtonClicked(action: string, event: any): void {
     event.preventDefault();
     if ('showDetails' === action) {
-      if (this.cfg.mappings.activeMapping == null) {
-        this.cfg.mappingService.addNewMapping(null, false);
+      if (this.cfg.showMappingDetailTray) {
+        this.cfg.showMappingDetailTray = false;
       } else {
-        this.cfg.mappingService.deselectMapping();
+        this.cfg.showMappingDetailTray = true;
       }
     } else if ('editTemplate' === action) {
       this.editTemplate();


### PR DESCRIPTION
Fixes: #1429

Show/hide should simply toggle the mapping details panel - not imply deselection or new mapping creation.