### PR TITLE
feat(react-ui): show the type for a field

### DIFF
--- a/ui-react/packages/atlasmap-provider/src/AtlasmapProvider.tsx
+++ b/ui-react/packages/atlasmap-provider/src/AtlasmapProvider.tsx
@@ -1,4 +1,4 @@
-import { IFieldsGroup, IMappings } from '@atlasmap/ui/src';
+import { IDocument, IFieldsGroup, IMappings } from '@atlasmap/ui';
 import ky from 'ky';
 import React, { createContext, FunctionComponent, useCallback, useContext, useEffect, useMemo, useReducer } from 'react';
 import { timer } from 'rxjs';
@@ -168,8 +168,8 @@ export function useAtlasmap({
 }: IUseAtlasmapArgs = {}): {
   pending: boolean;
   error: boolean;
-  sources: IFieldsGroup[];
-  targets: IFieldsGroup[];
+  sources: IDocument[];
+  targets: IDocument[];
   mappings: IMappings[];
   exportAtlasFile: () => void;
   importAtlasFile: (file: File, isSource: boolean) => void;
@@ -214,8 +214,8 @@ export function useAtlasmap({
     () => ({
       pending: pending,
       error: error,
-      sources: sourceDocs.map(fromDocumentDefinitionToFieldGroup).filter(d => d) as IFieldsGroup[],
-      targets: targetDocs.map(fromDocumentDefinitionToFieldGroup).filter(d => d) as IFieldsGroup[],
+      sources: sourceDocs.map(fromDocumentDefinitionToFieldGroup).filter(d => d) as IDocument[],
+      targets: targetDocs.map(fromDocumentDefinitionToFieldGroup).filter(d => d) as IDocument[],
       mappings: fromMappingDefinitionToIMappings(mappingDefinition),
       exportAtlasFile: exportAtlasFile,
       importAtlasFile: handleImportAtlasFile,

--- a/ui-react/packages/atlasmap-provider/src/utils/to-ui-models-util.ts
+++ b/ui-react/packages/atlasmap-provider/src/utils/to-ui-models-util.ts
@@ -1,32 +1,36 @@
 import { IFieldsGroup, IFieldsNode, IMappingField, IMappings } from '@atlasmap/ui';
+import { IDocument, IDocumentField } from '@atlasmap/ui/src';
 import { DocumentDefinition, Field, MappedField, MappingDefinition } from '..';
 
-function fromFieldToIFieldsGroup(field: Field): IFieldsGroup {
+function fromFieldToIFieldsGroup(field: Field): IDocumentField & IFieldsGroup {
   return {
     id: `${field.docDef.uri}:${field.docDef.isSource ? 'source' : 'target'}:${field.uuid}`,
-    title: field.name,
+    name: field.name,
+    type: field.type,
     fields: field.children.map(fromFieldToIFields)
   }
 }
 
-function fromFieldToIFieldsNode(field: Field): IFieldsNode {
+function fromFieldToIFieldsNode(field: Field): IDocumentField & IFieldsNode {
   return {
     id: `${field.docDef.uri}:${field.docDef.isSource ? 'source' : 'target'}:${field.uuid}`,
-    name: field.getFieldLabel(false, false)
+    name: field.getFieldLabel(false, false),
+    type: field.type
   }
 }
 
-function fromFieldToIFields(field: Field): IFieldsGroup | IFieldsNode {
+function fromFieldToIFields(field: Field) {
   return field.children.length > 0
     ? fromFieldToIFieldsGroup(field)
     : fromFieldToIFieldsNode(field);
 }
 
-export function fromDocumentDefinitionToFieldGroup(def: DocumentDefinition): IFieldsGroup | null {
+export function fromDocumentDefinitionToFieldGroup(def: DocumentDefinition): IDocument | null {
   return def.visibleInCurrentDocumentSearch ? {
     id: def.id,
     fields: def.fields.map(fromFieldToIFields),
-    title: def.name
+    name: def.name,
+    type: def.type
   } : null;
 }
 

--- a/ui-react/packages/atlasmap-ui/src/atlasmap/components/DocumentField.tsx
+++ b/ui-react/packages/atlasmap-ui/src/atlasmap/components/DocumentField.tsx
@@ -1,0 +1,13 @@
+import React, { FunctionComponent } from 'react';
+
+export interface IDocumentFieldProps {
+  name: string;
+  type: string;
+  showType: boolean;
+}
+
+export const DocumentField: FunctionComponent<IDocumentFieldProps> = ({ name, type, showType }) => {
+  return (
+    <>{name} {showType && `(${type})`}</>
+  );
+};

--- a/ui-react/packages/atlasmap-ui/src/atlasmap/components/DocumentFooter.tsx
+++ b/ui-react/packages/atlasmap-ui/src/atlasmap/components/DocumentFooter.tsx
@@ -1,0 +1,13 @@
+import React, { FunctionComponent } from 'react';
+
+export interface IDocumentFooterProps {
+  title: string;
+  type: string;
+  showType: boolean;
+}
+
+export const DocumentFooter: FunctionComponent<IDocumentFooterProps> = ({ title, type, showType }) => {
+  return (
+    <>{title} {showType && `(${type})`}</>
+  );
+};

--- a/ui-react/packages/atlasmap-ui/src/atlasmap/components/index.ts
+++ b/ui-react/packages/atlasmap-ui/src/atlasmap/components/index.ts
@@ -1,0 +1,1 @@
+export * from './DocumentFooter';

--- a/ui-react/packages/atlasmap-ui/src/canvas/CanvasContext.tsx
+++ b/ui-react/packages/atlasmap-ui/src/canvas/CanvasContext.tsx
@@ -6,7 +6,7 @@ import React, {
 } from 'react';
 import { createContext, FunctionComponent, useContext } from 'react';
 import { scaleLinear } from 'd3-scale';
-import { Rect, Rects } from '../models';
+import { Rect, Rects } from '../views/CanvasView/models';
 
 type RedrawCallback = () => unknown;
 type RedrawCallbacks = Array<RedrawCallback>;

--- a/ui-react/packages/atlasmap-ui/src/canvas/CanvasLink.tsx
+++ b/ui-react/packages/atlasmap-ui/src/canvas/CanvasLink.tsx
@@ -1,6 +1,6 @@
 import { linkHorizontal } from 'd3-shape';
 import React, { FunctionComponent, useMemo } from 'react';
-import { Coords } from '../models';
+import { Coords } from '../views/CanvasView/models';
 
 export interface ICanvasLinkProps {
   start: Coords;

--- a/ui-react/packages/atlasmap-ui/src/canvas/CanvasLinks.tsx
+++ b/ui-react/packages/atlasmap-ui/src/canvas/CanvasLinks.tsx
@@ -7,7 +7,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Coords } from '../models';
+import { Coords } from '../views/CanvasView/models';
 import { useCanvas } from './CanvasContext';
 
 export type SourceTargetNodes = {

--- a/ui-react/packages/atlasmap-ui/src/canvas/CanvasObject.tsx
+++ b/ui-react/packages/atlasmap-ui/src/canvas/CanvasObject.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, HTMLAttributes, useEffect, useState } from 'react';
-import { Coords } from '../models';
+import { Coords } from '../views/CanvasView/models';
 import { useMovable } from './useMovable';
 
 export interface ICanvasObjectProps extends HTMLAttributes<SVGForeignObjectElement> {

--- a/ui-react/packages/atlasmap-ui/src/canvas/useMovable.ts
+++ b/ui-react/packages/atlasmap-ui/src/canvas/useMovable.ts
@@ -2,7 +2,7 @@ import clamp from 'lodash.clamp'
 import { useEffect } from 'react';
 import { useDrag } from 'react-use-gesture';
 import { useCanvas } from './CanvasContext';
-import { Coords } from '../models';
+import { Coords } from '../views/CanvasView/models';
 
 export interface IUseMovableArgs {
   id: string;

--- a/ui-react/packages/atlasmap-ui/src/common/useDimensions.ts
+++ b/ui-react/packages/atlasmap-ui/src/common/useDimensions.ts
@@ -5,7 +5,7 @@ import {
   useRef,
   MutableRefObject,
 } from 'react';
-import { BrowserRect } from '../models';
+import { BrowserRect } from '../views/CanvasView/models';
 
 export interface UseDimensionsArgs {
   liveMeasure?: boolean;

--- a/ui-react/packages/atlasmap-ui/src/index.ts
+++ b/ui-react/packages/atlasmap-ui/src/index.ts
@@ -2,4 +2,3 @@ export * from './canvas';
 export * from './common';
 export * from './atlasmap';
 export * from './views';
-export * from './models';

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/CanvasViewLayoutProvider.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/CanvasViewLayoutProvider.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, FunctionComponent, useContext } from 'react';
 import { useCanvas } from '../../canvas';
-import { Coords } from '../../models';
+import { Coords } from './models';
 
 interface ICanvasViewLayoutContext {
   boxHeight: number;

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/CanvasViewProvider.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/CanvasViewProvider.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, FunctionComponent, useCallback, useContext, useState } from 'react';
 import { useGesture } from 'react-use-gesture';
-import { Coords } from '../../models';
+import { Coords } from './models';
 
 interface ICanvasViewContext {
   zoom: number;

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/CanvasViewControlBar.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/CanvasViewControlBar.tsx
@@ -1,6 +1,6 @@
 import {
   createTopologyControlButtons,
-  TopologyControlBar,
+  TopologyControlBar, TopologyControlButton,
 } from '@patternfly/react-topology';
 import React, { FunctionComponent, useCallback, useMemo } from 'react';
 import {
@@ -9,14 +9,15 @@ import {
   ExpandArrowsAltIcon,
   ExpandIcon,
   PficonDragdropIcon,
-  LinkIcon,
-  InfoIcon,
-  ConnectedIcon,
-  DisconnectedIcon, EyeIcon
+  LinkIcon
 } from '@patternfly/react-icons';
 import { useCanvasViewContext } from '../CanvasViewProvider';
 
-export const CanvasViewControlBar: FunctionComponent = () => {
+export interface ICanvasViewControlBarProps {
+  extraButtons?: TopologyControlButton[]
+}
+
+export const CanvasViewControlBar: FunctionComponent<ICanvasViewControlBarProps> = ({ extraButtons = [] }) => {
   const { updateZoom,
     resetZoom,
     resetPan,
@@ -94,33 +95,10 @@ export const CanvasViewControlBar: FunctionComponent = () => {
             ariaLabel: ' ',
             callback: toggleMaterializedMappings
           },
-          {
-            id: 'Show types',
-            icon: <InfoIcon />,
-            tooltip: 'Show types',
-            ariaLabel: ' ',
-          },
-          {
-            id: 'Show mapped fields',
-            icon: <ConnectedIcon />,
-            tooltip: 'Show mapped fields',
-            ariaLabel: ' ',
-          },
-          {
-            id: 'Show unmapped fields',
-            icon: <DisconnectedIcon />,
-            tooltip: 'Show unmapped fields',
-            ariaLabel: ' ',
-          },
-          {
-            id: 'Show mapping preview',
-            icon: <EyeIcon />,
-            tooltip: 'Show mapping preview',
-            ariaLabel: ' ',
-          },
+          ...extraButtons
         ],
       }),
-    [handleZoomIn, handleZoomOut, handleViewReset, toggleFreeView, toggleMaterializedMappings]
+    [freeView, handleZoomIn, handleZoomOut, handleViewReset, toggleFreeView, toggleMaterializedMappings, extraButtons]
   );
 
   return (

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Document.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Document.tsx
@@ -8,7 +8,8 @@ import {
   CardHead,
   CardHeader,
   Dropdown,
-  DropdownItem, DropdownItemIcon,
+  DropdownItem,
+  DropdownItemIcon,
   DropdownSeparator,
   DropdownToggle,
   DropdownToggleAction,
@@ -22,12 +23,12 @@ import {
 } from '@patternfly/react-icons';
 import { css, StyleSheet } from '@patternfly/react-styles';
 import React, {
-  FunctionComponent,
-  ReactElement, useEffect,
+  ReactElement,
+  useEffect,
   useRef,
   useState,
 } from 'react';
-import { DocumentType, IFieldsGroup } from '../../../models';
+import { DocumentType, IFieldsGroup, IFieldsNode } from '../models';
 import { FieldGroup } from './FieldGroup';
 
 const styles = StyleSheet.create({
@@ -76,27 +77,31 @@ const styles = StyleSheet.create({
   },
 });
 
-export interface IDocumentProps {
+export interface IDocumentProps<NodeType> {
   title: ReactElement | string;
   footer: ReactElement | string;
   fields: IFieldsGroup;
   type: DocumentType;
-  lineConnectionSide: 'left' | 'right'
+  lineConnectionSide: 'left' | 'right';
+  renderNode: (node: NodeType & (IFieldsGroup | IFieldsNode)) => ReactElement;
 }
 
-export const Document: FunctionComponent<IDocumentProps> = ({
+export function Document<NodeType>({
   title,
   footer,
   type,
   lineConnectionSide,
-  fields
-}) => {
+  fields,
+  renderNode,
+}: IDocumentProps<NodeType>) {
   const ref = useRef<HTMLDivElement | null>(null);
   const [isExpanded, setIsExpanded] = useState(true);
   const toggleIsExpanded = () => setIsExpanded(!isExpanded);
   const [showActions, setShowActions] = useState(false);
   const toggleActions = (open: boolean) => setShowActions(open);
-  const [expandFields, setExpandField] = useState<boolean | undefined>(undefined);
+  const [expandFields, setExpandField] = useState<boolean | undefined>(
+    undefined
+  );
   const handleCollapseField = () => setExpandField(false);
   const handleExpandField = () => setExpandField(true);
 
@@ -123,9 +128,12 @@ export const Document: FunctionComponent<IDocumentProps> = ({
               toggle={
                 <DropdownToggle
                   splitButtonItems={[
-                    <DropdownToggleAction key="action" onClick={handleExpandField}>
+                    <DropdownToggleAction
+                      key="action"
+                      onClick={handleExpandField}
+                    >
                       <FolderOpenIcon />
-                    </DropdownToggleAction>
+                    </DropdownToggleAction>,
                   ]}
                   splitButtonVariant="action"
                   onToggle={toggleActions}
@@ -134,7 +142,11 @@ export const Document: FunctionComponent<IDocumentProps> = ({
               isOpen={showActions}
               position={'right'}
               dropdownItems={[
-                <DropdownItem variant={'icon'} key={'collapse'} onClick={handleCollapseField}>
+                <DropdownItem
+                  variant={'icon'}
+                  key={'collapse'}
+                  onClick={handleCollapseField}
+                >
                   <DropdownItemIcon>
                     <FolderCloseIcon />
                   </DropdownItemIcon>
@@ -173,6 +185,7 @@ export const Document: FunctionComponent<IDocumentProps> = ({
                 rightAlign={rightAlign}
                 parentExpanded={isExpanded}
                 initiallyExpanded={expandFields}
+                renderNode={renderNode}
               />
             </Accordion>
           </div>

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/FieldElement.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/FieldElement.tsx
@@ -1,9 +1,14 @@
 import { css, StyleSheet } from '@patternfly/react-styles';
-import React, { FunctionComponent, useCallback, useEffect, useRef } from 'react';
+import React, {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react';
 import { useDrag } from 'react-dnd';
-import { getEmptyImage } from 'react-dnd-html5-backend'
+import { getEmptyImage } from 'react-dnd-html5-backend';
 import { useBoundingCanvasRect, useMappingNode } from '../../../canvas';
-import { ElementId, DocumentType, IFieldsNode } from '../../../models';
+import { ElementId, DocumentType, IFieldsNode } from '../models';
 
 const styles = StyleSheet.create({
   element: {
@@ -40,6 +45,7 @@ export const FieldElement: FunctionComponent<IFieldElementProps> = ({
   getParentRef,
   getBoxRef,
   rightAlign = false,
+  children,
 }) => {
   const ref = useRef<HTMLDivElement | null>(null);
 
@@ -61,30 +67,30 @@ export const FieldElement: FunctionComponent<IFieldElementProps> = ({
         ),
       };
     }
-    // if (node.id === 'io.paul.Bicycle-/serialId')
-    // console.log(node.id, ref.current, parentRef, boxRef)
     return null;
-  }, [getBoundingCanvasRect, getBoxRef, getParentRef, documentType]);
+  }, [getParentRef, getBoxRef, getBoundingCanvasRect, lineConnectionSide]);
 
-  const [{ opacity }, dragRef, preview] = useDrag<
+  const [{ color }, dragRef, preview] = useDrag<
     IFieldElementDragSource,
     undefined,
-    { opacity: number }
-    >({
+    { color: string | undefined }
+  >({
     item: { id: node.id, type: documentType, name: node.name },
     collect: monitor => ({
-      opacity: monitor.isDragging() ? 0.4 : 1,
+      color: monitor.isDragging()
+        ? 'var(--pf-global--primary-color--100)'
+        : undefined,
     }),
     begin: () => {
       setLineNode('dragsource', getCoords);
-    }
+    },
   });
 
   useEffect(() => {
     setLineNode(node.id, getCoords);
     return () => {
       unsetLineNode(node.id);
-    }
+    };
   }, [node, setLineNode, unsetLineNode, getCoords]);
 
   const handleRef = (el: HTMLDivElement) => {
@@ -93,16 +99,16 @@ export const FieldElement: FunctionComponent<IFieldElementProps> = ({
   };
 
   useEffect(() => {
-    preview(getEmptyImage(), { captureDraggingState: true })
+    preview(getEmptyImage(), { captureDraggingState: true });
   }, [preview]);
 
   return (
     <div
       ref={handleRef}
       className={css(styles.element, rightAlign && styles.rightAlign)}
-      style={{ opacity }}
+      style={{ color }}
     >
-      {node.name}
+      {children}
     </div>
   );
 };

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/FieldsBox.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/FieldsBox.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, HTMLAttributes, ReactElement, useEffect } from 'react';
 import { CanvasObject, useCanvas } from '../../../canvas';
 import { useDimensions } from '../../../common';
-import { Coords } from '../../../models';
+import { Coords } from '../models';
 import { useCanvasViewContext } from '../CanvasViewProvider';
 import { Box } from './Box';
 

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Links.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Links.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { CanvasLink } from '../../../canvas';
-import { IMappings } from '../../../models';
+import { IMappings } from '../models';
 import { useCanvasViewContext } from '../CanvasViewProvider';
 import { useMappingLinks } from './useMappingLinks';
 import { useSourceTargetLinks } from './useSourceTargetLinks';

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/MappingElement.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/MappingElement.tsx
@@ -29,7 +29,7 @@ import {
   useBoundingCanvasRect,
   useMappingNode,
 } from '../../../canvas';
-import { ElementId, DocumentType, IMappings } from '../../../models';
+import { ElementId, DocumentType, IMappings } from '../models';
 import { IFieldElementDragSource } from './FieldElement';
 
 const styles = StyleSheet.create({

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/useMappingLinks.ts
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/useMappingLinks.ts
@@ -2,7 +2,7 @@ import { scaleSequential } from 'd3-scale';
 import { interpolateRainbow } from 'd3-scale-chromatic';
 import { useMemo } from 'react';
 import { SourceTargetNodes, useCanvasLinks } from '../../../canvas';
-import { IMappings } from '../../../models';
+import { IMappings } from '../models';
 
 export interface IUseMappingsLinksArgs {
   mappings: IMappings[];

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/useSourceTargetLinks.ts
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/useSourceTargetLinks.ts
@@ -2,7 +2,7 @@ import { scaleSequential } from 'd3-scale';
 import { interpolateRainbow } from 'd3-scale-chromatic';
 import { useMemo } from 'react';
 import { SourceTargetNodes, useCanvasLinks } from '../../../canvas';
-import { IMappings } from '../../../models';
+import { IMappings } from '../models';
 
 export interface IUseSourceTargetLinksArgs {
   mappings: IMappings[];

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/index.ts
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/index.ts
@@ -1,3 +1,4 @@
 export * from './CanvasView';
 export * from './CanvasViewProvider';
 export * from './components';
+export * from './models';

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/models.ts
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/models.ts
@@ -8,13 +8,13 @@ export type BrowserRect = ClientRect | DOMRect;
 export type ElementId = string;
 export type DocumentType = 'source' | 'target';
 export type GroupId = string;
+
 export interface IFieldsNode {
   id: ElementId;
   name: string;
 }
 export interface IFieldsGroup {
   id: GroupId;
-  title: string;
   fields: (IFieldsNode | IFieldsGroup)[];
 }
 export interface IMappingField {

--- a/ui-react/packages/atlasmap-ui/stories/Atlasmap.stories.tsx
+++ b/ui-react/packages/atlasmap-ui/stories/Atlasmap.stories.tsx
@@ -1,7 +1,7 @@
 import { action } from '@storybook/addon-actions';
 import React, { createElement, useState } from 'react';
 import { Atlasmap } from '../src/atlasmap';
-import { ElementId, DocumentType, IMappings } from '../src/models';
+import { ElementId, DocumentType, IMappings } from '../src/views/CanvasView';
 import { mappings as sampleMappings, sources, targets } from './sampleData';
 
 export default {

--- a/ui-react/packages/atlasmap-ui/stories/sampleData.tsx
+++ b/ui-react/packages/atlasmap-ui/stories/sampleData.tsx
@@ -902,12 +902,14 @@ const XMLInstanceSource: XMLObject = {
 export const sources = [
   {
     id: 'JSONInstanceSource',
-    title: 'JSONInstanceSource',
+    name: 'JSONInstanceSource',
+    type: 'JSON',
     fields: jsonToFieldGroup(mockJSONInstanceSource, 'JSONInstanceSource'),
   },
   {
     id: 'JSONSchemaSource',
-    title: 'JSONSchemaSource',
+    name: 'JSONSchemaSource',
+    type: 'JSON',
     fields: jsonToFieldGroup(mockJSONSchemaSource, 'JSONSchemaSource'),
   },
 ];
@@ -915,17 +917,20 @@ export const sources = [
 export const targets = [
   {
     id: 'XMLInstanceSource',
-    title: 'XMLInstanceSource',
+    name: 'XMLInstanceSource',
+    type: 'XML',
     fields: xmlToFieldGroup(XMLInstanceSource, 'XMLInstanceSource'),
   },
   {
     id: 'XMLSchemaSource',
-    title: 'XMLSchemaSource',
+    name: 'XMLSchemaSource',
+    type: 'XML',
     fields: xmlToFieldGroup(XMLSchemaSource, 'XMLSchemaSource'),
   },
   {
     id: 'io.paul.Bicycle',
-    title: 'io.paul.Bicycle',
+    name: 'io.paul.Bicycle',
+    type: 'JAVA',
     fields: javaToFieldGroup(ioPaulBicycle, 'io.paul.Bicycle'),
   },
 ];

--- a/ui-react/packages/atlasmap-ui/stories/utils/fromJava.ts
+++ b/ui-react/packages/atlasmap-ui/stories/utils/fromJava.ts
@@ -1,4 +1,4 @@
-import { IFieldsGroup } from '../../src/models';
+import { IDocument } from '../../src/atlasmap';
 
 interface Modifiers {
   modifier: string[];
@@ -71,10 +71,12 @@ export interface JavaObject {
 export function javaToFieldGroup(java: JavaObject, idPrefix: string) {
   const fromElement = (jf: JavaField) => ({
     id: `${idPrefix}-${jf.path}`,
-    name: jf.name
+    name: jf.name,
+    type: jf.fieldType
   });
-  const fromGroup = (f: JavaField): IFieldsGroup => ({
-    title: f.name,
+  const fromGroup = (f: JavaField): IDocument => ({
+    name: f.name,
+    type: f.fieldType,
     id: `${idPrefix}-${f.path}`,
     fields: f.javaFields!.javaField.map(f => f.javaFields ? fromGroup(f as JavaField) : fromElement(f))
   });

--- a/ui-react/packages/atlasmap-ui/stories/utils/fromJson.ts
+++ b/ui-react/packages/atlasmap-ui/stories/utils/fromJson.ts
@@ -1,4 +1,4 @@
-import { IFieldsGroup } from '../../src/models';
+import { IDocument } from '../../src/atlasmap';
 
 interface JsonField {
   jsonType: string;
@@ -44,13 +44,15 @@ export interface JsonObject {
   JsonInspectionResponse: JsonInspectionResponse;
 }
 
-export function jsonToFieldGroup(json: JsonObject, idPrefix: string): IFieldsGroup[] {
+export function jsonToFieldGroup(json: JsonObject, idPrefix: string): IDocument[] {
   const fromElement = (jf: JsonField) => ({
     id: `${idPrefix}-${jf.path}`,
-    name: jf.name
+    name: jf.name,
+    type: jf.fieldType
   });
-  const fromGroup = (f: Field): IFieldsGroup => ({
-    title: f.name,
+  const fromGroup = (f: Field): IDocument => ({
+    name: f.name,
+    type: f.fieldType,
     id: `${idPrefix}-${f.path}`,
     fields: f.jsonFields.jsonField.map(f => f.jsonFields ? fromGroup(f as Field) : fromElement(f))
   });

--- a/ui-react/packages/atlasmap-ui/stories/utils/fromXML.ts
+++ b/ui-react/packages/atlasmap-ui/stories/utils/fromXML.ts
@@ -1,4 +1,4 @@
-import { IFieldsGroup } from '../../src/models';
+import { IDocument } from '../../src/atlasmap';
 
 interface Restrictions {
   restriction: any[];
@@ -59,11 +59,13 @@ export interface XMLObject {
 export function xmlToFieldGroup(xml: XMLObject, idPrefix: string) {
   const fromElement = (jf: XmlField) => ({
     id: `${idPrefix}-${jf.path}`,
-    name: jf.name
+    name: jf.name,
+    type: jf.fieldType,
   });
 
-  const fromGroup = (f: Field): IFieldsGroup => ({
-    title: f.name,
+  const fromGroup = (f: Field): IDocument => ({
+    name: f.name,
+    type: f.fieldType,
     id: `${idPrefix}-${f.path}`,
     fields: f.xmlFields.xmlField.map(
       f => f.xmlFields ? fromGroup(f as Field) : fromElement(f)

--- a/ui-react/packages/atlasmap-ui/stories/views/CanvasView/CanvasView.stories.tsx
+++ b/ui-react/packages/atlasmap-ui/stories/views/CanvasView/CanvasView.stories.tsx
@@ -40,11 +40,12 @@ export const sample = () => {
           return (
             <Document
               key={s.id}
-              title={s.title}
+              title={s.name}
               footer={'Source document'}
               type={'source'}
               lineConnectionSide={'right'}
               fields={s}
+              renderNode={_ => <>test</>}
             />
           );
         })}
@@ -84,11 +85,12 @@ export const sample = () => {
           return (
             <Document
               key={t.id}
-              title={t.title}
+              title={t.name}
               footer={'Target document'}
               type={'target'}
               lineConnectionSide={'left'}
               fields={t}
+              renderNode={_ => <>test</>}
             />
           );
         })}

--- a/ui-react/packages/atlasmap-ui/stories/views/CanvasView/FieldGroup.stories.tsx
+++ b/ui-react/packages/atlasmap-ui/stories/views/CanvasView/FieldGroup.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { boolean, text } from '@storybook/addon-knobs';
+import { boolean } from '@storybook/addon-knobs';
 import { FieldGroup } from '../../../src/views/CanvasView';
 
 export default {
@@ -14,10 +14,10 @@ export const interactiveExample = () => (
     lineConnectionSide={'right'}
     group={{
       fields: [],
-      id: 'text-id',
-      title: text('Group title', 'Sample title'),
+      id: 'text-id'
     }}
     getBoxRef={() => null}
     parentExpanded={boolean('Parent expanded', true)}
+    renderNode={_ => <>test</>}
   />
 );


### PR DESCRIPTION
This enables the "Show types" toggle in the canvas bar. Atlasmap specific rendering - like showing the field type - is delegated to the `Atlasmap` component from the CanvasView family of components. 

This design should ideally keep the components type required by the "draggable fields with connecting lines bandwagon" to the bare minimum.

For example, the "Preview" toggle should be about creating a new component to show a field preview, and then rendering that instead of the `DocumentField` when needed.

Fixes #1542