### PR TITLE
fix: correct app component template for selector atlasmap-dev-root

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atlasmap/atlasmap-data-mapper",
-  "version": "1.43.0-SNAPSHOT",
+  "version": "1.44.0-SNAPSHOT",
   "description": "Atlasmap Data Mapper UI module.",
   "author": "AtlasMap",
   "license": "Apache-2.0",

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -18,7 +18,8 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'atlasmap-dev-root',
-  template: '<router-outlet></router-outlet>',
+  template: '<data-mapper-example-host></data-mapper-example-host>',  // Required for vscode
+  // template: '<router-outlet></router-outlet>',
 })
 
 export class AppComponent {}


### PR DESCRIPTION
in support of vscode.  WIll need to get migrated to 1.43.x
Fixes: #1704