### PR TITLE
feat(react-ui): improve the add to mapping flow

### DIFF
--- a/ui-react/packages/atlasmap-standalone/src/App.tsx
+++ b/ui-react/packages/atlasmap-standalone/src/App.tsx
@@ -42,13 +42,10 @@ const App: React.FC = () => {
   const [exportDialog, openExportDialog] = useSingleInputDialog({
     title: 'Export Mappings and Documents.',
     content: 'Please enter a name for your exported catalog file',
-    placeholder: 'atlasmap-mapping.adm',
+    defaultValue: 'atlasmap-mapping.adm',
     onConfirm: (closeDialog, value) => {
-      if (value!.length === 0) {
-        value = 'atlasmap-mapping.adm';
-      }
       closeDialog();
-      exportAtlasFile(value!);
+      exportAtlasFile(value);
     },
     onCancel: (closeDialog) => {
       closeDialog();
@@ -109,7 +106,6 @@ const App: React.FC = () => {
         sources={sources}
         targets={targets}
         mappings={mappings}
-        addToMapping={() => void 0}
         pending={pending}
         error={error}
         onImportAtlasFile={handleImportAtlasFile}
@@ -124,6 +120,8 @@ const App: React.FC = () => {
         onActiveMappingChange={changeActiveMapping}
         onShowMappingPreview={enableMappingPreview}
         onFieldPreviewChange={handleFieldPreviewChange}
+        onAddToMapping={() => void 0}
+        onCreateMapping={() => void 0}
       />
       {exportDialog}
       {deleteDocumentDialog}

--- a/ui-react/packages/atlasmap-ui/src/atlasmap/components/DocumentField.tsx
+++ b/ui-react/packages/atlasmap-ui/src/atlasmap/components/DocumentField.tsx
@@ -1,3 +1,5 @@
+import { AddCircleOIcon } from '@patternfly/react-icons';
+import { Button, Label } from '@patternfly/react-core';
 import { css, StyleSheet } from '@patternfly/react-styles';
 import React, { FunctionComponent, useEffect, useRef } from 'react';
 import { useDrag } from 'react-dnd';
@@ -8,18 +10,15 @@ import { Coords, ElementId } from '../../views/CanvasView';
 const styles = StyleSheet.create({
   element: {
     display: 'flex',
-    flexFlow: 'column'
-  },
-  isSelected: {
-    background: 'var(--pf-global--BackgroundColor--150)',
-    color: 'var(--pf-global--Color--100)',
-    padding: '0.5rem'
+    flexFlow: 'column',
   },
   isDragging: {
-    color: 'var(--pf-global--primary-color--100)',
+    color: 'var(--pf-global--active-color--400)',
+  },
+  isOver: {
+    color: 'var(--pf-global--active-color--400)',
   }
 });
-
 
 export interface IFieldElementDragSource {
   id: ElementId;
@@ -35,6 +34,9 @@ export interface IDocumentFieldProps {
   showType: boolean;
   getCoords: () => Coords | null;
   isSelected: boolean;
+  showAddToMapping: boolean;
+  isOver?: boolean;
+  onAddToMapping: () => void;
 }
 
 export const DocumentField: FunctionComponent<IDocumentFieldProps> = ({
@@ -45,7 +47,10 @@ export const DocumentField: FunctionComponent<IDocumentFieldProps> = ({
   showType,
   getCoords,
   isSelected,
-  children
+  showAddToMapping,
+  onAddToMapping,
+  isOver = false,
+  children,
 }) => {
   const { setLineNode } = useLinkNode();
 
@@ -54,7 +59,7 @@ export const DocumentField: FunctionComponent<IDocumentFieldProps> = ({
     IFieldElementDragSource,
     undefined,
     { isDragging: boolean }
-    >({
+  >({
     item: { id, type: documentType, name },
     collect: monitor => ({
       isDragging: monitor.isDragging(),
@@ -70,25 +75,36 @@ export const DocumentField: FunctionComponent<IDocumentFieldProps> = ({
 
   useEffect(() => {
     if (ref.current) {
-      ref.current.scrollIntoView({ behavior: 'smooth' })
+      ref.current.scrollIntoView({ behavior: 'smooth' });
     }
   }, [isSelected]);
 
-  const handleRef= (el: HTMLDivElement | null) => {
+  const handleRef = (el: HTMLDivElement | null) => {
     dragRef(el);
     ref.current = el;
   };
+
+  const content = isSelected ? <Label>{name}</Label> : name;
 
   return (
     <span
       ref={handleRef}
       className={css(
         styles.element,
-        isSelected && styles.isSelected,
+        isOver && styles.isOver,
         isDragging && styles.isDragging
       )}
     >
-      <span>{name} {showType && `(${type})`}</span>
+      <span>
+        {showAddToMapping ? (
+          <Button variant={'link'} onClick={onAddToMapping} isInline={true} icon={<AddCircleOIcon />}>
+            {content}
+          </Button>
+        ) : (
+          content
+        )}
+        {showType && ` (${type})`}
+      </span>
       {children}
     </span>
   );

--- a/ui-react/packages/atlasmap-ui/src/atlasmap/components/DropTarget.tsx
+++ b/ui-react/packages/atlasmap-ui/src/atlasmap/components/DropTarget.tsx
@@ -1,23 +1,22 @@
 import React, { FunctionComponent, ReactChild, useEffect } from 'react';
 import { useDrop } from 'react-dnd';
 import { useLinkNode } from '../../canvas';
-import { ElementId, IMappings, useLinkable } from '../../views/CanvasView';
+import { ElementId, useLinkable } from '../../views/CanvasView';
 import { IFieldElementDragSource } from './DocumentField';
 
 export interface IDropTargetProps {
-  node: IMappings;
-  addToMapping: (
+  onDrop: (
     elementId: ElementId,
-    mappingId: string
   ) => void;
   boxRef: HTMLElement | null;
+  isFieldDroppable: (documentType: string, fieldId: string) => boolean;
   children: (props: { isOver: boolean, canDrop: boolean }) => ReactChild;
 }
 
 export const DropTarget: FunctionComponent<IDropTargetProps> = ({
-  node,
-  addToMapping,
+  onDrop,
   boxRef,
+  isFieldDroppable,
   children
 }) => {
   const { ref, getLeftSideCoords, getRightSideCoords } = useLinkable({ getBoxRef: () => boxRef });
@@ -29,7 +28,7 @@ export const DropTarget: FunctionComponent<IDropTargetProps> = ({
     { isOver: boolean; canDrop: boolean, type?: string }
     >({
     accept: ['source', 'target'],
-    drop: item => addToMapping(item.id, node.id),
+    drop: item => onDrop(item.id),
     collect: monitor => ({
       isOver: monitor.isOver(),
       canDrop: monitor.canDrop(),
@@ -37,29 +36,7 @@ export const DropTarget: FunctionComponent<IDropTargetProps> = ({
     }),
     canDrop: (props, monitor) => {
       const type = monitor.getItemType();
-      if (node.sourceFields.length === 1 && node.targetFields.length === 1) {
-        if (
-          type === 'source' &&
-          !node.sourceFields.find(f => f.id === props.id)
-        ) {
-          return true;
-        } else if (!node.targetFields.find(f => f.id === props.id)) {
-          return true;
-        }
-      } else if (
-        type === 'source' &&
-        node.targetFields.length === 1 &&
-        !node.sourceFields.find(f => f.id === props.id)
-      ) {
-        return true;
-      } else if (
-        type === 'target' &&
-        node.sourceFields.length === 1 &&
-        !node.targetFields.find(f => f.id === props.id)
-      ) {
-        return true;
-      }
-      return false;
+      return isFieldDroppable(type as string, props.id);
     }
   });
 

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/CanvasView.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/CanvasView.tsx
@@ -3,17 +3,21 @@ import { DndProvider } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 import { CanvasLinksProvider } from '../../canvas';
 import { CanvasViewFieldsProvider } from './CanvasViewFieldsProvider';
-import { CanvasViewLayoutProvider } from './CanvasViewLayoutProvider';
+import { CanvasViewLayoutProvider, ICanvasViewLayoutProviderProps } from './CanvasViewLayoutProvider';
 import { CanvasViewCanvas } from './components';
 
-export const CanvasView: FunctionComponent = ({
+export interface ICanvasViewProps extends ICanvasViewLayoutProviderProps {
+}
+
+export const CanvasView: FunctionComponent<ICanvasViewProps> = ({
+  isMappingColumnVisible,
   children
 }) => {
   return (
     <DndProvider backend={HTML5Backend}>
       <CanvasLinksProvider>
         <CanvasViewCanvas>
-          <CanvasViewLayoutProvider>
+          <CanvasViewLayoutProvider isMappingColumnVisible={isMappingColumnVisible}>
             <CanvasViewFieldsProvider>
               {children}
             </CanvasViewFieldsProvider>

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/CanvasViewCanvasProvider.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/CanvasViewCanvasProvider.tsx
@@ -15,10 +15,7 @@ interface ICanvasViewContext {
 }
 const CanvasViewContext = createContext<ICanvasViewContext | undefined>(undefined);
 
-export interface ICanvasViewProviderProps {
-
-}
-export const CanvasViewCanvasProvider: FunctionComponent<ICanvasViewProviderProps> = ({
+export const CanvasViewCanvasProvider: FunctionComponent = ({
   children
 }) => {
   const { freeView } = useCanvasViewOptionsContext();

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/CanvasViewLayoutProvider.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/CanvasViewLayoutProvider.tsx
@@ -10,50 +10,65 @@ interface ICanvasViewLayoutContext {
   initialSourceCoords: Coords;
   initialMappingCoords: Coords;
   initialTargetCoords: Coords;
+  isMappingColumnVisible: boolean;
 }
-const CanvasViewLayoutContext = createContext<ICanvasViewLayoutContext | undefined>(undefined);
+const CanvasViewLayoutContext = createContext<
+  ICanvasViewLayoutContext | undefined
+>(undefined);
 
-export const CanvasViewLayoutProvider: FunctionComponent = ({
-  children
-}) => {
+export interface ICanvasViewLayoutProviderProps {
+  isMappingColumnVisible?: boolean;
+}
+
+export const CanvasViewLayoutProvider: FunctionComponent<
+  ICanvasViewLayoutProviderProps
+> = ({ isMappingColumnVisible = true, children }) => {
   const { height, width } = useCanvas();
+  const minBoxWidth = 280;
   const gutter = 30;
   const boxHeight = height - gutter * 2;
-  const sourceWidth = Math.max(250, (width / 6) * 2 - gutter * 2);
+  const sourceWidth = Math.max(minBoxWidth, (width / 6) * 2 - gutter * 2);
   const targetWidth = sourceWidth;
-  const mappingWidth = Math.max(300, width / 6 - gutter);
+  const mappingWidth = Math.max(minBoxWidth, width / 6 - gutter);
 
   const initialSourceCoords = { x: gutter, y: gutter };
   const initialMappingCoords = {
     x: initialSourceCoords.x + sourceWidth + gutter * 3,
     y: gutter,
   };
-  const initialTargetCoords = {
-    x: initialMappingCoords.x + mappingWidth + gutter * 3,
-    y: gutter,
-  };
+  const initialTargetCoords = isMappingColumnVisible
+   ? {
+      x: initialMappingCoords.x + mappingWidth + gutter * 3,
+      y: gutter,
+    } : {
+      x: initialMappingCoords.x + gutter,
+      y: gutter,
+    };
 
   return (
-    <CanvasViewLayoutContext.Provider value={{
-      boxHeight,
-      sourceWidth,
-      targetWidth,
-      mappingWidth,
-      initialSourceCoords,
-      initialMappingCoords,
-      initialTargetCoords,
-    }}>
+    <CanvasViewLayoutContext.Provider
+      value={{
+        boxHeight,
+        sourceWidth,
+        targetWidth,
+        mappingWidth,
+        initialSourceCoords,
+        initialMappingCoords,
+        initialTargetCoords,
+        isMappingColumnVisible,
+      }}
+    >
       {children}
     </CanvasViewLayoutContext.Provider>
-  )
-}
+  );
+};
 
 export function useCanvasViewLayoutContext() {
   const context = useContext(CanvasViewLayoutContext);
   if (!context) {
     throw new Error(
-      `CanvasViewLayout compound components cannot be rendered outside the CanvasViewLayout component`,
-    )
+      `CanvasViewLayout compound components cannot be rendered outside the CanvasViewLayout component`
+    );
   }
   return context;
 }

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/CanvasViewOptionsProvider.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/CanvasViewOptionsProvider.tsx
@@ -2,8 +2,6 @@ import React, { createContext, FunctionComponent, useCallback, useContext, useSt
 interface ICanvasViewOptionsContext {
   freeView: boolean;
   toggleFreeView: () => void;
-  materializedMappings: boolean;
-  toggleMaterializedMappings: () => void;
 }
 const CanvasViewOptionsContext = createContext<ICanvasViewOptionsContext | undefined>(undefined);
 
@@ -11,8 +9,6 @@ export const CanvasViewOptionsProvider: FunctionComponent = ({
   children
 }) => {
   const [freeView, setFreeView] = useState(false);
-  const [materializedMappings, setMaterializedMappings] = useState(true);
-
   const toggleFreeView = useCallback(() =>
       setFreeView(!freeView),
     [
@@ -20,22 +16,15 @@ export const CanvasViewOptionsProvider: FunctionComponent = ({
       setFreeView,
     ]);
 
-  const toggleMaterializedMappings = useCallback(
-    () => setMaterializedMappings(!materializedMappings),
-    [setMaterializedMappings, materializedMappings]
-  );
-
   return (
     <CanvasViewOptionsContext.Provider value={{
       freeView,
-      toggleFreeView,
-      materializedMappings,
-      toggleMaterializedMappings
+      toggleFreeView
     }}>
       {children}
     </CanvasViewOptionsContext.Provider>
   )
-}
+};
 
 export function useCanvasViewOptionsContext() {
   const context = useContext(CanvasViewOptionsContext);

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/CanvasViewControlBar.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/CanvasViewControlBar.tsx
@@ -8,8 +8,7 @@ import {
   SearchMinusIcon,
   ExpandArrowsAltIcon,
   ExpandIcon,
-  PficonDragdropIcon,
-  LinkIcon
+  PficonDragdropIcon
 } from '@patternfly/react-icons';
 import { useCanvasViewOptionsContext } from '../CanvasViewOptionsProvider';
 import { useCanvasViewContext } from '../CanvasViewCanvasProvider';
@@ -26,8 +25,7 @@ export const CanvasViewControlBar: FunctionComponent<ICanvasViewControlBarProps>
 
   const {
     freeView,
-    toggleFreeView,
-    toggleMaterializedMappings
+    toggleFreeView
   } = useCanvasViewOptionsContext();
 
   const handleZoomIn = useCallback(() => {
@@ -92,17 +90,10 @@ export const CanvasViewControlBar: FunctionComponent<ICanvasViewControlBarProps>
             ariaLabel: ' ',
             callback: toggleFreeView
           },
-          {
-            id: 'Toggle mappings column',
-            icon: <LinkIcon />,
-            tooltip: 'Toggle mappings column',
-            ariaLabel: ' ',
-            callback: toggleMaterializedMappings
-          },
           ...extraButtons
         ],
       }),
-    [freeView, handleZoomIn, handleZoomOut, handleViewReset, toggleFreeView, toggleMaterializedMappings, extraButtons]
+    [freeView, handleZoomIn, handleZoomOut, handleViewReset, toggleFreeView, extraButtons]
   );
 
   return (

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Document.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Document.tsx
@@ -72,7 +72,7 @@ const styles = StyleSheet.create({
   },
 });
 
-export interface IDocumentProps extends Pick<IFieldGroupProps, 'renderNode'> {
+export interface IDocumentProps extends Pick<IFieldGroupProps, 'renderNode'>, Pick<IFieldGroupProps, 'renderGroup'> {
   title: ReactElement | string;
   footer: ReactElement | string;
   fields: IFieldsGroup;
@@ -86,10 +86,11 @@ export function Document({
   lineConnectionSide,
   fields,
   renderNode,
+  renderGroup,
   onDelete,
 }: IDocumentProps) {
   const ref = useRef<HTMLDivElement | null>(null);
-  const [isUserExpanded, setIsUserExpanded] = useState(false);
+  const [isUserExpanded, setIsUserExpanded] = useState(true);
   const [shouldBeExpanded, setShouldBeExpanded] = useState(false);
   const toggleIsExpanded = () => setIsUserExpanded(!isUserExpanded);
   const [showActions, setShowActions] = useState(false);
@@ -174,6 +175,7 @@ export function Document({
                 parentExpanded={isExpanded}
                 expandParent={setShouldBeExpanded}
                 renderNode={renderNode}
+                renderGroup={renderGroup}
               />
             </Accordion>
           </div>

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/FieldElement.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/FieldElement.tsx
@@ -1,23 +1,23 @@
 import { css, StyleSheet } from '@patternfly/react-styles';
 import React, {
-  ReactElement,
+  ReactChild,
   useEffect,
 } from 'react';
 import { useLinkNode } from '../../../canvas';
 import { useCanvasViewFieldsContext } from '../CanvasViewFieldsProvider';
-import { Coords, IFieldsGroup, IFieldsNode } from '../models';
+import { Coords, IFieldsNode } from '../models';
 import { useLinkable } from './useLinkable';
 
 const styles = StyleSheet.create({
   element: {
     padding:
-      'var(--pf-c-accordion__toggle--PaddingTop) var(--pf-c-accordion__toggle--PaddingRight) var(--pf-c-accordion__toggle--PaddingBottom) calc(var(--pf-c-accordion__toggle--PaddingLeft))',
+      '0.1rem var(--pf-c-accordion__toggle--PaddingRight) 0.1rem calc(var(--pf-c-accordion__toggle--PaddingLeft))',
     cursor: 'pointer',
   },
   rightAlign: {
     transform: 'scaleX(-1)',
     padding:
-      'var(--pf-c-accordion__toggle--PaddingTop) var(--pf-c-accordion__toggle--PaddingLeft) var(--pf-c-accordion__toggle--PaddingBottom) var(--pf-c-accordion__toggle--PaddingRight)',
+      '0.1rem var(--pf-c-accordion__toggle--PaddingLeft) 0.1rem var(--pf-c-accordion__toggle--PaddingRight)',
   },
 });
 
@@ -28,9 +28,10 @@ export interface IFieldElementProps {
   getBoxRef: () => HTMLElement | null;
   rightAlign?: boolean;
   renderNode: (
-    node: IFieldsGroup | IFieldsNode,
+    node: IFieldsNode,
     getCoords: () => Coords | null,
-  ) => ReactElement;
+    boxRef: HTMLElement | null
+  ) => ReactChild;
   expandParent: (expanded: boolean) => void;
 }
 
@@ -65,7 +66,7 @@ export function FieldElement ({
       ref={ref}
       className={css(styles.element, rightAlign && styles.rightAlign)}
     >
-      {renderNode(node as IFieldsNode, getCoords)}
+      {renderNode(node as IFieldsNode, getCoords, getBoxRef())}
     </div>
   );
 }

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/FieldGroup.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/FieldGroup.tsx
@@ -6,6 +6,7 @@ import {
 import { FolderOpenIcon, FolderCloseIcon } from '@patternfly/react-icons';
 import { css, StyleSheet } from '@patternfly/react-styles';
 import React, {
+  ReactChild,
   useCallback,
   useEffect,
   useMemo,
@@ -60,6 +61,10 @@ export interface IFieldGroupProps extends Pick<IFieldElementProps, 'renderNode'>
   level?: number;
   parentExpanded: boolean;
   expandParent?: (expanded: boolean) => void;
+  renderGroup: (
+    node: IFieldsGroup
+  ) => ReactChild;
+
 }
 export function FieldGroup({
   isVisible,
@@ -72,6 +77,7 @@ export function FieldGroup({
   parentExpanded,
   expandParent,
   renderNode,
+  renderGroup,
 }: IFieldGroupProps) {
   const { setLineNode } = useLinkNode();
   const { ref, getLeftSideCoords, getRightSideCoords } = useLinkable({ getBoxRef, getParentRef });
@@ -141,12 +147,13 @@ export function FieldGroup({
             key={f.id}
             level={level + 1}
             parentExpanded={parentExpanded}
+            renderGroup={renderGroup}
             renderNode={renderNode}
             expandParent={setExpanded}
           />
         )
       ),
-    [group.fields, lineConnectionSide, getBoxRef, rightAlign, renderNode, isVisible, isExpanded, level, parentExpanded, ref, getParentRef, setExpanded]
+    [group.fields, lineConnectionSide, getBoxRef, rightAlign, renderNode, renderGroup, isVisible, isExpanded, level, parentExpanded, ref, getParentRef, setExpanded]
   );
 
   return level === 0 ? (
@@ -175,7 +182,7 @@ export function FieldGroup({
           >
             {isExpanded ? <FolderOpenIcon /> : <FolderCloseIcon />}
             <span>&nbsp;</span>
-            {renderNode(group as IFieldsGroup, getCoords)}
+            {renderGroup(group)}
           </span>
         </AccordionToggle>
         <AccordionContent

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/FieldsBox.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/FieldsBox.tsx
@@ -11,7 +11,7 @@ export interface IMappingsBoxProps extends HTMLAttributes<HTMLDivElement> {
   initialHeight: number;
   position: Coords;
   header: ReactElement | string;
-  hidden: boolean;
+  visible?: boolean;
   rightAlign?: boolean;
 }
 export const FieldsBox: FunctionComponent<IMappingsBoxProps> = ({
@@ -21,7 +21,7 @@ export const FieldsBox: FunctionComponent<IMappingsBoxProps> = ({
   position,
   header,
   rightAlign = false,
-  hidden,
+  visible = true,
   children,
   ...props
 }) => {
@@ -54,7 +54,7 @@ export const FieldsBox: FunctionComponent<IMappingsBoxProps> = ({
         ref={ref}
         style={{
           height: scrollable ? '100%' : undefined,
-          opacity: hidden ? 0 : 1,
+          opacity: visible ? 1 : 0,
         }}
         {...props}
       >

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Links.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Links.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { CanvasLink } from '../../../canvas';
-import { useCanvasViewOptionsContext } from '../CanvasViewOptionsProvider';
+import { useCanvasViewLayoutContext } from '../CanvasViewLayoutProvider';
 import { IMappings } from '../models';
 import { useMappingLinks } from './useMappingLinks';
 import { useSourceTargetLinks } from './useSourceTargetLinks';
@@ -10,12 +10,12 @@ export interface ILinksProps {
   selectedMapping: string | undefined;
 }
 export const Links: FunctionComponent<ILinksProps> = ({ mappings, selectedMapping }) => {
-  const { materializedMappings } = useCanvasViewOptionsContext();
+  const { isMappingColumnVisible } = useCanvasViewLayoutContext();
   const { links: smtLinks } = useMappingLinks({ mappings, selectedMapping });
-  const { links: stLinks } = useSourceTargetLinks({ mappings });
+  const { links: stLinks } = useSourceTargetLinks({ mappings, selectedMapping });
   return (
     <g>
-      {(materializedMappings ? smtLinks : stLinks).map(({ id, start, end, color }) => (
+      {(isMappingColumnVisible ? smtLinks : stLinks).map(({ id, start, end, color }) => (
         <CanvasLink key={id} start={start} end={end} color={color} />
       ))}
     </g>

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Mapping.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Mapping.tsx
@@ -1,7 +1,6 @@
 import { css, StyleSheet } from '@patternfly/react-styles';
 import React, { FunctionComponent, ReactElement, useRef } from 'react';
 import { useCanvasViewLayoutContext } from '../CanvasViewLayoutProvider';
-import { useCanvasViewOptionsContext } from '../CanvasViewOptionsProvider';
 import { FieldsBox } from './FieldsBox';
 
 const styles = StyleSheet.create({
@@ -18,7 +17,7 @@ export interface IMappingProps {
 }
 
 export const Mapping: FunctionComponent<IMappingProps> = ({ children }) => {
-  const { materializedMappings } = useCanvasViewOptionsContext();
+  const { isMappingColumnVisible } = useCanvasViewLayoutContext();
   const { mappingWidth, boxHeight, initialMappingCoords } = useCanvasViewLayoutContext();
   const ref = useRef<HTMLDivElement | null>(null);
   return (
@@ -28,7 +27,7 @@ export const Mapping: FunctionComponent<IMappingProps> = ({ children }) => {
       initialHeight={boxHeight}
       position={initialMappingCoords}
       header={'Mapping'}
-      hidden={!materializedMappings}
+      visible={isMappingColumnVisible}
     >
       <div
         className={css(styles.content)}

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/MappingElement.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/MappingElement.tsx
@@ -33,10 +33,10 @@ const styles = StyleSheet.create({
     border: '2px solid transparent',
   },
   selected: {
-    borderColor: 'var(--pf-global--primary-color--100) !important',
+    borderColor: 'var(--pf-global--active-color--400) !important',
   },
   dropTarget: {
-    borderColor: 'var(--pf-global--primary-color--100) !important',
+    borderColor: 'var(--pf-global--active-color--400) !important',
   },
   canDrop: {
     borderColor: 'var(--pf-global--success-color--100) !important',

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Source.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Source.tsx
@@ -19,7 +19,6 @@ export const Source: FunctionComponent<ISourceProps> = ({ children, header }) =>
       initialHeight={boxHeight}
       position={initialSourceCoords}
       header={header}
-      hidden={false}
     >
       {children}
     </FieldsBox>

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Target.tsx
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/Target.tsx
@@ -16,7 +16,6 @@ export const Target: FunctionComponent<ITargetProps> = ({ children, header }) =>
       position={initialTargetCoords}
       header={header}
       rightAlign={true}
-      hidden={false}
     >
       {children}
     </FieldsBox>

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/useMappingLinks.ts
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/useMappingLinks.ts
@@ -19,7 +19,7 @@ export function useMappingLinks({ mappings, selectedMapping }: IUseMappingsLinks
     (lines, { id, sourceFields, targetFields }, idx) => {
       const isMappingSelected = id === selectedMapping;
       const color = selectedMapping ? (
-        isMappingSelected ? 'var(--pf-global--primary-color--100)' : '#ccc'
+        isMappingSelected ? 'var(--pf-global--active-color--400)' : '#ccc'
       ) : colors(idx);
       const sourcesToMappings = sourceFields.map(source => ({
         start: source.id,
@@ -46,7 +46,7 @@ export function useMappingLinks({ mappings, selectedMapping }: IUseMappingsLinks
       {
         start: 'dragsource',
         end: 'dragtarget',
-        color: 'var(--pf-global--primary-color--100)'
+        color: 'var(--pf-global--active-color--400)'
       }
     ]
   ),

--- a/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/useSourceTargetLinks.ts
+++ b/ui-react/packages/atlasmap-ui/src/views/CanvasView/components/useSourceTargetLinks.ts
@@ -6,16 +6,20 @@ import { IMappings } from '../models';
 
 export interface IUseSourceTargetLinksArgs {
   mappings: IMappings[];
+  selectedMapping: string | undefined;
 }
-export function useSourceTargetLinks({ mappings }: IUseSourceTargetLinksArgs) {
+export function useSourceTargetLinks({ selectedMapping, mappings }: IUseSourceTargetLinksArgs) {
   const colors = useMemo(
     () => scaleSequential(interpolateRainbow).domain([0, mappings.length]),
     [mappings]
   );
 
   const linkedNodes = mappings.reduce<SourceTargetNodes[]>(
-    (lines, { sourceFields, targetFields }, idx) => {
-      const color = colors(idx);
+    (lines, { id, sourceFields, targetFields }, idx) => {
+      const isMappingSelected = id === selectedMapping;
+      const color = selectedMapping ? (
+        isMappingSelected ? 'var(--pf-global--active-color--400)' : '#ccc'
+      ) : colors(idx);
       const mappingLines = sourceFields.reduce<SourceTargetNodes[]>(
         (lines, start) => {
           const linesFromSource = targetFields.map(end => ({
@@ -27,7 +31,9 @@ export function useSourceTargetLinks({ mappings }: IUseSourceTargetLinksArgs) {
         },
         []
       );
-      return [...lines, ...mappingLines];
+      return isMappingSelected
+        ? [...lines, ...mappingLines]
+        : [...mappingLines, ...lines];
     },
     []
   );

--- a/ui-react/packages/atlasmap-ui/stories/Atlasmap.stories.tsx
+++ b/ui-react/packages/atlasmap-ui/stories/Atlasmap.stories.tsx
@@ -24,12 +24,23 @@ export const sample = () => createElement(() => {
     setMappings(updatedMappings)
   };
 
+  const createMapping = (sourceId: ElementId, targetId: ElementId) => {
+    setMappings([
+      ...mappings,
+      {
+        id: `${Date.now()}`,
+        name: 'One to One (mock)',
+        sourceFields: [{id: sourceId, name: sourceId, tip: sourceId}],
+        targetFields: [{id: targetId, name: targetId, tip: targetId}],
+      }
+    ])
+  };
+
   return (
     <Atlasmap
       sources={sources}
       targets={targets}
       mappings={mappings}
-      addToMapping={addToMapping}
       onImportAtlasFile={action('importAtlasFile')}
       onImportSourceDocument={action('onImportSourceDocument')}
       onImportTargetDocument={action('onImportTargetDocument')}
@@ -42,6 +53,8 @@ export const sample = () => createElement(() => {
       onActiveMappingChange={action('onActiveMappingChange')}
       onShowMappingPreview={action('onShowMappingPreview')}
       onFieldPreviewChange={action('onFieldPreviewChange')}
+      onAddToMapping={addToMapping}
+      onCreateMapping={createMapping}
       pending={false}
       error={false}
     />

--- a/ui-react/packages/atlasmap-ui/stories/sampleData.tsx
+++ b/ui-react/packages/atlasmap-ui/stories/sampleData.tsx
@@ -938,7 +938,7 @@ export const targets = [
 export const mappings = [
   {
     id: 'a',
-    name: 'Lorem',
+    name: 'Many To One(Concatenate)',
     sourceFields: [
       {
         id: 'JSONInstanceSource-/order/address/city',
@@ -961,7 +961,7 @@ export const mappings = [
   },
   {
     id: 'b',
-    name: 'Lorem',
+    name: 'One to Many (Split)',
     sourceFields: [
       {
         id: 'JSONInstanceSource-/primitives/numberPrimitive',
@@ -989,7 +989,7 @@ export const mappings = [
   },
   {
     id: 'c',
-    name: 'Lorem',
+    name: 'Many to One (Concatenate)',
     sourceFields: [
       {
         id: 'JSONInstanceSource-/primitives/stringPrimitive',

--- a/ui-react/packages/atlasmap-ui/stories/views/CanvasView/Document.stories.tsx
+++ b/ui-react/packages/atlasmap-ui/stories/views/CanvasView/Document.stories.tsx
@@ -28,7 +28,8 @@ export const interactive = () => (
         footer={text('footer', 'Source document')}
         lineConnectionSide={'right'}
         fields={s}
-        renderNode={node => <>{node.id}</>}
+        renderGroup={node => node.id}
+        renderNode={node => node.id}
         onDelete={action('onDelete Source')}
       />
     </CanvasLinksProvider>

--- a/ui-react/packages/atlasmap-ui/stories/views/CanvasView/FieldGroup.stories.tsx
+++ b/ui-react/packages/atlasmap-ui/stories/views/CanvasView/FieldGroup.stories.tsx
@@ -32,7 +32,8 @@ export const interactiveExample = () => (
         }}
         getBoxRef={() => null}
         parentExpanded={boolean('Parent expanded', true)}
-        renderNode={node => <>{node.id}</>}
+        renderGroup={node => node.id}
+        renderNode={node => node.id}
       />
     </CanvasLinksProvider>
   </CanvasProvider>

--- a/ui-react/packages/atlasmap-ui/stories/views/CanvasView/FieldsBox.stories.tsx
+++ b/ui-react/packages/atlasmap-ui/stories/views/CanvasView/FieldsBox.stories.tsx
@@ -25,7 +25,7 @@ export const interactive = () => (
           initialHeight={number('Height', 300)}
           position={{ x: number('X', 10), y: number('Y', 10)}}
           header={text('Header', 'Sample header')}
-          hidden={boolean('Hidden', false)}
+          visible={boolean('Hidden', false)}
         >
           {text('Children', 'lorem dolor')}
         </FieldsBox>

--- a/ui-react/packages/atlasmap-ui/stories/views/CanvasView/MappingElement.stories.tsx
+++ b/ui-react/packages/atlasmap-ui/stories/views/CanvasView/MappingElement.stories.tsx
@@ -28,7 +28,7 @@ const Wrapper: FunctionComponent = ({ children }) => (
           initialHeight={400}
           position={{ x: 10, y: 10}}
           header={'Mappings'}
-          hidden={false}
+          visible={false}
         >
           {children}
         </FieldsBox>


### PR DESCRIPTION
## Quickly create a mapping 

![Kapture 2019-12-11 at 13 00 11](https://user-images.githubusercontent.com/966316/70621633-57716c80-1c1a-11ea-8c43-04d05c1dca4c.gif)

## Improved add to mapping flow
![Kapture 2019-12-11 at 12 06 04](https://user-images.githubusercontent.com/966316/70621715-7f60d000-1c1a-11ea-801d-3a930c6e6285.gif)

* with nothing selected, fields can be drag & dropped on any existing mapping (if possible)
* with a mapping selected, fields can still be drag & dropped as before but they'll also show a button to hint that it can be quickly added (with a click) to the selected mapping (if possible)
* with a mapping in editing mode, the mapping column is automatically hidden and d&d is disabled; fields can still be added using the buttons
