### PR TITLE
feat(project): publish storybooks on Netlify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ yarn.lock
 yarn-error.log
 package-lock.json
 /package.json
+_netflify
 
 .idea
 *.iml

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/4acba1646e0a4cbabac3a76ad5df4df7)](https://www.codacy.com/app/atlasmapio/atlasmap?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=atlasmap/atlasmap&amp;utm_campaign=Badge_Grade)
 [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/4acba1646e0a4cbabac3a76ad5df4df7)](https://www.codacy.com/app/atlasmapio/atlasmap?utm_source=github.com&utm_medium=referral&utm_content=atlasmap/atlasmap&utm_campaign=Badge_Coverage)
 [![Gitter chat](https://badges.gitter.im/atlasmap/community.png)](https://gitter.im/atlasmap/community)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/08a56260-a890-4ffb-9c6d-7b7be24f0cc7/deploy-status)](https://app.netlify.com/sites/atlasmap/deploys)
 [Google Group](https://groups.google.com/d/forum/atlasmap)
 
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+  base = "ui-react/"
+  command = "make netlify"
+  publish = "_netlify"

--- a/ui-react/Makefile
+++ b/ui-react/Makefile
@@ -1,0 +1,34 @@
+BUILD_DIR = ./_netlify
+BUILD_DIR_TEMPLATE = ./_netlify_template
+UI = .
+UI_PACKAGES = ${UI}/packages
+
+netlify:
+	@echo Building Netlify website
+
+	make netlify-clean
+	make netlify-build-modules
+	make netlify-build-storybooks
+	make netlify-prepare-dist
+	make netlify-collect-storybooks
+
+netlify-clean:
+	@echo Cleanup
+	rm -rf ${BUILD_DIR}
+	
+netlify-build-modules:
+	@echo Build all modules
+	(cd ${UI}; yarn build:module)
+	
+netlify-build-storybooks:
+	@echo Build all storybooks
+	(cd ${UI}; yarn build:storybook)
+
+netlify-prepare-dist:
+	@echo Create dist
+	cp -a ${BUILD_DIR_TEMPLATE} ${BUILD_DIR}
+
+netlify-collect-storybooks:
+	@echo Collect built storybooks
+	cp -a ${UI_PACKAGES}/atlasmap-ui/storybook-static ${BUILD_DIR}/atlasmap-ui
+	cp -a ${UI_PACKAGES}/atlasmap-core/storybook-static ${BUILD_DIR}/atlasmap-core

--- a/ui-react/_netlify_template/index.html
+++ b/ui-react/_netlify_template/index.html
@@ -1,0 +1,3 @@
+<title>Atlasmap Storybook</title>
+<a href='./atlasmap-ui'>Atlasmap UI</a>
+<a href='./atlasmap-core'>Atlasmap core</a>

--- a/ui-react/package.json
+++ b/ui-react/package.json
@@ -13,6 +13,8 @@
   },
   "scripts": {
     "build": "lerna run --stream build",
+    "build:module": "lerna run --stream build:module",
+    "build:storybook": "lerna run --stream build:storybook",
     "watch": "lerna run --ignore @atlasmap/standalone --parallel --no-bail start -- --verbose",
     "standalone": "lerna run --stream --scope @atlasmap/standalone start"
   }

--- a/ui-react/packages/atlasmap-core/package.json
+++ b/ui-react/packages/atlasmap-core/package.json
@@ -13,7 +13,7 @@
     "start": "tsdx watch",
     "build:module": "tsdx build",
     "build:storybook": "build-storybook --quiet",
-    "build": "npm-run-all lint build:* ",
+    "build": "npm-run-all lint build:module",
     "test": "tsdx test",
     "test:coverage": "tsdx test --coverage --coverageReporters=text-lcov | coveralls",
     "lint": "tsdx lint src/react",

--- a/ui-react/packages/atlasmap-ui/package.json
+++ b/ui-react/packages/atlasmap-ui/package.json
@@ -13,7 +13,7 @@
     "start": "tsdx watch",
     "build:module": "tsdx build",
     "build:storybook": "build-storybook --quiet",
-    "build": "npm-run-all lint test build:* ",
+    "build": "npm-run-all lint test build:module",
     "test": "tsdx test",
     "test:coverage": "tsdx test --coverage --coverageReporters=text-lcov | coveralls",
     "lint": "tsdx lint src test stories",


### PR DESCRIPTION
This uses Netlify to publish all the storybooks we have in the React UI.

For master, the website will be accessible under https://atlasmap.netlify.com
For PRs, a link to the preview will be pushed by Netlify Bot as a PR comment, but you can also click on the details link in GH PR checks:
![image](https://user-images.githubusercontent.com/966316/75346830-d41df980-589f-11ea-8d38-20619484566f.png)

Storybooks will not be built under Circle CI anymore, only on Netlify.