### PR TITLE
fix: Remove component method definition out of useAtlasmap.tsx and in…

### DIFF
--- a/ui-react/packages/atlasmap-provider/src/components/toolbar/MapperUtilsToolbar.ts
+++ b/ui-react/packages/atlasmap-provider/src/components/toolbar/MapperUtilsToolbar.ts
@@ -1,0 +1,85 @@
+import { InspectionType } from '../../common/config.types';
+import { ConfigModel } from '../../models/config.model';
+import { DocumentDefinition } from '../../models/document-definition.model';
+import {
+  ErrorScope,
+  ErrorType,
+  ErrorInfo,
+  ErrorLevel,
+} from '../../models/error.model';
+import { MappingDefinition } from '../../models/mapping-definition.model';
+import { DocumentManagementService } from '../../services/document-management.service';
+import { ErrorHandlerService } from '../../services/error-handler.service';
+import { FileManagementService } from '../../services/file-management.service';
+
+/**
+ * A user has selected a compressed mappings catalog file to be imported into the canvas.
+ *
+ * @param selectedFile
+ */
+async function processMappingsCatalog(selectedFile: any, cfg: ConfigModel) {
+  cfg.initializationService.updateLoadingStatus('Importing AtlasMap Catalog');
+  await cfg.fileService.importADMCatalog(selectedFile);
+}
+
+/**
+ * The user has imported a file (mapping catalog or Java archive).
+ *
+ * @param event
+ */
+export function importAtlasFile(selectedFile: File) {
+  const cfg = ConfigModel.getConfig();
+  const userFileComps = selectedFile.name.split('.');
+  const userFileSuffix: string = userFileComps[
+    userFileComps.length - 1
+  ].toUpperCase();
+
+  if (userFileSuffix === 'ADM') {
+    cfg.errorService.resetAll();
+
+    // Clear out current user documents from the backend service before processing the
+    // imported ADM.
+    cfg.fileService
+      .resetMappings()
+      .toPromise()
+      .then(async () => {
+        cfg.fileService
+          .resetLibs()
+          .toPromise()
+          .then(async () => {
+            await processMappingsCatalog(selectedFile, cfg);
+          });
+      })
+      .catch((error: any) => {
+        if (error.status === 0) {
+          cfg.errorService.addError(
+            new ErrorInfo({
+              message:
+                'Fatal network error: Could not connect to AtlasMap design runtime service.',
+              level: ErrorLevel.ERROR,
+              scope: ErrorScope.APPLICATION,
+              type: ErrorType.INTERNAL,
+              object: error,
+            })
+          );
+        } else {
+          cfg.errorService.addError(
+            new ErrorInfo({
+              message: 'Could not reset document definitions before import.',
+              level: ErrorLevel.ERROR,
+              scope: ErrorScope.APPLICATION,
+              type: ErrorType.INTERNAL,
+              object: error,
+            })
+          );
+        }
+      });
+  } else if (userFileSuffix === 'JAR') {
+    cfg.documentService.processDocument(
+      selectedFile,
+      InspectionType.JAVA_CLASS,
+      false
+    );
+  }
+}
+

--- a/ui-react/packages/atlasmap-provider/src/useAtlasmap.tsx
+++ b/ui-react/packages/atlasmap-provider/src/useAtlasmap.tsx
@@ -2,15 +2,7 @@ import ky from 'ky';
 import { useCallback, useEffect, useMemo, useReducer } from 'react';
 import { timer } from 'rxjs';
 import { debounce } from 'rxjs/operators';
-import { InspectionType } from './common/config.types';
-import { ConfigModel } from './models/config.model';
 import { DocumentDefinition } from './models/document-definition.model';
-import {
-  ErrorScope,
-  ErrorType,
-  ErrorInfo,
-  ErrorLevel,
-} from './models/error.model';
 import { MappingDefinition } from './models/mapping-definition.model';
 import { DocumentManagementService } from './services/document-management.service';
 import { ErrorHandlerService } from './services/error-handler.service';
@@ -22,79 +14,9 @@ import {
   fromDocumentDefinitionToFieldGroup,
   fromMappingDefinitionToIMappings,
 } from './utils/to-ui-models-util';
+import { importAtlasFile } from './components/toolbar/MapperUtilsToolbar';
 
 const api = ky.create({ headers: { 'ATLASMAP-XSRF-TOKEN': 'awesome' } });
-
-/**
- * A user has selected a compressed mappings catalog file to be imported into the canvas.
- *
- * @param selectedFile
- */
-async function processMappingsCatalog(selectedFile: any, cfg: ConfigModel) {
-  cfg.initializationService.updateLoadingStatus('Importing AtlasMap Catalog');
-  await cfg.fileService.importADMCatalog(selectedFile);
-}
-
-/**
- * The user has imported a file (mapping catalog or Java archive).
- *
- * @param event
- */
-export function importAtlasFile(selectedFile: File) {
-  const cfg = ConfigModel.getConfig();
-  const userFileComps = selectedFile.name.split('.');
-  const userFileSuffix: string = userFileComps[
-    userFileComps.length - 1
-  ].toUpperCase();
-
-  if (userFileSuffix === 'ADM') {
-    cfg.errorService.resetAll();
-
-    // Clear out current user documents from the backend service before processing the
-    // imported ADM.
-    cfg.fileService
-      .resetMappings()
-      .toPromise()
-      .then(async () => {
-        cfg.fileService
-          .resetLibs()
-          .toPromise()
-          .then(async () => {
-            await processMappingsCatalog(selectedFile, cfg);
-          });
-      })
-      .catch((error: any) => {
-        if (error.status === 0) {
-          cfg.errorService.addError(
-            new ErrorInfo({
-              message:
-                'Fatal network error: Could not connect to AtlasMap design runtime service.',
-              level: ErrorLevel.ERROR,
-              scope: ErrorScope.APPLICATION,
-              type: ErrorType.INTERNAL,
-              object: error,
-            })
-          );
-        } else {
-          cfg.errorService.addError(
-            new ErrorInfo({
-              message: 'Could not reset document definitions before import.',
-              level: ErrorLevel.ERROR,
-              scope: ErrorScope.APPLICATION,
-              type: ErrorType.INTERNAL,
-              object: error,
-            })
-          );
-        }
-      });
-  } else if (userFileSuffix === 'JAR') {
-    cfg.documentService.processDocument(
-      selectedFile,
-      InspectionType.JAVA_CLASS,
-      false
-    );
-  }
-}
 
 export interface IUseAtlasmapArgs {
   baseJavaInspectionServiceUrl: string;


### PR DESCRIPTION
…to its own component support utility.

Fixes: #1520

By mirroring the existing UI components directory it will be easier to make sure we don't miss
anything.  It additionally reduces the complexity of useAtlasmap.tsx.