### PR TITLE
Partial fix for i1555

### DIFF
--- a/ui-react/packages/atlasmap-provider/src/AtlasmapProvider.tsx
+++ b/ui-react/packages/atlasmap-provider/src/AtlasmapProvider.tsx
@@ -202,6 +202,7 @@ export function useAtlasmap({
     },
     [dispatch]
   );
+  /*
   const handleDeleteAtlasFile = useCallback(
     (fileName: string, isSource: boolean) => {
       dispatch({ type: 'reset' });
@@ -209,6 +210,7 @@ export function useAtlasmap({
     },
     [dispatch]
   );
+  */
   const handleResetAtlasmap = useCallback(
     () => {
       dispatch({ type: 'reset' });
@@ -224,12 +226,12 @@ export function useAtlasmap({
       sources: sourceDocs.map(fromDocumentDefinitionToFieldGroup).filter(d => d) as IDocument[],
       targets: targetDocs.map(fromDocumentDefinitionToFieldGroup).filter(d => d) as IDocument[],
       mappings: fromMappingDefinitionToIMappings(mappingDefinition),
-      deleteAtlasFile: handleDeleteAtlasFile,
+      deleteAtlasFile: deleteAtlasFile,
       exportAtlasFile: exportAtlasFile,
       importAtlasFile: handleImportAtlasFile,
       resetAtlasmap: handleResetAtlasmap,
     }),
-    [error, handleImportAtlasFile, handleResetAtlasmap, handleDeleteAtlasFile, mappingDefinition,
+    [error, handleImportAtlasFile, handleResetAtlasmap, mappingDefinition,
      pending, sourceDocs, targetDocs, sourceFilter, targetFilter]
   );
 }

--- a/ui-react/packages/atlasmap-provider/src/AtlasmapProvider.tsx
+++ b/ui-react/packages/atlasmap-provider/src/AtlasmapProvider.tsx
@@ -16,7 +16,7 @@ import {
   fromDocumentDefinitionToFieldGroup,
   fromMappingDefinitionToIMappings,
 } from './utils/to-ui-models-util';
-import { exportAtlasFile, importAtlasFile, resetAtlasmap } from './components/toolbar/toolbar-util';
+import { deleteAtlasFile, exportAtlasFile, importAtlasFile, resetAtlasmap } from './components/toolbar/toolbar-util';
 
 const api = ky.create({ headers: { 'ATLASMAP-XSRF-TOKEN': 'awesome' } });
 
@@ -171,6 +171,7 @@ export function useAtlasmap({
   sources: IDocument[];
   targets: IDocument[];
   mappings: IMappings[];
+  deleteAtlasFile: (fileName: any, isSource: any) => void;
   exportAtlasFile: () => void;
   importAtlasFile: (file: File, isSource: boolean) => void;
   resetAtlasmap: () => void;
@@ -201,7 +202,13 @@ export function useAtlasmap({
     },
     [dispatch]
   );
-
+  const handleDeleteAtlasFile = useCallback(
+    (fileName: string, isSource: boolean) => {
+      dispatch({ type: 'reset' });
+      deleteAtlasFile(fileName, isSource);
+    },
+    [dispatch]
+  );
   const handleResetAtlasmap = useCallback(
     () => {
       dispatch({ type: 'reset' });
@@ -217,10 +224,12 @@ export function useAtlasmap({
       sources: sourceDocs.map(fromDocumentDefinitionToFieldGroup).filter(d => d) as IDocument[],
       targets: targetDocs.map(fromDocumentDefinitionToFieldGroup).filter(d => d) as IDocument[],
       mappings: fromMappingDefinitionToIMappings(mappingDefinition),
+      deleteAtlasFile: handleDeleteAtlasFile,
       exportAtlasFile: exportAtlasFile,
       importAtlasFile: handleImportAtlasFile,
       resetAtlasmap: handleResetAtlasmap,
     }),
-    [error, handleImportAtlasFile, handleResetAtlasmap, mappingDefinition, pending, sourceDocs, targetDocs, sourceFilter, targetFilter]
+    [error, handleImportAtlasFile, handleResetAtlasmap, handleDeleteAtlasFile, mappingDefinition,
+     pending, sourceDocs, targetDocs, sourceFilter, targetFilter]
   );
 }

--- a/ui-react/packages/atlasmap-provider/src/components/document/document-util.ts
+++ b/ui-react/packages/atlasmap-provider/src/components/document/document-util.ts
@@ -34,7 +34,7 @@ async function importDoc(selectedFile: any, cfg: ConfigModel, isSource: boolean)
  *
  * @param docDef
  */
-async function removeDocumentRef(docDef: DocumentDefinition, cfg: ConfigModel): Promise<boolean> {
+export async function removeDocumentRef(docDef: DocumentDefinition, cfg: ConfigModel): Promise<boolean> {
   return new Promise<boolean>( async(resolve) => {
     cfg.mappingService.removeDocumentReferenceFromAllMappings(docDef.id);
     if (docDef.isSource) {
@@ -53,7 +53,7 @@ async function removeDocumentRef(docDef: DocumentDefinition, cfg: ConfigModel): 
  *
  * @param docName
  */
-function getDocDef(docName: string, cfg: ConfigModel, isSource: boolean): DocumentDefinition {
+export function getDocDef(docName: string, cfg: ConfigModel, isSource: boolean): DocumentDefinition {
   for (const docDef of cfg.getDocs(isSource)) {
     const candidateDocName = docDef.getName(false) + '.' + docDef.type.toLowerCase();
     if (candidateDocName.match(docName)) {

--- a/ui-react/packages/atlasmap-provider/src/components/toolbar/toolbar-util.ts
+++ b/ui-react/packages/atlasmap-provider/src/components/toolbar/toolbar-util.ts
@@ -13,6 +13,7 @@ export async function deleteAtlasFile(fileName: string, isSource: boolean) {
   const cfg = ConfigModel.getConfig();
   const docDef = getDocDef(fileName, cfg, isSource);
   await removeDocumentRef(docDef, cfg);
+  cfg.initializationService.updateInitComplete();
 }
 
  /**

--- a/ui-react/packages/atlasmap-provider/src/components/toolbar/toolbar-util.ts
+++ b/ui-react/packages/atlasmap-provider/src/components/toolbar/toolbar-util.ts
@@ -7,7 +7,13 @@ import {
   ErrorLevel,
 } from '../../models/error.model';
 import { ErrorHandlerService } from '../../services/error-handler.service';
-import { importInstanceSchema } from '../../components/document/document-util';
+import { importInstanceSchema, getDocDef, removeDocumentRef } from '../../components/document/document-util';
+
+export async function deleteAtlasFile(fileName: string, isSource: boolean) {
+  const cfg = ConfigModel.getConfig();
+  const docDef = getDocDef(fileName, cfg, isSource);
+  await removeDocumentRef(docDef, cfg);
+}
 
  /**
   * The user has requested their current mappings be exported.  Use the mapping management

--- a/ui-react/packages/atlasmap-provider/src/services/initialization.service.ts
+++ b/ui-react/packages/atlasmap-provider/src/services/initialization.service.ts
@@ -543,9 +543,7 @@ ${error.status} ${error.statusText}`,
         }
         MappingUtil.removeStaleMappings(this.cfg);
       }
-      this.updateLoadingStatus('Initialization complete.');
-      this.cfg.initCfg.initialized = true;
-      this.systemInitializedSource.next();
+      this.updateInitComplete();
     }
   }
 
@@ -562,6 +560,12 @@ ${error.status} ${error.statusText}`,
   updateLoadingStatus(status: string): void {
     this.cfg.initCfg.loadingStatus = status;
     this.initializationStatusChangedSource.next();
+  }
+
+  updateInitComplete(): void {
+    this.updateLoadingStatus('Initialization complete.');
+    this.cfg.initCfg.initialized = true;
+    this.systemInitializedSource.next();
   }
 
 }

--- a/ui-react/packages/atlasmap-standalone/src/App.tsx
+++ b/ui-react/packages/atlasmap-standalone/src/App.tsx
@@ -15,7 +15,8 @@ const App: React.FC = () => {
     error,
     importAtlasFile,
     resetAtlasmap,
-    exportAtlasFile
+    exportAtlasFile,
+    deleteAtlasFile
   } = useAtlasmap({
     sourceFilter,
     targetFilter
@@ -30,7 +31,7 @@ const App: React.FC = () => {
     [importAtlasFile]
   );
   const handleImportTargetDocument = useCallback(
-    (selectedFile: File) => importAtlasFile(selectedFile, true),
+    (selectedFile: File) => importAtlasFile(selectedFile, false),
     [importAtlasFile]
   );
 
@@ -47,19 +48,30 @@ const App: React.FC = () => {
   });
 
   const documentToDelete = useRef<GroupId | undefined>();
+  let documentIsSource = useRef<boolean>();
+
   const [deleteDocumentDialog, openDeleteDocumentDialog] = useConfirmationDialog({
     title: 'Remove selected document?',
     content: 'Are you sure you want to remove the selected document and any associated mappings?',
     onConfirm: (closeDialog) => {
       closeDialog();
+      deleteAtlasFile(documentToDelete.current, documentIsSource.current);
       console.log(`TODO: delete document id ${documentToDelete.current}`);
     },
     onCancel: (closeDialog) => {
       closeDialog();
     }
   });
-  const handleDeleteDocumentDialog = useCallback((id: GroupId) => {
+
+  const handleDeleteSourceDocumentDialog = useCallback((id: GroupId) => {
     documentToDelete.current = id;
+    documentIsSource.current = true;
+    openDeleteDocumentDialog();
+  }, [openDeleteDocumentDialog]);
+
+  const handleDeleteTargetDocumentDialog = useCallback((id: GroupId) => {
+    documentToDelete.current = id;
+    documentIsSource.current = false;
     openDeleteDocumentDialog();
   }, [openDeleteDocumentDialog]);
 
@@ -75,11 +87,12 @@ const App: React.FC = () => {
         onImportAtlasFile={handleImportAtlasFile}
         onImportSourceDocument={handleImportSourceDocument}
         onImportTargetDocument={handleImportTargetDocument}
+        onDeleteSourceDocument={handleDeleteSourceDocumentDialog}
+        onDeleteTargetDocument={handleDeleteTargetDocumentDialog}
         onResetAtlasmap={openResetDialog}
         onSourceSearch={setSourceFilter}
         onTargetSearch={setTargetFilter}
         onExportAtlasFile={exportAtlasFile}
-        onDeleteDocument={handleDeleteDocumentDialog}
       />
       {resetDialog}
       {deleteDocumentDialog}

--- a/ui-react/packages/atlasmap-ui/src/atlasmap/Atlasmap.tsx
+++ b/ui-react/packages/atlasmap-ui/src/atlasmap/Atlasmap.tsx
@@ -53,10 +53,11 @@ export interface IAtlasmapProps {
   onImportAtlasFile: (selectedFile: File) => void;
   onImportSourceDocument: (selectedFile: File) => void;
   onImportTargetDocument: (selectedFile: File) => void;
+  onDeleteSourceDocument: (fileName: GroupId) => void;
+  onDeleteTargetDocument: (fileName: GroupId) => void;
   onResetAtlasmap: () => void;
   onSourceSearch: (content: string) => void;
   onTargetSearch: (content: string) => void;
-  onDeleteDocument: (id: GroupId) => void;
 }
 
 export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
@@ -70,10 +71,11 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
   onImportAtlasFile,
   onImportSourceDocument,
   onImportTargetDocument,
+  onDeleteSourceDocument,
+  onDeleteTargetDocument,
   onResetAtlasmap,
   onSourceSearch,
-  onTargetSearch,
-  onDeleteDocument
+  onTargetSearch
 }) => {
   const [selectedMapping, setSelectedMapping] = useState<string>();
   const [isEditingMapping, setisEditingMapping] = useState(false);
@@ -209,7 +211,7 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
                           showType={showTypes}
                         />
                     }
-                    onDelete={() => onDeleteDocument(s.id)}
+                    onDelete={() => onDeleteSourceDocument(s.id)}
                   />
                 );
               })}
@@ -268,7 +270,7 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
                           showType={showTypes}
                         />
                     }
-                    onDelete={() => onDeleteDocument(t.id)}
+                    onDelete={() => onDeleteTargetDocument(t.id)}
                   />
                 );
               })}

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Document.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Document.tsx
@@ -79,7 +79,7 @@ export interface IDocumentProps<NodeType> {
   type: DocumentType;
   lineConnectionSide: 'left' | 'right';
   renderNode: (node: NodeType & (IFieldsGroup | IFieldsNode)) => ReactElement;
-  onDelete: (id: any) => void;
+  onDelete: () => void;
 }
 
 export function Document<NodeType>({

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Document.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Document.tsx
@@ -79,7 +79,7 @@ export interface IDocumentProps<NodeType> {
   type: DocumentType;
   lineConnectionSide: 'left' | 'right';
   renderNode: (node: NodeType & (IFieldsGroup | IFieldsNode)) => ReactElement;
-  onDelete: () => void;
+  onDelete: (id: any) => void;
 }
 
 export function Document<NodeType>({
@@ -101,7 +101,6 @@ export function Document<NodeType>({
   );
   const handleCollapseField = () => setExpandField(false);
   const handleExpandField = () => setExpandField(true);
-
   const rightAlign = lineConnectionSide === 'left';
 
   useEffect(() => {


### PR DESCRIPTION
@riccardo-forina - This implements document delete in source/target panels.  There is an issue that
I need your help with.  I'm dispatching the handleDeleteAtlasFile through the useCallback as 'reset'
(It seemed the closest to what I needed).  The result is the UI still shows the deleted file (if you refresh
the window it correctly disappears).   Is there a new context state that's needed (basically refresh the UI but not reinit)??