### PR TITLE
fix: enable toggle mappings when mapping details is open

### DIFF
--- a/ui-react/packages/atlasmap-core/src/Atlasmap.tsx
+++ b/ui-react/packages/atlasmap-core/src/Atlasmap.tsx
@@ -141,7 +141,7 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
       targets={targets}
       mappings={mappings}
       onActiveMappingChange={changeActiveMapping}
-      renderMappingDetails={({ mapping, closeDetails }) => (
+      renderMappingDetails={({ mapping, closeDetails }) => (mapping) && (
         <AtlasmapMappingDetails
           mapping={(mapping as IAtlasmapMapping).mapping}
           closeDetails={closeDetails}

--- a/ui-react/packages/atlasmap-ui/src/AtlasmapUI/AtlasmapCanvasView/AtlasmapCanvasViewMappings.tsx
+++ b/ui-react/packages/atlasmap-ui/src/AtlasmapUI/AtlasmapCanvasView/AtlasmapCanvasViewMappings.tsx
@@ -10,6 +10,7 @@ export const AtlasmapCanvasViewMappings: FunctionComponent = () => {
     selectedMapping,
     selectMapping,
     deselectMapping,
+    closeMappingDetails,
     editMapping,
   } = useAtlasmapUI();
   return (
@@ -33,6 +34,7 @@ export const AtlasmapCanvasViewMappings: FunctionComponent = () => {
                     selectedMapping={selectedMapping}
                     selectMapping={selectMapping}
                     deselectMapping={deselectMapping}
+                    closeMappingDetails={closeMappingDetails}
                     editMapping={editMapping}
                     canDrop={canDrop}
                     isOver={isOver}

--- a/ui-react/packages/atlasmap-ui/src/AtlasmapUI/AtlasmapUIProvider.tsx
+++ b/ui-react/packages/atlasmap-ui/src/AtlasmapUI/AtlasmapUIProvider.tsx
@@ -61,10 +61,8 @@ export const AtlasmapUIProvider: FunctionComponent<
 
   const selectMapping = useCallback(
     (mapping: string) => {
-      if (!isEditingMapping) {
-        onActiveMappingChange(mapping);
-        setSelectedMapping(mapping);
-      }
+      onActiveMappingChange(mapping);
+      setSelectedMapping(mapping);
     },
     [isEditingMapping, onActiveMappingChange]
   );

--- a/ui-react/packages/atlasmap-ui/src/CanvasView/components/MappingElement.tsx
+++ b/ui-react/packages/atlasmap-ui/src/CanvasView/components/MappingElement.tsx
@@ -55,6 +55,7 @@ export interface IMappingElementProps {
   selectedMapping: string | undefined;
   selectMapping: (id: string) => void;
   deselectMapping: () => void;
+  closeMappingDetails: () => void;
   editMapping: () => void;
   canDrop: boolean;
   isOver: boolean;
@@ -66,6 +67,7 @@ export const MappingElement: FunctionComponent<IMappingElementProps> = ({
   selectedMapping,
   selectMapping,
   deselectMapping,
+  closeMappingDetails,
   editMapping,
   canDrop,
   isOver,
@@ -83,11 +85,12 @@ export const MappingElement: FunctionComponent<IMappingElementProps> = ({
   const handleSelect = useCallback(() => {
     wasPreviouslySelected.current = true;
     if (isSelected) {
+      closeMappingDetails();
       deselectMapping();
     } else {
       selectMapping(node.id);
     }
-  }, [isSelected, node, deselectMapping, selectMapping]);
+  }, [closeMappingDetails, isSelected, node, deselectMapping, selectMapping]);
 
   const handleEdit = useCallback(
     (e: MouseEvent) => {


### PR DESCRIPTION
Fixes: #1742

If you had Mapoping details open and selected another mapping the UI would blow up.  This now keeps mapping details open and matches it to the selected mapping.  If you select the existing mapping while mapping details is open it toggles the selected mapping and closes the mapping details pane.