### PR TITLE
fix: Avoid duplication of property/constant fields nodes.

### DIFF
--- a/ui/packages/atlasmap-core/src/utils/mapping-serializer.ts
+++ b/ui/packages/atlasmap-core/src/utils/mapping-serializer.ts
@@ -119,6 +119,15 @@ export class MappingSerializer {
   }
 
   static deserializeMappingServiceJSON(json: any, cfg: ConfigModel): void {
+
+    // Process constants and properties before mappings.
+    for (const field of MappingSerializer.deserializeConstants(json)) {
+      cfg.constantDoc.addField(field);
+    }
+    for (const field of MappingSerializer.deserializeProperties(json)) {
+      cfg.propertyDoc.addField(field);
+    }
+
     if (!cfg.mappings) {
       cfg.mappings = new MappingDefinition;
     }
@@ -127,12 +136,6 @@ export class MappingSerializer {
     cfg.mappings.mappings = cfg.mappings.mappings.concat(MappingSerializer.deserializeMappings(json, cfg));
     for (const lookupTable of MappingSerializer.deserializeLookupTables(json)) {
       cfg.mappings.addTable(lookupTable);
-    }
-    for (const field of MappingSerializer.deserializeConstants(json)) {
-      cfg.constantDoc.addField(field);
-    }
-    for (const field of MappingSerializer.deserializeProperties(json)) {
-      cfg.propertyDoc.addField(field);
     }
   }
 

--- a/ui/packages/atlasmap-core/src/utils/mapping-util.ts
+++ b/ui/packages/atlasmap-core/src/utils/mapping-util.ts
@@ -83,16 +83,45 @@ at URI ${mappedField.parsedData.parsedDocURI}`,
         mappedField.field = doc.getField(mappedField.parsedData.parsedPath!);
       }
       if (mappedField.field == null) {
-        if (mappedField.parsedData.fieldIsConstant || mappedField.parsedData.fieldIsProperty) {
-          const constantField: Field = new Field();
-          constantField.value = mappedField.parsedData.parsedValue!; // TODO: check this non null operator
-          constantField.type = mappedField.parsedData.parsedValueType!; // TODO: check this non null operator
+        if (mappedField.parsedData.fieldIsConstant &&
+          mappedField.parsedData.parsedValue &&
+          mappedField.parsedData.parsedValueType) {
+          let constantField =
+            cfg.constantDoc.getField(mappedField.parsedData.parsedValue);
+          if (!constantField) {
+            constantField = new Field();
+          }
+          constantField.value = mappedField.parsedData.parsedValue;
+          constantField.type = mappedField.parsedData.parsedValueType;
           constantField.displayName = constantField.value;
           constantField.name = constantField.value;
           constantField.path = constantField.value;
           constantField.userCreated = true;
           mappedField.field = constantField;
           doc.addField(constantField);
+        } else if (mappedField.parsedData.fieldIsProperty &&
+          mappedField.parsedData.parsedValue &&
+          mappedField.parsedData.parsedValueType &&
+          mappedField.parsedData.parsedName &&
+          mappedField.parsedData.parsedPath) {
+          let propertyField =
+            cfg.propertyDoc.getField(mappedField.parsedData.parsedName);
+          if (!propertyField) {
+            propertyField = new Field();
+          }
+          const lastSeparator: number =
+            mappedField.parsedData.parsedName.lastIndexOf('/');
+          let fieldName = (lastSeparator === -1)
+            ? mappedField.parsedData.parsedName
+            : mappedField.parsedData.parsedName.substring(lastSeparator + 1);
+          propertyField.value = mappedField.parsedData.parsedValue;
+          propertyField.type = mappedField.parsedData.parsedValueType;
+          propertyField.displayName = fieldName;
+          propertyField.name = fieldName;
+          propertyField.path = mappedField.parsedData.parsedPath;
+          propertyField.userCreated = true;
+          mappedField.field = propertyField;
+          doc.addField(propertyField);
         } else if (mappedField.parsedData.userCreated || mappedField.parsedData.parsedPath) {
           const path: string = mappedField.parsedData.parsedPath!; // TODO: check this non null operator
 

--- a/ui/packages/atlasmap/src/Atlasmap/utils/field.ts
+++ b/ui/packages/atlasmap/src/Atlasmap/utils/field.ts
@@ -15,7 +15,9 @@ import {
 export function createConstant(constValue: string, constType: string): void {
   const cfg = ConfigModel.getConfig();
   let field = cfg.constantDoc.getField(constValue);
-  field = !field ? new Field() : field.copy();
+  if (!field) {
+    field = new Field();
+  }
   field.name = constValue;
   field.value = constValue;
   field.type = constType;
@@ -77,7 +79,9 @@ export function createProperty(
 ): void {
   const cfg = ConfigModel.getConfig();
   let field = cfg.propertyDoc.getField(propName);
-  field = !field ? new Field() : field.copy();
+  if (!field) {
+    field = new Field();
+  }
   field.name = propName;
   field.value = propValue;
   field.type = propType;
@@ -107,7 +111,7 @@ export function editProperty(
 ): void {
   const cfg = ConfigModel.getConfig();
   const field = cfg.propertyDoc.getField(
-    cfg.propertyDoc.pathSeparator + propName.split(" ")[0],
+    cfg.propertyDoc.pathSeparator + propName,
   );
   if (!field) {
     return;


### PR DESCRIPTION
Fixes: #2012

If a constant or property appeared as part of a mapping it became
duplicated.

Business logic fix.