### PR TITLE
WIP for 1481

### DIFF
--- a/ui-react/packages/atlasmap-provider/src/useAtlasmap.tsx
+++ b/ui-react/packages/atlasmap-provider/src/useAtlasmap.tsx
@@ -8,6 +8,45 @@ import { FileManagementService } from './services/file-management.service';
 import { InitializationService } from './services/initialization.service';
 import { MappingManagementService } from './services/mapping-management.service';
 
+
+export function importAtlasFile(selectedFile: File) {
+  console.log('importAtlasFile: ' + selectedFile.name);
+
+  const userFileComps = selectedFile.name.split('.');
+  const userFileSuffix: string = userFileComps[userFileComps.length - 1].toUpperCase();
+
+  if (userFileSuffix === 'ADM') {
+        /*
+    const error: any = null;
+    new ErrorInfo({
+      message: 'This is a test of the AtlasMap error service.',
+      level: ErrorLevel.ERROR, scope: ErrorScope.APPLICATION, type: ErrorType.INTERNAL, 
+      object: error});
+
+      this.cfg.errorService.resetAll();
+
+      // Clear out current user documents from the runtime service before processing the imported ADM.
+      this.cfg.fileService.resetMappings().toPromise().then( async() => {
+        this.cfg.fileService.resetLibs().toPromise().then( async() => {
+          await this.processMappingsCatalog(selectedFile);
+        });
+      }).catch((error: any) => {
+        if (error.status === 0) {
+          this.cfg.errorService.addError(new ErrorInfo({
+            message: 'Fatal network error: Could not connect to AtlasMap design runtime service.',
+            level: ErrorLevel.ERROR, scope: ErrorScope.APPLICATION, type: ErrorType.INTERNAL, object: error}));
+        } else {
+          this.cfg.errorService.addError(new ErrorInfo({
+            message: 'Could not reset document definitions before import.',
+            level: ErrorLevel.ERROR, scope: ErrorScope.APPLICATION, type: ErrorType.INTERNAL, object: error}));
+        }
+      });
+      */
+  } else if (userFileSuffix === 'JAR') {
+    // this.cfg.documentService.processDocument(selectedFile, InspectionType.JAVA_CLASS, false);
+  }
+}
+
 export interface IUseAtlasmapArgs {
   baseJavaInspectionServiceUrl: string;
   baseXMLInspectionServiceUrl: string;
@@ -64,5 +103,5 @@ export function useAtlasmap({
     baseMappingServiceUrl,
   ]);
 
-  return { sourceDocs, targetDocs };
+  return { sourceDocs, targetDocs, importAtlasFile };
 }

--- a/ui-react/packages/atlasmap-standalone/src/App.tsx
+++ b/ui-react/packages/atlasmap-standalone/src/App.tsx
@@ -47,6 +47,7 @@ const App: React.FC = () => {
       targets={targetDocs.map(fromDocumentDefinitionToFieldGroup)}
       mappings={[]}
       addToMapping={() => void(0)}
+      importAtlasFile={() => void(0)}
     />
   );
 };

--- a/ui-react/packages/atlasmap-ui/src/mapper/Mapper.tsx
+++ b/ui-react/packages/atlasmap-ui/src/mapper/Mapper.tsx
@@ -21,13 +21,15 @@ export interface IMapperProps {
   targets: IFieldsGroup[];
   mappings: IMappings[];
   addToMapping: (elementId: ElementId, elementType: ElementType, mappingId: string) => void;
+  importAtlasFile: (selectedFile: File) => void;
 }
 
 export const Mapper: FunctionComponent<IMapperProps> = ({
   sources,
   mappings,
   targets,
-  addToMapping
+  addToMapping,
+  importAtlasFile
 }) => {
   const [freeView, setFreeView] = useState(false);
   const [materializedMappings, setMaterializedMappings] = useState(true);
@@ -117,7 +119,7 @@ export const Mapper: FunctionComponent<IMapperProps> = ({
     return () => clearTimeout(timeout);
   }, [measure, selectedMapping]);
 
-  const contextToolbar = useMemo(() => <MapperContextToolbar />, []);
+  const contextToolbar = useMemo(() => <MapperContextToolbar importAtlasFile={importAtlasFile}/>, []);
   const toggleFreeView = useCallback(() => setFreeView(!freeView), [
     freeView,
     setFreeView,

--- a/ui-react/packages/atlasmap-ui/src/mapper/MapperContextToolbar.tsx
+++ b/ui-react/packages/atlasmap-ui/src/mapper/MapperContextToolbar.tsx
@@ -15,13 +15,16 @@ import {
 } from '@patternfly/react-core';
 
 import { FilePicker } from 'react-file-picker';
-import { processImportedFile } from './MapperUtilsToolbar';
+// import { processImportedFile } from './MapperUtilsToolbar';
 
-export interface IMapperContextToolbarProps {}
+
+export interface IMapperContextToolbarProps {
+  importAtlasFile: (selectedFile: File) => void;
+}
 
 export const MapperContextToolbar: FunctionComponent<
   IMapperContextToolbarProps
-> = () => {
+> = (importAtlasFile) => {
   return (
     <Toolbar
       className="view-toolbar pf-u-px-md pf-u-py-md"
@@ -41,7 +44,8 @@ export const MapperContextToolbar: FunctionComponent<
           >
           <FilePicker
             extensions={['adm', 'jar']}
-            onChange={(selectedFile: File) => processImportedFile( {selectedFile} )}
+            // onChange={(selectedFile: File) => processImportedFile( {selectedFile} )}
+            onChange={(selectedFile: File) => importAtlasFile(selectedFile)}
             onError={(errMsg: any) => console.error(errMsg)}
           >
             <Button variant={'plain'} aria-label="Import mappings">

--- a/ui-react/packages/atlasmap-ui/src/mapper/MapperUtilsToolbar.ts
+++ b/ui-react/packages/atlasmap-ui/src/mapper/MapperUtilsToolbar.ts
@@ -1,55 +1,12 @@
-// import { InspectionType } from '../../../../../ui/src/app/lib/atlasmap-data-mapper/common/config.types';
-// import { ConfigModel } from '../../../../../ui/src/app/lib/atlasmap-data-mapper/models/config.model';
-// import { ModalWindowComponent } from '../../../../../ui/src/app/lib/atlasmap-data-mapper/components/modal/modal-window.component';
-// import { TemplateEditComponent } from '../../../../../ui/src/app/lib/atlasmap-data-mapper/components/app/template-edit.component';
-// import { ExpressionComponent } from '../../../../../ui/src/app/lib/atlasmap-data-mapper/components/toolbar/expression.component';
-// import { TransitionMode } from '../../../../../ui/src/app/lib/atlasmap-data-mapper/models/transition.model';
-// import { ErrorScope, ErrorType, ErrorInfo, ErrorLevel } from '../../../../../ui/src/app/lib/atlasmap-data-mapper/models/error.model';
-// import { ErrorHandlerService } from '../../../../../ui/dist/lib/src/app/lib/atlasmap-data-mapper';
+export interface IMapperUtilsToolbarProps {
+  importAtlasFile: (selectedFile: File) => void;
+}
 
 export interface IProcessImportedFileArgs {
   selectedFile: File;
 }
 
-/**
- * User file import callback (ADM or Java archive).
- *
- * @param selectedFile - user selected File object
- */
 export function processImportedFile({ selectedFile }: IProcessImportedFileArgs) {
   console.log('processImportedFile: ' + selectedFile.name);
-
-  const userFileComps = selectedFile.name.split('.');
-  const userFileSuffix: string = userFileComps[userFileComps.length - 1].toUpperCase();
-
-  if (userFileSuffix === 'ADM') {
-        /*
-    const error: any = null;
-    new ErrorInfo({
-      message: 'This is a test of the AtlasMap error service.',
-      level: ErrorLevel.ERROR, scope: ErrorScope.APPLICATION, type: ErrorType.INTERNAL, 
-      object: error});
-
-      this.cfg.errorService.resetAll();
-
-      // Clear out current user documents from the runtime service before processing the imported ADM.
-      this.cfg.fileService.resetMappings().toPromise().then( async() => {
-        this.cfg.fileService.resetLibs().toPromise().then( async() => {
-          await this.processMappingsCatalog(selectedFile);
-        });
-      }).catch((error: any) => {
-        if (error.status === 0) {
-          this.cfg.errorService.addError(new ErrorInfo({
-            message: 'Fatal network error: Could not connect to AtlasMap design runtime service.',
-            level: ErrorLevel.ERROR, scope: ErrorScope.APPLICATION, type: ErrorType.INTERNAL, object: error}));
-        } else {
-          this.cfg.errorService.addError(new ErrorInfo({
-            message: 'Could not reset document definitions before import.',
-            level: ErrorLevel.ERROR, scope: ErrorScope.APPLICATION, type: ErrorType.INTERNAL, object: error}));
-        }
-      });
-      */
-  } else if (userFileSuffix === 'JAR') {
-    // this.cfg.documentService.processDocument(selectedFile, InspectionType.JAVA_CLASS, false);
-  }
+  importAtlasFile(selectedFile);
 }


### PR DESCRIPTION
DO NOT PUSH - WIP
Hey @riccardo-forina - pls take a look.
This gets as far as MapperContextToolbar - FilePicker.  I'm calling 

`onChange={(selectedFile: File) => importAtlasFile(selectedFile)}`

which generates the error:
`Cannot invoke an expression whose type lacks a call signature. Type 'PropsWithChildren<IMapperContextToolbarProps>' has no compatible
call signatures.`

MapperContextToolbar defines:

`export interface IMapperContextToolbarProps {
  importAtlasFile: (selectedFile: File) => void;
}`