### PR TITLE
Disable x-frame-option in standalone application #1501

### DIFF
--- a/standalone/src/main/java/io/atlasmap/standalone/SecurityConfiguration.java
+++ b/standalone/src/main/java/io/atlasmap/standalone/SecurityConfiguration.java
@@ -26,6 +26,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity httpSecurity) throws Exception {
-        httpSecurity.csrf().csrfTokenRepository(new AtlasMapXsrfRepository());
+        httpSecurity
+          .headers().frameOptions().disable()
+          .and().csrf().csrfTokenRepository(new AtlasMapXsrfRepository());
     }
 }


### PR DESCRIPTION
it allows to embed it in Eclipse Theia (requirement to embed in Eclipse
Che)


Is it safe to do it this way? Are there other ways to avoid x-frame-options issues when embedding in an i-frame?

I can also imagine to disable it only when starting the standalone app with specific parameters. Would it make sense?