### PR TITLE
fix: Create 'New Mapping' button

### DIFF
--- a/ui-react/packages/atlasmap-core/src/components/field/field-util.ts
+++ b/ui-react/packages/atlasmap-core/src/components/field/field-util.ts
@@ -128,6 +128,17 @@ export function createMapping(source: Field, target: Field): void {
 }
 
 /**
+ * Create a new mapping using the specified source and target IDs.
+ *
+ * @param source
+ * @param target
+ */
+export function newMapping(): void {
+  const cfg = ConfigModel.getConfig();
+  cfg.mappingService.newMapping();
+}
+
+/**
  * Add the specified field to the current mapping.
  *
  * @param field

--- a/ui-react/packages/atlasmap-core/src/react/Atlasmap.tsx
+++ b/ui-react/packages/atlasmap-core/src/react/Atlasmap.tsx
@@ -93,6 +93,7 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
     onFieldPreviewChange,
     addToCurrentMapping,
     createMapping,
+    newMapping,
     createConstant,
     deleteConstant,
     editConstant,
@@ -215,6 +216,10 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
     [createMapping]
   );
 
+  const handleNewMapping = useCallback(() => {
+    newMapping();
+  }, [newMapping]);
+
   return (
     <AtlasmapUIProvider
       error={error}
@@ -249,6 +254,7 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
         onExportAtlasFile={handleExportAtlasFile}
         onImportAtlasFile={(file: File) => handleImportAtlasFile(file)}
         onResetAtlasmap={handleResetAtlasmap}
+        onAddMapping={handleNewMapping}
         expressionTokens={expressionTokens}
       >
         {({ showTypes, showMappingPreview }) => (

--- a/ui-react/packages/atlasmap-core/src/react/AtlasmapProvider.tsx
+++ b/ui-react/packages/atlasmap-core/src/react/AtlasmapProvider.tsx
@@ -28,6 +28,7 @@ import {
 import {
   addToCurrentMapping,
   createMapping,
+  newMapping,
   createConstant,
   deleteConstant,
   editConstant,
@@ -403,6 +404,7 @@ export function useAtlasmap() {
       onFieldPreviewChange,
       addToCurrentMapping,
       createMapping,
+      newMapping,
       documentExists,
       getMappingActions,
       getMultiplicityActions,

--- a/ui-react/packages/atlasmap-core/src/services/mapping-management.service.ts
+++ b/ui-react/packages/atlasmap-core/src/services/mapping-management.service.ts
@@ -430,6 +430,22 @@ export class MappingManagementService {
     this.selectMapping(mapping);
   }
 
+  /**
+   * Instantiate a new mapping model.
+   */
+  newMapping(): void {
+    this.deselectMapping();
+    const mapping: MappingModel = new MappingModel();
+    // Determine type of mapping (i.e., transition mode)
+    this.updateTransition(mapping);
+    // SelectMapping marks new mapping as active mapping, which is necessary so
+    // that it gets added to the existing mappings in notifyMappingUpdated().
+    // TODO: this seems very unintuitive, seems like some step to explicitly
+    // add the new mapping would make more sense
+    this.selectMapping(mapping);
+    this.notifyMappingUpdated();
+  }
+
   selectMapping(mappingModel: MappingModel) {
     if (mappingModel == null) {
       this.deselectMapping();

--- a/ui-react/packages/atlasmap-ui/src/AtlasmapUI/AtlasmapCanvasView/AtlasmapCanvasView.tsx
+++ b/ui-react/packages/atlasmap-ui/src/AtlasmapUI/AtlasmapCanvasView/AtlasmapCanvasView.tsx
@@ -26,6 +26,7 @@ export interface IAtlasmapCanvasViewProps {
   onExportAtlasFile: (event: any) => void;
   onImportAtlasFile: (selectedFile: File) => void;
   onResetAtlasmap: () => void;
+  onAddMapping: () => void;
   expressionTokens: string[];
   children: (props: {
     showTypes: boolean;
@@ -43,6 +44,7 @@ export const AtlasmapCanvasView: FunctionComponent<IAtlasmapCanvasViewProps> = (
   onExportAtlasFile,
   onImportAtlasFile,
   onResetAtlasmap,
+  onAddMapping,
   expressionTokens,
   children,
 }) => {
@@ -101,6 +103,7 @@ export const AtlasmapCanvasView: FunctionComponent<IAtlasmapCanvasViewProps> = (
         onExportAtlasFile={onExportAtlasFile}
         onImportAtlasFile={onImportAtlasFile}
         onResetAtlasmap={onResetAtlasmap}
+        onAddMapping={onAddMapping}
         controlBar={controlBar}
         onConditionalMappingExpressionEnabled={
           onConditionalMappingExpressionEnabled

--- a/ui-react/packages/atlasmap-ui/src/AtlasmapUI/AtlasmapContextToolbar.tsx
+++ b/ui-react/packages/atlasmap-ui/src/AtlasmapUI/AtlasmapContextToolbar.tsx
@@ -8,6 +8,7 @@ import {
   MapMarkedIcon,
   MapIcon,
   PficonDragdropIcon,
+  PlusIcon,
 } from '@patternfly/react-icons';
 import React, { FunctionComponent } from 'react';
 import { Button, Tooltip, Toolbar, ToolbarItem } from '@patternfly/react-core';
@@ -23,6 +24,7 @@ export interface IAtlasmapContextToolbarProps {
   onExportAtlasFile: (event: any) => void;
   onImportAtlasFile: (selectedFile: File) => void;
   onResetAtlasmap: () => void;
+  onAddMapping: () => void;
   onToggleShowTypes: (id: any) => void;
   onToggleShowMappingPreview: (id: any) => void;
   onToggleShowMappedFields: (id: any) => void;
@@ -34,6 +36,7 @@ export const AtlasmapContextToolbar: FunctionComponent<IAtlasmapContextToolbarPr
   onImportAtlasFile,
   onResetAtlasmap,
   onExportAtlasFile,
+  onAddMapping,
   onToggleShowMappingPreview,
   onToggleShowTypes,
   onToggleShowMappedFields,
@@ -101,6 +104,21 @@ export const AtlasmapContextToolbar: FunctionComponent<IAtlasmapContextToolbarPr
             onClick={onResetAtlasmap}
           >
             Reset all
+          </Button>
+        </Tooltip>
+      </ToolbarItem>
+      <ToolbarItem>
+        <Tooltip
+          position={'auto'}
+          enableFlip={true}
+          content={<div>Add new mapping</div>}
+        >
+          <Button
+            variant={'plain'}
+            aria-label="Add new mapping"
+            onClick={onAddMapping}
+          >
+            <PlusIcon />
           </Button>
         </Tooltip>
       </ToolbarItem>

--- a/ui-react/packages/atlasmap-ui/src/AtlasmapUI/AtlasmapLayout.tsx
+++ b/ui-react/packages/atlasmap-ui/src/AtlasmapUI/AtlasmapLayout.tsx
@@ -11,6 +11,7 @@ export interface IAtlasmapLayoutProps {
   onExportAtlasFile: (event: any) => void;
   onImportAtlasFile: (selectedFile: File) => void;
   onResetAtlasmap: () => void;
+  onAddMapping: () => void;
   controlBar?: ReactNode;
   onConditionalMappingExpressionEnabled: () => boolean;
   onGetMappingExpressionStr: () => string;
@@ -26,6 +27,7 @@ export const AtlasmapLayout: FunctionComponent<IAtlasmapLayoutProps> = ({
   onExportAtlasFile,
   onImportAtlasFile,
   onResetAtlasmap,
+  onAddMapping,
   controlBar,
   onConditionalMappingExpressionEnabled,
   onGetMappingExpressionStr,
@@ -47,6 +49,7 @@ export const AtlasmapLayout: FunctionComponent<IAtlasmapLayoutProps> = ({
         onExportAtlasFile={onExportAtlasFile}
         onImportAtlasFile={onImportAtlasFile}
         onResetAtlasmap={onResetAtlasmap}
+        onAddMapping={onAddMapping}
         onToggleShowTypes={onToggleShowTypes}
         onToggleShowMappingPreview={onToggleShowMappingPreview}
         onToggleShowMappedFields={onToggleShowMappedFields}
@@ -58,6 +61,7 @@ export const AtlasmapLayout: FunctionComponent<IAtlasmapLayoutProps> = ({
       onExportAtlasFile,
       onImportAtlasFile,
       onResetAtlasmap,
+      onAddMapping,
       onToggleShowMappedFields,
       onToggleShowMappingPreview,
       onToggleShowTypes,

--- a/ui-react/packages/atlasmap-ui/stories/Atlasmap.stories.tsx
+++ b/ui-react/packages/atlasmap-ui/stories/Atlasmap.stories.tsx
@@ -78,6 +78,7 @@ export const sample = () =>
           onExportAtlasFile={action('onExportAtlasFile')}
           onImportAtlasFile={action('onImportAtlasFile')}
           onResetAtlasmap={action('onResetAtlasmap')}
+          onAddMapping={action('onAddMapping')}
           onConditionalMappingExpressionEnabled={
             conditionalMappingExpressionEnabled
           }


### PR DESCRIPTION
Fixes: #1862 

Note, the empty mapping currently allows no way to assign fields to it, but I will address this in a separate issue.