### PR TITLE
fix: UI_REACT: Deselect current mapping when background clicked

### DIFF
--- a/ui-react/packages/atlasmap-ui/src/Canvas/CanvasTransforms.tsx
+++ b/ui-react/packages/atlasmap-ui/src/Canvas/CanvasTransforms.tsx
@@ -1,5 +1,6 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useCallback } from 'react';
 import { useCanvas } from './CanvasContext';
+import { useAtlasmapUI } from '../AtlasmapUI/AtlasmapUIProvider';
 
 export const CanvasTransforms: FunctionComponent = ({ children }) => {
   const { panX, panY, zoom /* width, height, xDomain, yDomain*/ } = useCanvas();
@@ -7,12 +8,26 @@ export const CanvasTransforms: FunctionComponent = ({ children }) => {
   // const originY = height / 2;
   // const x = xDomain(zoom * (panX + originX) - originX);
   // const y = yDomain(zoom * (panY + originY) - originY);
+  const {
+    deselectMapping,
+    closeMappingDetails,
+    selectedMapping,
+  } = useAtlasmapUI();
+
+  const handleSelect = useCallback(() => {
+    if (selectedMapping) {
+      closeMappingDetails();
+      deselectMapping();
+    }
+  }, [selectedMapping, closeMappingDetails, deselectMapping]);
+
   return (
     <g
       transform={`
         translate(${panX} ${panY})
         scale(${zoom})
       `}
+      onClick={handleSelect}
     >
       {children}
     </g>


### PR DESCRIPTION
Fixes: #1806 

I'm guessing, however, that there might be a more appropriate way to fix this. Based on previous comments, I believe this violates the division between the 'generic' REACT components we've created and the AtlasMap-specific ones. Should I instead place this code in a new AtlasMap component that gets inserted after AtlasmapLayout and before CanvasTransform?