### PR TITLE
chore: Upgrade to Camel 3.1

### DIFF
--- a/camel/pom.xml
+++ b/camel/pom.xml
@@ -45,6 +45,10 @@
       <artifactId>camel-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-support</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.atlasmap</groupId>
       <artifactId>atlas-api</artifactId>
     </dependency>

--- a/camel/src/main/java/org/apache/camel/component/atlasmap/AtlasComponent.java
+++ b/camel/src/main/java/org/apache/camel/component/atlasmap/AtlasComponent.java
@@ -20,9 +20,9 @@ package org.apache.camel.component.atlasmap;
 import java.util.Map;
 
 import org.apache.camel.Endpoint;
-import org.apache.camel.impl.DefaultComponent;
 import org.apache.camel.spi.Metadata;
-import org.apache.camel.util.ResourceHelper;
+import org.apache.camel.support.DefaultComponent;
+import org.apache.camel.support.ResourceHelper;
 
 import io.atlasmap.api.AtlasContextFactory;
 

--- a/camel/src/test/java/org/apache/camel/component/atlasmap/AtlasEndpointTest.java
+++ b/camel/src/test/java/org/apache/camel/component/atlasmap/AtlasEndpointTest.java
@@ -150,7 +150,6 @@ public class AtlasEndpointTest {
             }
         }).when(outMessage).setBody(any());
         doNothing().when(outMessage).setHeaders(any());
-        doNothing().when(outMessage).setAttachments(any());
         if (targetDocId == null) {
             when(session.getDefaultTargetDocument()).thenAnswer(new Answer<Object>() {
                 @Override
@@ -169,7 +168,7 @@ public class AtlasEndpointTest {
                 }
             });
         }
-        when(exchange.getOut()).thenReturn(outMessage);
+        when(exchange.getMessage()).thenReturn(outMessage);
         endpoint.onExchange(exchange);
     }
 

--- a/camel/src/test/java/org/apache/camel/component/atlasmap/AtlasMapMultiDocsTest.java
+++ b/camel/src/test/java/org/apache/camel/component/atlasmap/AtlasMapMultiDocsTest.java
@@ -6,15 +6,13 @@ import static org.xmlunit.assertj.XmlAssert.assertThat;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.xml.bind.JAXBElement;
-
 import org.apache.camel.CamelContext;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.impl.DefaultMessage;
+import org.apache.camel.support.DefaultMessage;
 import org.apache.camel.test.spring.CamelSpringRunner;
 import org.apache.camel.test.spring.CamelTestContextBootstrapper;
 import org.junit.After;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -39,7 +39,7 @@
     <atlas.version.range>[1,3)</atlas.version.range>
     <bcel-bundle-version>5.2_4</bcel-bundle-version>
     <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
-    <camel.version>2.23.4</camel.version>
+    <camel.version>3.1.0-SNAPSHOT</camel.version>
     <daffodil.version>2.5.0</daffodil.version>
     <fabric8-maven-plugin.version>4.4.0</fabric8-maven-plugin.version>
     <hamcrest.version>1.3</hamcrest.version>
@@ -76,8 +76,8 @@
     <resteasy-spring-boot-starter.version>4.4.0.Final</resteasy-spring-boot-starter.version>
     <selenium.version>3.141.59</selenium.version>
     <slf4j.version>1.7.30</slf4j.version>
-    <spring.version>5.1.13.RELEASE</spring.version>
-    <spring-boot.version>2.1.12.RELEASE</spring-boot.version>
+    <spring.version>5.2.3.RELEASE</spring.version>
+    <spring-boot.version>2.2.4.RELEASE</spring-boot.version>
     <swagger.version>1.6.0</swagger.version>
     <swagger-maven-plugin.version>3.1.8</swagger-maven-plugin.version>
     <swagger2markup.version>1.3.3</swagger2markup.version>
@@ -428,6 +428,11 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core</artifactId>
+        <version>${camel.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-support</artifactId>
         <version>${camel.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
This upgrades to Camel 3.1. Notable changes are that the in/out pattern
on Exchange is now deprecated and Exchange how has the `message`
property. With that the original message can be mutated with the new
body resulting from the transformation.