### PR TITLE
feat(react-ui): UI elements to display mapping previews

### DIFF
--- a/ui-react/packages/atlasmap-provider/src/components/toolbar/toolbar-util.ts
+++ b/ui-react/packages/atlasmap-provider/src/components/toolbar/toolbar-util.ts
@@ -55,9 +55,9 @@ async function processMappingsCatalog(selectedFile: any, cfg: ConfigModel) {
 /**
  * Import an ADM catalog file or a user JAR file.
  *
- * @param selectedFile 
- * @param userFileSuffix 
- * @param cfg 
+ * @param selectedFile
+ * @param userFileSuffix
+ * @param cfg
  */
 function importAtlasGlobalFile(selectedFile: File, userFileSuffix: string, cfg: ConfigModel) {
   if (userFileSuffix === 'ADM') {
@@ -154,4 +154,14 @@ export function resetAtlasmap() {
         level: ErrorLevel.ERROR, scope: ErrorScope.APPLICATION, type: ErrorType.INTERNAL, object: error}));
     }
   });
+}
+
+export function enableMappingPreview(enabled: boolean) {
+  const cfg = ConfigModel.getConfig();
+
+  if (enabled) {
+    cfg.mappingService.enableMappingPreview();
+  } else {
+    cfg.mappingService.disableMappingPreview();
+  }
 }

--- a/ui-react/packages/atlasmap-provider/src/utils/to-ui-models-util.ts
+++ b/ui-react/packages/atlasmap-provider/src/utils/to-ui-models-util.ts
@@ -1,12 +1,14 @@
 import { IFieldsGroup, IFieldsNode, IMappingField, IMappings, IDocument, IDocumentField } from '@atlasmap/ui';
 import { DocumentDefinition, Field, MappedField, MappingDefinition } from '..';
 
+export type AtlasmapFields = Array<IFieldsGroup & IAtlasmapField | IFieldsNode & IAtlasmapField>;
+
 export interface IAtlasmapField extends IDocumentField {
   amField: Field;
 }
 
 export interface IAtlasmapDocument extends IDocument {
-  fields: Array<IFieldsGroup & IAtlasmapField | IFieldsNode & IAtlasmapField>;
+  fields: AtlasmapFields;
 }
 
 function fromFieldToIFieldsGroup(field: Field): IAtlasmapField & IFieldsGroup {

--- a/ui-react/packages/atlasmap-standalone/src/App.tsx
+++ b/ui-react/packages/atlasmap-standalone/src/App.tsx
@@ -17,6 +17,8 @@ const App: React.FC = () => {
     resetAtlasmap,
     exportAtlasFile,
     deleteAtlasFile,
+    enableMappingPreview,
+    onFieldPreviewChange
   } = useAtlasmap({
     sourceFilter,
     targetFilter
@@ -72,7 +74,7 @@ const App: React.FC = () => {
     documentIsSource.current = true;
     openDeleteDocumentDialog();
   }, [openDeleteDocumentDialog]);
- 
+
   const handleDeleteTargetDocumentDialog = useCallback((id: GroupId) => {
     documentToDelete.current = id;
     documentIsSource.current = false;
@@ -97,6 +99,8 @@ const App: React.FC = () => {
         onSourceSearch={setSourceFilter}
         onTargetSearch={setTargetFilter}
         onExportAtlasFile={exportAtlasFile}
+        onShowMappingPreview={enableMappingPreview}
+        onFieldPreviewChange={onFieldPreviewChange}
       />
       {resetDialog}
       {deleteDocumentDialog}

--- a/ui-react/packages/atlasmap-ui/src/atlasmap/Atlasmap.tsx
+++ b/ui-react/packages/atlasmap-ui/src/atlasmap/Atlasmap.tsx
@@ -31,6 +31,7 @@ import {
   DragLayer,
   DropTarget,
   DocumentField,
+  DocumentFieldPreview, DocumentFieldPreviewResults,
 } from './components';
 import { MappingDetails } from './MappingDetails';
 
@@ -61,6 +62,8 @@ export interface IAtlasmapProps {
   onResetAtlasmap: () => void;
   onSourceSearch: (content: string) => void;
   onTargetSearch: (content: string) => void;
+  onShowMappingPreview: (enabled: boolean) => void;
+  onFieldPreviewChange: (id: string, value: string) => void;
 }
 
 export function Atlasmap({
@@ -79,6 +82,8 @@ export function Atlasmap({
   onResetAtlasmap,
   onSourceSearch,
   onTargetSearch,
+  onShowMappingPreview,
+  onFieldPreviewChange
 }: IAtlasmapProps) {
   const [selectedMapping, setSelectedMapping] = useState<string>();
   const [isEditingMapping, setisEditingMapping] = useState(false);
@@ -86,6 +91,12 @@ export function Atlasmap({
   const toggleShowTypes = useCallback(() => setShowTypes(!showTypes), [
     showTypes,
   ]);
+  const [showMappingPreview, setShowMappingPreview] = useState(false);
+  const toggleShowMappingPreview = useCallback(() => {
+    const newValue = !showMappingPreview;
+    setShowMappingPreview(newValue);
+    onShowMappingPreview(newValue);
+  }, [onShowMappingPreview, showMappingPreview]);
 
   const closeMappingDetails = useCallback(() => {
     setisEditingMapping(false);
@@ -173,11 +184,12 @@ export function Atlasmap({
             icon: <EyeIcon />,
             tooltip: 'Show mapping preview',
             ariaLabel: ' ',
+            callback: toggleShowMappingPreview
           },
         ]}
       />
     ),
-    [toggleShowTypes]
+    [toggleShowMappingPreview, toggleShowTypes]
   );
 
   return (
@@ -220,6 +232,7 @@ export function Atlasmap({
                     renderNode={(node, getCoords) => {
                       const { id, name, type } = node as IDocumentField &
                         (IFieldsNode | IFieldsGroup);
+                      const showPreview = isFieldPartOfSelection(id) && showMappingPreview;
                       return (
                         <DocumentField
                           id={id}
@@ -229,7 +242,13 @@ export function Atlasmap({
                           showType={showTypes}
                           getCoords={getCoords}
                           isSelected={isFieldPartOfSelection(id)}
-                        />
+                        >
+                          {showPreview &&
+                            <DocumentFieldPreview
+                              id={id}
+                              onChange={value => onFieldPreviewChange(id, value)}/>
+                          }
+                        </DocumentField>
                       );
                     }}
                     onDelete={() => onDeleteSourceDocument(s.id)}
@@ -284,7 +303,7 @@ export function Atlasmap({
                     title={t.name}
                     footer={
                       <DocumentFooter
-                        title="Target document"
+                        title='Target document'
                         type={t.type}
                         showType={showTypes}
                       />
@@ -294,6 +313,7 @@ export function Atlasmap({
                     renderNode={(node, getCoords) => {
                       const { id, name, type } = node as IDocumentField &
                         (IFieldsNode | IFieldsGroup);
+                      const showPreview = isFieldPartOfSelection(id) && showMappingPreview;
                       return (
                         <DocumentField
                           id={id}
@@ -303,7 +323,13 @@ export function Atlasmap({
                           showType={showTypes}
                           getCoords={getCoords}
                           isSelected={isFieldPartOfSelection(id)}
-                        />
+                        >
+                          {showPreview &&
+                            <DocumentFieldPreviewResults
+                              id={id}
+                              value={'TODO'}/>
+                          }
+                        </DocumentField>
                       );
                     }}
                     onDelete={() => onDeleteTargetDocument(t.id)}

--- a/ui-react/packages/atlasmap-ui/src/atlasmap/components/DocumentField.tsx
+++ b/ui-react/packages/atlasmap-ui/src/atlasmap/components/DocumentField.tsx
@@ -5,10 +5,10 @@ import { getEmptyImage } from 'react-dnd-html5-backend';
 import { useLinkNode } from '../../canvas';
 import { Coords, ElementId } from '../../views/CanvasView';
 
-
 const styles = StyleSheet.create({
   element: {
     display: 'flex',
+    flexFlow: 'column'
   },
   isSelected: {
     background: 'var(--pf-global--BackgroundColor--150)',
@@ -44,7 +44,8 @@ export const DocumentField: FunctionComponent<IDocumentFieldProps> = ({
   documentType,
   showType,
   getCoords,
-  isSelected
+  isSelected,
+  children
 }) => {
   const { setLineNode } = useLinkNode();
 
@@ -75,7 +76,8 @@ export const DocumentField: FunctionComponent<IDocumentFieldProps> = ({
         isDragging && styles.isDragging
       )}
     >
-      {name} {showType && `(${type})`}
+      <span>{name} {showType && `(${type})`}</span>
+      {children}
     </span>
   );
 };

--- a/ui-react/packages/atlasmap-ui/src/atlasmap/components/DocumentFieldPreview.tsx
+++ b/ui-react/packages/atlasmap-ui/src/atlasmap/components/DocumentFieldPreview.tsx
@@ -1,0 +1,22 @@
+import { Form, FormGroup, TextInput } from '@patternfly/react-core';
+import React, { FunctionComponent } from 'react';
+
+export interface IDocumentFieldPreviewProps {
+  id: string;
+  onChange: (value: string) => void;
+}
+
+export const DocumentFieldPreview: FunctionComponent<IDocumentFieldPreviewProps> = ({ id, onChange }) => {
+  return (
+    <Form style={{ marginTop: '0.5rem' }}>
+      <FormGroup label='Mapping preview' helperText='Type sample data here' fieldId={id}>
+        <TextInput
+          id={id}
+          type='text'
+          onChange={onChange}
+          aria-label='Type sample data here'
+        />
+      </FormGroup>
+    </Form>
+  )
+};

--- a/ui-react/packages/atlasmap-ui/src/atlasmap/components/DocumentFieldPreviewResults.tsx
+++ b/ui-react/packages/atlasmap-ui/src/atlasmap/components/DocumentFieldPreviewResults.tsx
@@ -1,0 +1,22 @@
+import { Form, FormGroup, TextInput } from '@patternfly/react-core';
+import React, { FunctionComponent } from 'react';
+
+export interface IDocumentFieldPreviewResultsProps {
+  id: string;
+  value: string;
+}
+
+export const DocumentFieldPreviewResults: FunctionComponent<IDocumentFieldPreviewResultsProps> = ({ id, value }) => {
+  return (
+    <Form style={{ marginTop: '0.5rem' }}>
+      <FormGroup label='Preview results' helperText='Results will be displayed here' fieldId={id}>
+        <TextInput
+          id={id}
+          type='text'
+          value={value}
+          aria-label='Mapping results preview'
+        />
+      </FormGroup>
+    </Form>
+  )
+};

--- a/ui-react/packages/atlasmap-ui/src/atlasmap/components/index.ts
+++ b/ui-react/packages/atlasmap-ui/src/atlasmap/components/index.ts
@@ -1,4 +1,6 @@
 export * from './DocumentField';
+export * from './DocumentFieldPreview';
+export * from './DocumentFieldPreviewResults';
 export * from './DocumentFooter';
 export * from './DragLayer';
 export * from './DropTarget';

--- a/ui-react/packages/atlasmap-ui/stories/Atlasmap.stories.tsx
+++ b/ui-react/packages/atlasmap-ui/stories/Atlasmap.stories.tsx
@@ -39,6 +39,8 @@ export const sample = () => createElement(() => {
       onTargetSearch={action('onTargetSearch')}
       onDeleteSourceDocument={action('onDeleteSourceDocument')}
       onDeleteTargetDocument={action('onDeleteTargetDocument')}
+      onShowMappingPreview={action('onShowMappingPreview')}
+      onFieldPreviewChange={action('onFieldPreviewChange')}
       pending={false}
       error={false}
     />


### PR DESCRIPTION
I also took a stab at the glue layer, but the functional approach used in the UI components is clashing badly with the RXjs state.

We also need to return back to the UI the preview values.

![Kapture 2019-12-06 at 18 43 57](https://user-images.githubusercontent.com/966316/70343872-a2753380-1858-11ea-8539-969b0bbc5b56.gif)
