### PR TITLE
feat(react-ui): move the options from the view toolbar to the view controlbar

### DIFF
--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/CanvasViewControlBar.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/CanvasViewControlBar.tsx
@@ -8,12 +8,22 @@ import {
   SearchMinusIcon,
   ExpandArrowsAltIcon,
   ExpandIcon,
+  PficonDragdropIcon,
+  LinkIcon,
+  InfoIcon,
+  ConnectedIcon,
+  DisconnectedIcon, EyeIcon
 } from '@patternfly/react-icons';
 import { useCanvasViewContext } from '../CanvasViewProvider';
 
 export const CanvasViewControlBar: FunctionComponent = () => {
-
-  const { updateZoom, resetZoom, resetPan } = useCanvasViewContext();
+  const { updateZoom,
+    resetZoom,
+    resetPan,
+    freeView,
+    toggleFreeView,
+    toggleMaterializedMappings,
+  } = useCanvasViewContext();
 
   const handleZoomIn = useCallback(() => {
     updateZoom(0.2);
@@ -29,7 +39,7 @@ export const CanvasViewControlBar: FunctionComponent = () => {
   const controlButtons = useMemo(
     () =>
       createTopologyControlButtons({
-        zoomIn: true,
+        zoomIn: freeView,
         zoomInIcon: <SearchPlusIcon />,
         zoomInTip: 'Zoom In',
         zoomInAriaLabel: ' ',
@@ -37,7 +47,7 @@ export const CanvasViewControlBar: FunctionComponent = () => {
         zoomInDisabled: false,
         zoomInHidden: false,
 
-        zoomOut: true,
+        zoomOut: freeView,
         zoomOutIcon: <SearchMinusIcon />,
         zoomOutTip: 'Zoom Out',
         zoomOutAriaLabel: ' ',
@@ -53,7 +63,7 @@ export const CanvasViewControlBar: FunctionComponent = () => {
         fitToScreenDisabled: false,
         fitToScreenHidden: false,
 
-        resetView: true,
+        resetView: freeView,
         resetViewIcon: <ExpandIcon />,
         resetViewTip: 'Reset View',
         resetViewAriaLabel: ' ',
@@ -69,10 +79,51 @@ export const CanvasViewControlBar: FunctionComponent = () => {
         legendDisabled: false,
         legendHidden: false,
 
-        customButtons: [],
+        customButtons: [
+          {
+            id: 'Free view mode',
+            icon: <PficonDragdropIcon />,
+            tooltip: 'Free view mode',
+            ariaLabel: ' ',
+            callback: toggleFreeView
+          },
+          {
+            id: 'Toggle mappings column',
+            icon: <LinkIcon />,
+            tooltip: 'Toggle mappings column',
+            ariaLabel: ' ',
+            callback: toggleMaterializedMappings
+          },
+          {
+            id: 'Show types',
+            icon: <InfoIcon />,
+            tooltip: 'Show types',
+            ariaLabel: ' ',
+          },
+          {
+            id: 'Show mapped fields',
+            icon: <ConnectedIcon />,
+            tooltip: 'Show mapped fields',
+            ariaLabel: ' ',
+          },
+          {
+            id: 'Show unmapped fields',
+            icon: <DisconnectedIcon />,
+            tooltip: 'Show unmapped fields',
+            ariaLabel: ' ',
+          },
+          {
+            id: 'Show mapping preview',
+            icon: <EyeIcon />,
+            tooltip: 'Show mapping preview',
+            ariaLabel: ' ',
+          },
+        ],
       }),
-    [handleZoomIn, handleZoomOut, handleViewReset]
+    [handleZoomIn, handleZoomOut, handleViewReset, toggleFreeView, toggleMaterializedMappings]
   );
 
-  return <TopologyControlBar controlButtons={controlButtons} />;
+  return (
+    <TopologyControlBar controlButtons={controlButtons} />
+  );
 };

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/CanvasViewToolbar.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/CanvasViewToolbar.tsx
@@ -1,73 +1,13 @@
-import React, { FunctionComponent, useCallback, useState } from 'react';
+import React, { FunctionComponent } from 'react';
 import {
   Button,
-  OptionsMenu,
-  OptionsMenuItem,
-  OptionsMenuItemGroup,
-  OptionsMenuPosition,
-  OptionsMenuToggle,
   TextInput,
   Toolbar,
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { CaretDownIcon, CaretUpIcon } from '@patternfly/react-icons';
-import { useCanvasViewContext } from '../CanvasViewProvider';
 
 export const CanvasViewToolbar: FunctionComponent = () => {
-  const {
-    freeView,
-    toggleFreeView,
-    materializedMappings,
-    toggleMaterializedMappings,
-  } = useCanvasViewContext();
-
-  const menuItems = [
-    <OptionsMenuItemGroup key="first group" aria-label="Sort Column">
-      <OptionsMenuItem
-        onSelect={toggleFreeView}
-        isSelected={freeView}
-        id="free-view"
-        key="free-view"
-      >
-        Free view mode
-      </OptionsMenuItem>
-      <OptionsMenuItem
-        onSelect={toggleMaterializedMappings}
-        isSelected={materializedMappings}
-        id="materialized-mappings"
-        key="materialized-mappings"
-      >
-        Toggle mappings column
-      </OptionsMenuItem>
-      <OptionsMenuItem>Show types</OptionsMenuItem>
-      <OptionsMenuItem>Show types</OptionsMenuItem>
-      <OptionsMenuItem>Show mapped fields</OptionsMenuItem>
-      <OptionsMenuItem>Show unmapped fields</OptionsMenuItem>
-      <OptionsMenuItem>Show mapping preview</OptionsMenuItem>
-    </OptionsMenuItemGroup>,
-  ];
-  const [isOptionsMenuExpanded, setIsOptionsMenuExpanded] = useState(false);
-  const toggleIsOptionsMenuExpanded = useCallback(
-    () => setIsOptionsMenuExpanded(!isOptionsMenuExpanded),
-    [isOptionsMenuExpanded, setIsOptionsMenuExpanded]
-  );
-  const toggle = (
-    <OptionsMenuToggle
-      onToggle={toggleIsOptionsMenuExpanded}
-      toggleTemplate={
-        <>
-          Options&nbsp;
-          {isOptionsMenuExpanded ? (
-            <CaretUpIcon aria-hidden={true} />
-          ) : (
-            <CaretDownIcon aria-hidden={true} />
-          )}
-        </>
-      }
-    />
-  );
-
   return (
     <Toolbar
       className="view-toolbar pf-u-px-md pf-u-py-md"
@@ -88,17 +28,6 @@ export const CanvasViewToolbar: FunctionComponent = () => {
 
         <ToolbarItem style={{ flex: 1 }}>
           <TextInput aria-label={'Conditional mapping expression'} />
-        </ToolbarItem>
-        <ToolbarItem>
-          <OptionsMenu
-            id="mapper-options"
-            position={OptionsMenuPosition.right}
-            menuItems={menuItems}
-            isOpen={isOptionsMenuExpanded}
-            toggle={toggle}
-            isGrouped={true}
-            isPlain={true}
-          />
         </ToolbarItem>
       </ToolbarGroup>
     </Toolbar>

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/FieldsBox.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/FieldsBox.tsx
@@ -11,6 +11,7 @@ export interface IMappingsBoxProps extends HTMLAttributes<HTMLDivElement> {
   initialHeight: number;
   position: Coords;
   header: ReactElement | string;
+  hidden: boolean;
   rightAlign?: boolean;
 }
 export const FieldsBox: FunctionComponent<IMappingsBoxProps> = ({
@@ -20,12 +21,12 @@ export const FieldsBox: FunctionComponent<IMappingsBoxProps> = ({
   position,
   header,
   rightAlign = false,
+  hidden,
   children,
   ...props
 }) => {
-  const { freeView, materializedMappings } = useCanvasViewContext();
+  const { freeView } = useCanvasViewContext();
   const scrollable = !freeView;
-  const hidden = !materializedMappings;
 
   const [ref, dimensions, measure ] = useDimensions();
   const { yDomain, addRedrawListener, removeRedrawListener } = useCanvas();

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Mapping.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Mapping.tsx
@@ -1,6 +1,7 @@
 import { css, StyleSheet } from '@patternfly/react-styles';
 import React, { FunctionComponent, ReactElement, useRef } from 'react';
 import { useCanvasViewLayoutContext } from '../CanvasViewLayoutProvider';
+import { useCanvasViewContext } from '../CanvasViewProvider';
 import { FieldsBox } from './FieldsBox';
 
 const styles = StyleSheet.create({
@@ -17,6 +18,7 @@ export interface IMappingProps {
 }
 
 export const Mapping: FunctionComponent<IMappingProps> = ({ children }) => {
+  const { materializedMappings } = useCanvasViewContext();
   const { mappingWidth, boxHeight, initialMappingCoords } = useCanvasViewLayoutContext();
   const ref = useRef<HTMLDivElement | null>(null);
   return (
@@ -26,7 +28,7 @@ export const Mapping: FunctionComponent<IMappingProps> = ({ children }) => {
       initialHeight={boxHeight}
       position={initialMappingCoords}
       header={'Mapping'}
-      hidden={false}
+      hidden={!materializedMappings}
     >
       <div
         className={css(styles.content)}

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Source.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Source.tsx
@@ -19,6 +19,7 @@ export const Source: FunctionComponent<ISourceProps> = ({ children, header }) =>
       initialHeight={boxHeight}
       position={initialSourceCoords}
       header={header}
+      hidden={false}
     >
       {children}
     </FieldsBox>

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Target.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Target.tsx
@@ -16,6 +16,7 @@ export const Target: FunctionComponent<ITargetProps> = ({ children, header }) =>
       position={initialTargetCoords}
       header={header}
       rightAlign={true}
+      hidden={false}
     >
       {children}
     </FieldsBox>


### PR DESCRIPTION
Options right now look like this (icons picked semi-randomly):

![image](https://user-images.githubusercontent.com/966316/69967549-ea265300-1518-11ea-8773-2388f83a4b7c.png)

Hopefully [this](https://github.com/patternfly/patternfly-next/issues/2478) will make it easier to read.