### PR TITLE
fix: UI_REACT: How to delete mapping block which doesn't have any related mapping lines?

### DIFF
--- a/ui-react/packages/atlasmap/src/Atlasmap/Atlasmap.tsx
+++ b/ui-react/packages/atlasmap/src/Atlasmap/Atlasmap.tsx
@@ -365,11 +365,21 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
     ],
   );
 
+  const handleRemoveMapping = useCallback(
+    () =>
+      handlers.onDeleteMapping(() => {
+        removeMapping(selectedMapping!.mapping);
+        deselectMapping();
+      }),
+    [handlers, deselectMapping, removeMapping, selectedMapping],
+  );
+
   const mappingEvents: IMappingDocumentEvents = useMemo(
     () => ({
       onSelectMapping: selectMapping,
       onDeselectMapping: deselectMapping,
       onEditMapping: () => void 0,
+      onDeleteMapping: handleRemoveMapping,
       onFieldPreviewChange: () => void 0,
       onMouseOver: () => void 0,
       onMouseOut: () => void 0,
@@ -377,7 +387,7 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
         !m.sourceFields.find((s) => s.id === f.id) &&
         !m.targetFields.find((t) => t.id === f.id),
     }),
-    [deselectMapping, selectMapping],
+    [deselectMapping, selectMapping, handleRemoveMapping],
   );
 
   const currentView = useMemo(() => {
@@ -462,12 +472,6 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
         delimiterValue: a.actualDelimiter,
       }));
       const multiplicityFieldAction = m.transition.transitionFieldAction;
-      const handleRemoveMapping = () => {
-        handlers.onDeleteMapping(() => {
-          removeMapping(m);
-          deselectMapping();
-        });
-      };
       return (
         <MappingDetailsView
           mapping={selectedMapping}
@@ -495,8 +499,7 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
     getMultiplicityActions,
     handleActionChange,
     handleRemoveFromMapping,
-    handlers,
-    removeMapping,
+    handleRemoveMapping,
     selectedMapping,
   ]);
 

--- a/ui-react/packages/atlasmap/src/Views/ColumnMapperView/ColumnMapperView.stories.tsx
+++ b/ui-react/packages/atlasmap/src/Views/ColumnMapperView/ColumnMapperView.stories.tsx
@@ -84,6 +84,7 @@ export const mappingsColumn = () => (
         onSelectMapping={action("onSelectMapping")}
         onDeselectMapping={action("onDeselectMapping")}
         onEditMapping={action("onEditMapping")}
+        onDeleteMapping={action("onDeleteMapping")}
         onMouseOver={action("onMouseOver")}
         onMouseOut={action("onMouseOut")}
         canDrop={() => true}

--- a/ui-react/packages/atlasmap/src/Views/ColumnMapperView/Columns/MappingsColumn.tsx
+++ b/ui-react/packages/atlasmap/src/Views/ColumnMapperView/Columns/MappingsColumn.tsx
@@ -15,7 +15,7 @@ import {
   NodeRef,
 } from "../../../UI";
 import { IAtlasmapField, IAtlasmapMapping } from "../../models";
-import { EditMappingAction } from "../Actions";
+import { EditMappingAction, DeleteMappingAction } from "../Actions";
 import {
   MAPPINGS_DOCUMENT_ID_PREFIX,
   MAPPINGS_DROP_TYPE,
@@ -81,6 +81,7 @@ export interface IMappingDocumentEvents {
   onSelectMapping: (mapping: IAtlasmapMapping) => void;
   onDeselectMapping: (mapping: IAtlasmapMapping) => void;
   onEditMapping: (mapping: IAtlasmapMapping) => void;
+  onDeleteMapping: (mapping: IAtlasmapMapping) => void;
   onFieldPreviewChange: (field: IAtlasmapField, value: string) => void;
   onMouseOver: (mapping: IAtlasmapMapping) => void;
   onMouseOut: () => void;
@@ -102,6 +103,7 @@ export const MappingDocument: FunctionComponent<
   onSelectMapping,
   onDeselectMapping,
   onEditMapping,
+  onDeleteMapping,
   onFieldPreviewChange,
   onMouseOver,
   onMouseOut,
@@ -144,6 +146,10 @@ export const MappingDocument: FunctionComponent<
               <EditMappingAction
                 onClick={() => onEditMapping(mapping)}
                 key="edit"
+              />,
+              <DeleteMappingAction
+                onClick={() => onDeleteMapping(mapping)}
+                key="delete"
               />,
             ]}
             selected={isSelected}

--- a/ui-react/packages/atlasmap/src/Views/SourceMappingTargetView.stories.tsx
+++ b/ui-react/packages/atlasmap/src/Views/SourceMappingTargetView.stories.tsx
@@ -75,6 +75,7 @@ export const sourceMappingTargetView = () =>
           mappingEvents={{
             canDrop: () => true,
             onEditMapping: action("onEditMapping"),
+            onDeleteMapping: action("onDeleteMapping"),
             onFieldPreviewChange: action("onFieldPreviewChange"),
             onMouseOut: action("onMouseOut"),
             onMouseOver: action("onMouseOver"),


### PR DESCRIPTION
Fixes: #1892 

Technically, the user could click the edit details button, which then has a delete mapping button, but it certainly wasn't intuitive how to do this.