### PR TITLE
feat(react-ui): confirmation modals

### DIFF
--- a/ui-react/package.json
+++ b/ui-react/package.json
@@ -13,6 +13,6 @@
   "scripts": {
     "build": "lerna run --stream build",
     "watch": "lerna run --ignore @atlasmap/standalone --parallel --no-bail start -- --verbose",
-    "standalone": "lerna run --scope @atlasmap/standalone start"
+    "standalone": "lerna run --stream --scope @atlasmap/standalone start"
   }
 }

--- a/ui-react/packages/atlasmap-standalone/public/index.html
+++ b/ui-react/packages/atlasmap-standalone/public/index.html
@@ -29,6 +29,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <div id="modals"></div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/ui-react/packages/atlasmap-standalone/src/App.tsx
+++ b/ui-react/packages/atlasmap-standalone/src/App.tsx
@@ -1,7 +1,8 @@
 import { useAtlasmap } from "@atlasmap/provider";
-import { Atlasmap } from "@atlasmap/ui";
-import React, { useCallback, useState } from "react";
+import { Atlasmap, GroupId } from "@atlasmap/ui";
+import React, { useCallback, useRef, useState } from 'react';
 import "./App.css";
+import { useConfirmationDialog } from './useConfirmationDialog';
 
 const App: React.FC = () => {
   const [sourceFilter, setSourceFilter] = useState<string | undefined>();
@@ -33,22 +34,56 @@ const App: React.FC = () => {
     [importAtlasFile]
   );
 
+  const [resetDialog, openResetDialog] = useConfirmationDialog({
+    title: 'Reset All Mappings and Imports?',
+    content: 'Are you sure you want to reset all mappings and clear all imported documents?',
+    onConfirm: (closeDialog) => {
+      closeDialog();
+      resetAtlasmap();
+    },
+    onCancel: (closeDialog) => {
+      closeDialog();
+    }
+  });
+
+  const documentToDelete = useRef<GroupId | undefined>();
+  const [deleteDocumentDialog, openDeleteDocumentDialog] = useConfirmationDialog({
+    title: 'Remove selected document?',
+    content: 'Are you sure you want to remove the selected document and any associated mappings?',
+    onConfirm: (closeDialog) => {
+      closeDialog();
+      console.log(`TODO: delete document id ${documentToDelete.current}`);
+    },
+    onCancel: (closeDialog) => {
+      closeDialog();
+    }
+  });
+  const handleDeleteDocumentDialog = useCallback((id: GroupId) => {
+    documentToDelete.current = id;
+    openDeleteDocumentDialog();
+  }, [openDeleteDocumentDialog]);
+
   return (
-    <Atlasmap
-      sources={sources}
-      targets={targets}
-      mappings={mappings}
-      addToMapping={() => void 0}
-      pending={pending}
-      error={error}
-      onImportAtlasFile={handleImportAtlasFile}
-      onImportSourceDocument={handleImportSourceDocument}
-      onImportTargetDocument={handleImportTargetDocument}
-      onResetAtlasmap={resetAtlasmap}
-      onSourceSearch={setSourceFilter}
-      onTargetSearch={setTargetFilter}
-      onExportAtlasFile={exportAtlasFile}
-    />
+    <>
+      <Atlasmap
+        sources={sources}
+        targets={targets}
+        mappings={mappings}
+        addToMapping={() => void 0}
+        pending={pending}
+        error={error}
+        onImportAtlasFile={handleImportAtlasFile}
+        onImportSourceDocument={handleImportSourceDocument}
+        onImportTargetDocument={handleImportTargetDocument}
+        onResetAtlasmap={openResetDialog}
+        onSourceSearch={setSourceFilter}
+        onTargetSearch={setTargetFilter}
+        onExportAtlasFile={exportAtlasFile}
+        onDeleteDocument={handleDeleteDocumentDialog}
+      />
+      {resetDialog}
+      {deleteDocumentDialog}
+    </>
   );
 };
 

--- a/ui-react/packages/atlasmap-standalone/src/useConfirmationDialog.tsx
+++ b/ui-react/packages/atlasmap-standalone/src/useConfirmationDialog.tsx
@@ -1,0 +1,48 @@
+import { Modal, Button } from '@patternfly/react-core';
+import React, { ReactChild, ReactPortal, useCallback, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+export type Callback = (closeDialog: () => void) => void;
+
+export interface IUseConfirmationDialogArgs {
+  title: string;
+  content: ReactChild;
+  onConfirm: Callback;
+  onCancel: Callback;
+}
+
+export function useConfirmationDialog({
+  title,
+  content,
+  onConfirm,
+  onCancel
+}: IUseConfirmationDialogArgs): [ReactPortal, () => void] {
+  const [isOpen, setIsOpen] = useState(false);
+  const openModal = () => setIsOpen(true);
+  const closeModal = () => setIsOpen(false);
+  const handleConfirm = useCallback(() => onConfirm(closeModal), [onConfirm]);
+  const handleCancel = useCallback(() => onCancel(closeModal), [onCancel]);
+
+  const modal = createPortal(
+    <Modal
+      isSmall
+      title={title}
+      isOpen={isOpen}
+      onClose={closeModal}
+      actions={[
+        <Button key={'confirm'} variant={'primary'} onClick={handleConfirm}>
+          Confirm
+        </Button>,
+        <Button key={'cancel'} variant={'link'} onClick={handleCancel}>
+          Cancel
+        </Button>
+      ]}
+      isFooterLeftAligned={true}
+    >
+      {content}
+    </Modal>,
+    document.getElementById('modals')!
+  );
+
+  return [modal, openModal];
+}

--- a/ui-react/packages/atlasmap-ui/src/atlasmap/Atlasmap.tsx
+++ b/ui-react/packages/atlasmap-ui/src/atlasmap/Atlasmap.tsx
@@ -8,7 +8,7 @@ import React, {
   useState,
 } from 'react';
 import { Loading } from '../common';
-import { ElementId, DocumentType, IFieldsGroup, IMappings, IFieldsNode } from '../views/CanvasView';
+import { ElementId, DocumentType, IFieldsGroup, IMappings, IFieldsNode, GroupId } from '../views/CanvasView';
 import {
   CanvasView,
   CanvasViewControlBar,
@@ -56,6 +56,7 @@ export interface IAtlasmapProps {
   onResetAtlasmap: () => void;
   onSourceSearch: (content: string) => void;
   onTargetSearch: (content: string) => void;
+  onDeleteDocument: (id: GroupId) => void;
 }
 
 export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
@@ -72,6 +73,7 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
   onResetAtlasmap,
   onSourceSearch,
   onTargetSearch,
+  onDeleteDocument
 }) => {
   const [selectedMapping, setSelectedMapping] = useState<string>();
   const [isEditingMapping, setisEditingMapping] = useState(false);
@@ -207,6 +209,7 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
                           showType={showTypes}
                         />
                     }
+                    onDelete={() => onDeleteDocument(s.id)}
                   />
                 );
               })}
@@ -265,6 +268,7 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
                           showType={showTypes}
                         />
                     }
+                    onDelete={() => onDeleteDocument(t.id)}
                   />
                 );
               })}

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Document.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Document.tsx
@@ -22,12 +22,7 @@ import {
   FolderOpenIcon,
 } from '@patternfly/react-icons';
 import { css, StyleSheet } from '@patternfly/react-styles';
-import React, {
-  ReactElement,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { ReactElement, useEffect, useRef, useState } from 'react';
 import { DocumentType, IFieldsGroup, IFieldsNode } from '../models';
 import { FieldGroup } from './FieldGroup';
 
@@ -84,6 +79,7 @@ export interface IDocumentProps<NodeType> {
   type: DocumentType;
   lineConnectionSide: 'left' | 'right';
   renderNode: (node: NodeType & (IFieldsGroup | IFieldsNode)) => ReactElement;
+  onDelete: () => void;
 }
 
 export function Document<NodeType>({
@@ -93,6 +89,7 @@ export function Document<NodeType>({
   lineConnectionSide,
   fields,
   renderNode,
+  onDelete
 }: IDocumentProps<NodeType>) {
   const ref = useRef<HTMLDivElement | null>(null);
   const [isExpanded, setIsExpanded] = useState(true);
@@ -153,7 +150,11 @@ export function Document<NodeType>({
                   Collapse all
                 </DropdownItem>,
                 <DropdownSeparator key={'sep-1'} />,
-                <DropdownItem variant={'icon'} key={'delete'}>
+                <DropdownItem
+                  variant={'icon'}
+                  key={'delete'}
+                  onClick={onDelete}
+                >
                   <DropdownItemIcon>
                     <TrashIcon />
                   </DropdownItemIcon>
@@ -201,4 +202,4 @@ export function Document<NodeType>({
       </Card>
     </div>
   );
-};
+}

--- a/ui-react/packages/atlasmap-ui/stories/Atlasmap.stories.tsx
+++ b/ui-react/packages/atlasmap-ui/stories/Atlasmap.stories.tsx
@@ -36,6 +36,7 @@ export const sample = () => createElement(() => {
       onResetAtlasmap={action('resetAtlasmap')}
       onSourceSearch={action('onSourceSearch')}
       onTargetSearch={action('onTargetSearch')}
+      onDeleteDocument={action('onDeleteDocument')}
       pending={false}
       error={false}
     />

--- a/ui-react/packages/atlasmap-ui/stories/views/CanvasView/CanvasView.stories.tsx
+++ b/ui-react/packages/atlasmap-ui/stories/views/CanvasView/CanvasView.stories.tsx
@@ -46,6 +46,7 @@ export const sample = () => {
               lineConnectionSide={'right'}
               fields={s}
               renderNode={_ => <>test</>}
+              onDelete={action('onDelete Source')}
             />
           );
         })}
@@ -91,6 +92,7 @@ export const sample = () => {
               lineConnectionSide={'left'}
               fields={t}
               renderNode={_ => <>test</>}
+              onDelete={action('onDelete Target')}
             />
           );
         })}


### PR DESCRIPTION
This adds a `useConfirmationDialog` hook to deal with confirmations in the app. 

It's a hook in the application and not a UI component since modals need to be handled by the host application - when embedded in Syndesis for example there will be Syndesis's way to deal with modals. The same decoupling will have to be implemented when we'll add notifications support.

![Kapture 2019-12-04 at 19 07 09](https://user-images.githubusercontent.com/966316/70168620-842cfd80-16c9-11ea-9265-91cd59cb39b9.gif)
