### PR TITLE
fix(react-ui): always show properties and constants

### DIFF
--- a/ui-react/packages/atlasmap/src/UI/ColumnMapper/ColumnHeader.tsx
+++ b/ui-react/packages/atlasmap/src/UI/ColumnMapper/ColumnHeader.tsx
@@ -22,6 +22,7 @@ const styles = StyleSheet.create({
     display: "flex",
     alignItems: "center",
     height: "36px",
+    paddingLeft: "1rem",
   },
   searchRow: {
     margin: "1rem calc(2rem + 10px) 0 2rem",

--- a/ui-react/packages/atlasmap/src/UI/Document.tsx
+++ b/ui-react/packages/atlasmap/src/UI/Document.tsx
@@ -26,7 +26,7 @@ const styles = StyleSheet.create({
   head: {
     paddingRight: "0 !important",
   },
-  body: {
+  noPadding: {
     padding: "0 !important",
   },
   hidden: {
@@ -55,6 +55,7 @@ export interface IDocumentProps
   dropAccepted?: boolean;
   stacked?: boolean;
   scrollIntoView?: boolean;
+  noPadding?: boolean;
   onSelect?: () => void;
   onDeselect?: () => void;
 }
@@ -75,6 +76,7 @@ export const Document = forwardRef<
       stacked = true,
       selectable = false,
       scrollIntoView = false,
+      noPadding = false,
       onSelect,
       onDeselect,
       children,
@@ -144,7 +146,9 @@ export const Document = forwardRef<
               )}
             </CardHead>
           )}
-          <CardBody className={css(styles.body)}>{children}</CardBody>
+          <CardBody className={css(noPadding && styles.noPadding)}>
+            {children}
+          </CardBody>
           {footer}
         </Card>
       </div>

--- a/ui-react/packages/atlasmap/src/UI/DocumentField.tsx
+++ b/ui-react/packages/atlasmap/src/UI/DocumentField.tsx
@@ -19,7 +19,7 @@ const styles = StyleSheet.create({
     "--bg-color-fade": "rgba(255, 255, 255, 0.5))",
   },
   row: {
-    padding: "0 1rem",
+    // padding: "0 1rem",
     display: "flex",
     position: "relative",
   },

--- a/ui-react/packages/atlasmap/src/UI/DocumentGroup.tsx
+++ b/ui-react/packages/atlasmap/src/UI/DocumentGroup.tsx
@@ -12,20 +12,10 @@ const styles = StyleSheet.create({
   buttonContent: {
     display: "flex",
     alignItems: "center",
+    padding: "0.5rem 1rem",
   },
   buttonIcon: {
     marginRight: "1rem",
-  },
-  content: {
-    fontSize: "inherit !important",
-    "& > div": {
-      boxSizing: "border-box",
-      padding:
-        "var(--pf-c-accordion__expanded-content-body--PaddingTop) 0 var(--pf-c-accordion__expanded-content-body--PaddingBottom) 1.2rem !important",
-    },
-  },
-  hiddenContent: {
-    display: "none",
   },
 });
 

--- a/ui-react/packages/atlasmap/src/UI/Tree/Tree.stories.mdx
+++ b/ui-react/packages/atlasmap/src/UI/Tree/Tree.stories.mdx
@@ -6,7 +6,7 @@ import { Tree, TreeGroup, TreeItem } from ".";
 
 # Tree
 
-<Story name="Tree">{treeExample()}</Story>
+<Story name="Example">{treeExample()}</Story>
 
 ## Keyboard Support
 

--- a/ui-react/packages/atlasmap/src/UI/Tree/TreeGroup.tsx
+++ b/ui-react/packages/atlasmap/src/UI/Tree/TreeGroup.tsx
@@ -21,7 +21,7 @@ import { useTreeFocus } from "./TreeFocusProvider";
 
 const styles = StyleSheet.create({
   button: {
-    paddingRight: "var(--pf-global--spacer--md) !important",
+    padding: "0 !important",
   },
   content: {
     fontSize: "inherit !important",

--- a/ui-react/packages/atlasmap/src/Views/ColumnMapperView/Columns/ConstantsTree.tsx
+++ b/ui-react/packages/atlasmap/src/Views/ColumnMapperView/Columns/ConstantsTree.tsx
@@ -1,0 +1,106 @@
+import React, { FunctionComponent } from "react";
+
+import { Button, Tooltip } from "@patternfly/react-core";
+import { EditIcon, TrashIcon } from "@patternfly/react-icons";
+
+import { Tree, IDragAndDropField } from "../../../UI";
+import {
+  IAtlasmapDocument,
+  IAtlasmapField,
+  IAtlasmapMapping,
+} from "../../models";
+import { commonActions } from "./commonActions";
+import {
+  SOURCES_CONSTANTS_ID,
+  SOURCES_DRAGGABLE_TYPE,
+  SOURCES_FIELD_ID_PREFIX,
+  SOURCES_HEIGHT_BOUNDARY_ID,
+  SOURCES_WIDTH_BOUNDARY_ID,
+  TARGETS_DRAGGABLE_TYPE,
+} from "./constants";
+import { TraverseFields } from "./TraverseFields";
+
+export interface IConstantsTreeCallbacks {
+  onDrop: (source: IAtlasmapField, target: IDragAndDropField) => void;
+  canDrop: (source: IAtlasmapField, target: IDragAndDropField) => boolean;
+  onShowMappingDetails: (mapping: IAtlasmapMapping) => void;
+  canAddToSelectedMapping: (source: IAtlasmapField) => boolean;
+  onAddToSelectedMapping: (source: IAtlasmapField) => void;
+  canRemoveFromSelectedMapping: (source: IAtlasmapField) => boolean;
+  onRemoveFromSelectedMapping: (source: IAtlasmapField) => void;
+  onEditConstant: (value: string) => void;
+  onDeleteConstant: (value: string) => void;
+}
+
+export interface IConstantsTreeProps extends IConstantsTreeCallbacks {
+  fields: IAtlasmapDocument["fields"];
+}
+
+export const ConstantsTree: FunctionComponent<IConstantsTreeProps> = ({
+  fields,
+  onDrop,
+  canDrop,
+  onShowMappingDetails,
+  canAddToSelectedMapping,
+  onAddToSelectedMapping,
+  canRemoveFromSelectedMapping,
+  onRemoveFromSelectedMapping,
+  onEditConstant,
+  onDeleteConstant,
+}) => (
+  <Tree>
+    <TraverseFields
+      fields={fields}
+      showTypes={false}
+      parentId={SOURCES_CONSTANTS_ID}
+      boundaryId={SOURCES_HEIGHT_BOUNDARY_ID}
+      overrideWidth={SOURCES_WIDTH_BOUNDARY_ID}
+      idPrefix={SOURCES_FIELD_ID_PREFIX}
+      acceptDropType={TARGETS_DRAGGABLE_TYPE}
+      draggableType={SOURCES_DRAGGABLE_TYPE}
+      onDrop={onDrop}
+      canDrop={canDrop}
+      renderActions={(field) => [
+        ...commonActions({
+          connectedMappings: field.mappings,
+          onShowMappingDetails: onShowMappingDetails,
+          canAddToSelectedMapping: canAddToSelectedMapping(field),
+          onAddToSelectedMapping: () => onAddToSelectedMapping(field),
+          canRemoveFromSelectedMapping: canRemoveFromSelectedMapping(field),
+          onRemoveFromSelectedMapping: () => onRemoveFromSelectedMapping(field),
+          onStartMapping: () => void 0,
+        }),
+        <Tooltip
+          key={"edit"}
+          position={"top"}
+          enableFlip={true}
+          content={<div>Edit constant</div>}
+        >
+          <Button
+            variant="plain"
+            onClick={() => onEditConstant(field.name)}
+            aria-label={"Edit constant"}
+            tabIndex={0}
+          >
+            <EditIcon />
+          </Button>
+        </Tooltip>,
+        <Tooltip
+          key={"delete"}
+          position={"top"}
+          enableFlip={true}
+          content={<div>Remove constant</div>}
+        >
+          <Button
+            variant="plain"
+            onClick={() => onDeleteConstant(field.name)}
+            aria-label={"Remove constant"}
+            tabIndex={0}
+          >
+            <TrashIcon />
+          </Button>
+        </Tooltip>,
+      ]}
+    />
+  </Tree>
+);

--- a/ui-react/packages/atlasmap/src/Views/ColumnMapperView/Columns/PropertiesTree.tsx
+++ b/ui-react/packages/atlasmap/src/Views/ColumnMapperView/Columns/PropertiesTree.tsx
@@ -1,0 +1,108 @@
+import React, { FunctionComponent } from "react";
+
+import { Button, Tooltip } from "@patternfly/react-core";
+import { EditIcon, TrashIcon } from "@patternfly/react-icons";
+
+import { Tree, IDragAndDropField } from "../../../UI";
+import {
+  IAtlasmapDocument,
+  IAtlasmapField,
+  IAtlasmapMapping,
+} from "../../models";
+import { commonActions } from "./commonActions";
+import {
+  SOURCES_DRAGGABLE_TYPE,
+  SOURCES_FIELD_ID_PREFIX,
+  SOURCES_HEIGHT_BOUNDARY_ID,
+  SOURCES_PROPERTIES_ID,
+  SOURCES_WIDTH_BOUNDARY_ID,
+  TARGETS_DRAGGABLE_TYPE,
+} from "./constants";
+import { TraverseFields } from "./TraverseFields";
+
+export interface IPropertiesTreeCallbacks {
+  onDrop: (source: IAtlasmapField, target: IDragAndDropField) => void;
+  canDrop: (source: IAtlasmapField, target: IDragAndDropField) => boolean;
+  onShowMappingDetails: (mapping: IAtlasmapMapping) => void;
+  canAddToSelectedMapping: (source: IAtlasmapField) => boolean;
+  onAddToSelectedMapping: (source: IAtlasmapField) => void;
+  canRemoveFromSelectedMapping: (source: IAtlasmapField) => boolean;
+  onRemoveFromSelectedMapping: (source: IAtlasmapField) => void;
+  onEditProperty: (name: string) => void;
+  onDeleteProperty: (name: string) => void;
+}
+
+export interface IPropertiesTreeProps extends IPropertiesTreeCallbacks {
+  fields: IAtlasmapDocument["fields"];
+  showTypes: boolean;
+}
+
+export const PropertiesTree: FunctionComponent<IPropertiesTreeProps> = ({
+  fields,
+  showTypes,
+  onDrop,
+  canDrop,
+  onShowMappingDetails,
+  canAddToSelectedMapping,
+  onAddToSelectedMapping,
+  canRemoveFromSelectedMapping,
+  onRemoveFromSelectedMapping,
+  onEditProperty,
+  onDeleteProperty,
+}) => (
+  <Tree>
+    <TraverseFields
+      fields={fields}
+      showTypes={showTypes}
+      parentId={SOURCES_PROPERTIES_ID}
+      boundaryId={SOURCES_HEIGHT_BOUNDARY_ID}
+      overrideWidth={SOURCES_WIDTH_BOUNDARY_ID}
+      idPrefix={SOURCES_FIELD_ID_PREFIX}
+      acceptDropType={TARGETS_DRAGGABLE_TYPE}
+      draggableType={SOURCES_DRAGGABLE_TYPE}
+      onDrop={onDrop}
+      canDrop={canDrop}
+      renderActions={(field) => [
+        ...commonActions({
+          connectedMappings: field.mappings,
+          onShowMappingDetails: onShowMappingDetails,
+          canAddToSelectedMapping: canAddToSelectedMapping(field),
+          onAddToSelectedMapping: () => onAddToSelectedMapping(field),
+          canRemoveFromSelectedMapping: canRemoveFromSelectedMapping(field),
+          onRemoveFromSelectedMapping: () => onRemoveFromSelectedMapping(field),
+          onStartMapping: () => void 0,
+        }),
+        <Tooltip
+          key={"edit"}
+          position={"top"}
+          enableFlip={true}
+          content={<div>Edit property</div>}
+        >
+          <Button
+            variant="plain"
+            onClick={() => onEditProperty(field.name)}
+            aria-label={"Edit property"}
+            tabIndex={0}
+          >
+            <EditIcon />
+          </Button>
+        </Tooltip>,
+        <Tooltip
+          key={"delete"}
+          position={"top"}
+          enableFlip={true}
+          content={<div>Remove property</div>}
+        >
+          <Button
+            variant="plain"
+            onClick={() => onDeleteProperty(field.name)}
+            aria-label={"Remove property"}
+            tabIndex={0}
+          >
+            <TrashIcon />
+          </Button>
+        </Tooltip>,
+      ]}
+    />
+  </Tree>
+);

--- a/ui-react/packages/atlasmap/src/Views/ColumnMapperView/Columns/SourcesColumn.tsx
+++ b/ui-react/packages/atlasmap/src/Views/ColumnMapperView/Columns/SourcesColumn.tsx
@@ -1,23 +1,23 @@
 import React, { FunctionComponent } from "react";
 
 import { Button, Tooltip } from "@patternfly/react-core";
-import { EditIcon, PlusIcon, TrashIcon } from "@patternfly/react-icons";
+import { PlusIcon } from "@patternfly/react-icons";
 
 import {
   ColumnBody,
   Document,
   DocumentFooter,
-  IDragAndDropField,
   NodeRef,
   SearchableColumnHeader,
   Tree,
   DocumentFieldPreview,
+  IDragAndDropField,
 } from "../../../UI";
 import {
+  GroupId,
   IAtlasmapDocument,
   IAtlasmapField,
   IAtlasmapMapping,
-  GroupId,
 } from "../../models";
 import {
   DeleteDocumentAction,
@@ -35,17 +35,17 @@ import {
   SOURCES_WIDTH_BOUNDARY_ID,
   TARGETS_DRAGGABLE_TYPE,
 } from "./constants";
+import { ConstantsTree, IConstantsTreeCallbacks } from "./ConstantsTree";
+import { IPropertiesTreeCallbacks, PropertiesTree } from "./PropertiesTree";
 import { TraverseFields } from "./TraverseFields";
 
-export interface ISourceColumnCallbacks {
+export interface ISourceColumnCallbacks
+  extends IConstantsTreeCallbacks,
+    IPropertiesTreeCallbacks {
   onCreateConstant: () => void;
-  onEditConstant: (value: string) => void;
-  onDeleteConstant: (value: string) => void;
   onCreateProperty: () => void;
-  onEditProperty: (name: string) => void;
-  onDeleteProperty: (name: string) => void;
-  onDeleteDocument: (id: GroupId) => void;
   onImportDocument: (selectedFile: File) => void;
+  onDeleteDocument: (id: GroupId) => void;
   onEnableJavaClasses: () => void;
   onSearch: (content: string) => void;
   canDrop: (source: IAtlasmapField, target: IDragAndDropField) => boolean;
@@ -107,188 +107,97 @@ export const SourcesColumn: FunctionComponent<
         <ColumnBody>
           <NodeRef id={SOURCES_WIDTH_BOUNDARY_ID}>
             <div>
-              {properties && (
-                <NodeRef
-                  id={SOURCES_PROPERTIES_ID}
-                  boundaryId={SOURCES_HEIGHT_BOUNDARY_ID}
-                  overrideWidth={SOURCES_WIDTH_BOUNDARY_ID}
-                >
-                  <Document
-                    title={"Properties"}
-                    actions={[
-                      <Tooltip
-                        position={"top"}
-                        enableFlip={true}
-                        content={
-                          <div>Create a constant for use in mapping</div>
-                        }
-                        key={"create-constant"}
+              <NodeRef
+                id={SOURCES_PROPERTIES_ID}
+                boundaryId={SOURCES_HEIGHT_BOUNDARY_ID}
+                overrideWidth={SOURCES_WIDTH_BOUNDARY_ID}
+              >
+                <Document
+                  title={"Properties"}
+                  actions={[
+                    <Tooltip
+                      position={"top"}
+                      enableFlip={true}
+                      content={<div>Create a constant for use in mapping</div>}
+                      key={"create-constant"}
+                    >
+                      <Button
+                        onClick={onCreateConstant}
+                        variant={"plain"}
+                        aria-label="Create a constant for use in mapping"
                       >
-                        <Button
-                          onClick={onCreateConstant}
-                          variant={"plain"}
-                          aria-label="Create a constant for use in mapping"
-                        >
-                          <PlusIcon />
-                        </Button>
-                      </Tooltip>,
-                    ]}
-                  >
-                    <Tree>
-                      <TraverseFields
-                        fields={properties.fields}
-                        showTypes={showTypes}
-                        parentId={SOURCES_PROPERTIES_ID}
-                        boundaryId={SOURCES_HEIGHT_BOUNDARY_ID}
-                        overrideWidth={SOURCES_WIDTH_BOUNDARY_ID}
-                        idPrefix={SOURCES_FIELD_ID_PREFIX}
-                        acceptDropType={TARGETS_DRAGGABLE_TYPE}
-                        draggableType={SOURCES_DRAGGABLE_TYPE}
-                        onDrop={onDrop}
-                        canDrop={canDrop}
-                        renderActions={(field) => [
-                          ...commonActions({
-                            connectedMappings: field.mappings,
-                            onShowMappingDetails,
-                            canAddToSelectedMapping: canAddToSelectedMapping(
-                              field,
-                            ),
-                            onAddToSelectedMapping: () =>
-                              onAddToSelectedMapping(field),
-                            canRemoveFromSelectedMapping: canRemoveFromSelectedMapping(
-                              field,
-                            ),
-                            onRemoveFromSelectedMapping: () =>
-                              onRemoveFromSelectedMapping(field),
-                            onStartMapping: () => void 0,
-                          }),
-                          <Tooltip
-                            key={"edit"}
-                            position={"top"}
-                            enableFlip={true}
-                            content={<div>Edit property</div>}
-                          >
-                            <Button
-                              variant="plain"
-                              onClick={() => onEditProperty(field.name)}
-                              aria-label={"Edit property"}
-                              tabIndex={0}
-                            >
-                              <EditIcon />
-                            </Button>
-                          </Tooltip>,
-                          <Tooltip
-                            key={"delete"}
-                            position={"top"}
-                            enableFlip={true}
-                            content={<div>Remove property</div>}
-                          >
-                            <Button
-                              variant="plain"
-                              onClick={() => onDeleteProperty(field.name)}
-                              aria-label={"Remove property"}
-                              tabIndex={0}
-                            >
-                              <TrashIcon />
-                            </Button>
-                          </Tooltip>,
-                        ]}
-                      />
-                    </Tree>
-                  </Document>
-                </NodeRef>
-              )}
-              {constants && (
-                <NodeRef
-                  id={SOURCES_CONSTANTS_ID}
-                  boundaryId={SOURCES_HEIGHT_BOUNDARY_ID}
-                  overrideWidth={SOURCES_WIDTH_BOUNDARY_ID}
+                        <PlusIcon />
+                      </Button>
+                    </Tooltip>,
+                  ]}
+                  noPadding={!!properties}
                 >
-                  <Document
-                    title={"Constants"}
-                    actions={[
-                      <Tooltip
-                        position={"top"}
-                        enableFlip={true}
-                        content={
-                          <div>Create a constant for use in mapping</div>
-                        }
-                        key={"create-constant"}
+                  {properties ? (
+                    <PropertiesTree
+                      onEditProperty={onEditProperty}
+                      onDeleteProperty={onDeleteProperty}
+                      canDrop={canDrop}
+                      onDrop={onDrop}
+                      onShowMappingDetails={onShowMappingDetails}
+                      canAddToSelectedMapping={canAddToSelectedMapping}
+                      onAddToSelectedMapping={onAddToSelectedMapping}
+                      canRemoveFromSelectedMapping={
+                        canRemoveFromSelectedMapping
+                      }
+                      onRemoveFromSelectedMapping={onRemoveFromSelectedMapping}
+                      fields={properties.fields}
+                      showTypes={showTypes}
+                    />
+                  ) : (
+                    "No properties"
+                  )}
+                </Document>
+              </NodeRef>
+              <NodeRef
+                id={SOURCES_CONSTANTS_ID}
+                boundaryId={SOURCES_HEIGHT_BOUNDARY_ID}
+                overrideWidth={SOURCES_WIDTH_BOUNDARY_ID}
+              >
+                <Document
+                  title={"Constants"}
+                  actions={[
+                    <Tooltip
+                      position={"top"}
+                      enableFlip={true}
+                      content={<div>Create a constant for use in mapping</div>}
+                      key={"create-constant"}
+                    >
+                      <Button
+                        onClick={onCreateProperty}
+                        variant={"plain"}
+                        aria-label="Create a constant for use in mapping"
                       >
-                        <Button
-                          onClick={onCreateProperty}
-                          variant={"plain"}
-                          aria-label="Create a constant for use in mapping"
-                        >
-                          <PlusIcon />
-                        </Button>
-                      </Tooltip>,
-                    ]}
-                  >
-                    <Tree>
-                      <TraverseFields
-                        fields={constants.fields}
-                        showTypes={false}
-                        parentId={SOURCES_CONSTANTS_ID}
-                        boundaryId={SOURCES_HEIGHT_BOUNDARY_ID}
-                        overrideWidth={SOURCES_WIDTH_BOUNDARY_ID}
-                        idPrefix={SOURCES_FIELD_ID_PREFIX}
-                        acceptDropType={TARGETS_DRAGGABLE_TYPE}
-                        draggableType={SOURCES_DRAGGABLE_TYPE}
-                        onDrop={onDrop}
-                        canDrop={canDrop}
-                        renderActions={(field) => [
-                          ...commonActions({
-                            connectedMappings: field.mappings,
-                            onShowMappingDetails,
-                            canAddToSelectedMapping: canAddToSelectedMapping(
-                              field,
-                            ),
-                            onAddToSelectedMapping: () =>
-                              onAddToSelectedMapping(field),
-                            canRemoveFromSelectedMapping: canRemoveFromSelectedMapping(
-                              field,
-                            ),
-                            onRemoveFromSelectedMapping: () =>
-                              onRemoveFromSelectedMapping(field),
-                            onStartMapping: () => void 0,
-                          }),
-                          <Tooltip
-                            key={"edit"}
-                            position={"top"}
-                            enableFlip={true}
-                            content={<div>Edit constant</div>}
-                          >
-                            <Button
-                              variant="plain"
-                              onClick={() => onEditConstant(field.name)}
-                              aria-label={"Edit constant"}
-                              tabIndex={0}
-                            >
-                              <EditIcon />
-                            </Button>
-                          </Tooltip>,
-                          <Tooltip
-                            key={"delete"}
-                            position={"top"}
-                            enableFlip={true}
-                            content={<div>Remove constant</div>}
-                          >
-                            <Button
-                              variant="plain"
-                              onClick={() => onDeleteConstant(field.name)}
-                              aria-label={"Remove constant"}
-                              tabIndex={0}
-                            >
-                              <TrashIcon />
-                            </Button>
-                          </Tooltip>,
-                        ]}
-                      />
-                    </Tree>
-                  </Document>
-                </NodeRef>
-              )}
+                        <PlusIcon />
+                      </Button>
+                    </Tooltip>,
+                  ]}
+                  noPadding={!!constants}
+                >
+                  {constants ? (
+                    <ConstantsTree
+                      onEditConstant={onEditConstant}
+                      onDeleteConstant={onDeleteConstant}
+                      canDrop={canDrop}
+                      onDrop={onDrop}
+                      onShowMappingDetails={onShowMappingDetails}
+                      canAddToSelectedMapping={canAddToSelectedMapping}
+                      onAddToSelectedMapping={onAddToSelectedMapping}
+                      canRemoveFromSelectedMapping={
+                        canRemoveFromSelectedMapping
+                      }
+                      onRemoveFromSelectedMapping={onRemoveFromSelectedMapping}
+                      fields={constants.fields}
+                    />
+                  ) : (
+                    <p>No constants</p>
+                  )}
+                </Document>
+              </NodeRef>
               {sources.map((s) => {
                 const documentId = `${SOURCES_DOCUMENT_ID_PREFIX}${s.id}`;
                 return (
@@ -311,6 +220,7 @@ export const SourcesColumn: FunctionComponent<
                           key={"delete-document"}
                         />,
                       ]}
+                      noPadding={true}
                     >
                       <Tree>
                         <TraverseFields

--- a/ui-react/packages/atlasmap/src/Views/ColumnMapperView/Columns/TargetsColumn.tsx
+++ b/ui-react/packages/atlasmap/src/Views/ColumnMapperView/Columns/TargetsColumn.tsx
@@ -107,6 +107,7 @@ export const TargetsColumn: FunctionComponent<
                           key={"delete-documents"}
                         />,
                       ]}
+                      noPadding={true}
                     >
                       <Tree>
                         <TraverseFields

--- a/ui-react/packages/atlasmap/src/Views/ColumnMapperView/Columns/TraverseFields.tsx
+++ b/ui-react/packages/atlasmap/src/Views/ColumnMapperView/Columns/TraverseFields.tsx
@@ -10,12 +10,12 @@ import {
   TreeGroupAndNodeRefsAndDnD,
 } from "./TreeGroupAndNodeRefsAndDnD";
 
-export interface ITraverseFields
+export interface ITraverseFieldsProps
   extends Omit<Omit<IFieldOrGroupProps, "field">, "fieldId"> {
   fields: AtlasmapFields;
 }
 
-export const TraverseFields: FunctionComponent<ITraverseFields> = ({
+export const TraverseFields: FunctionComponent<ITraverseFieldsProps> = ({
   fields,
   idPrefix,
   ...props


### PR DESCRIPTION
Fixes #1963 

This also removes some styling from the `Tree` family of components to delegate it to the specialised `DocumentXXX` components. It isn't strictly related but we needed some way to properly style the empty state and this change sneaked into the PR.