### PR TITLE
one_to_many mapping - repeat source value based on count of fieldPath…

### DIFF
--- a/__ui-old/src/app/lib/atlasmap-data-mapper/components/mapping-detail/mapping-field-action-argument.component.html
+++ b/__ui-old/src/app/lib/atlasmap-data-mapper/components/mapping-detail/mapping-field-action-argument.component.html
@@ -1,9 +1,18 @@
 <div class="mappingFieldActionArgument">
-  <div *ngIf="argConfig.name == 'delimiter'; then dropdownDelimiter; else regular"></div>
+    <div *ngIf="argConfig.name == 'delimiter'; then dropdownDelimiter; else dropdownFieldPathTemplate"></div>
 
-  <ng-template #regular>
-    <ng-container *ngIf="argConfig.values != null && argConfig.values.length > 0; then dropdown; else textInput"></ng-container> 
-  </ng-template>
+    <ng-template #dropdownFieldPathTemplate>
+        <ng-container *ngIf="argConfig.name == 'fieldPath'; then dropdownFieldPath; else fieldPathCount"></ng-container>
+    </ng-template>
+
+    <ng-template #regular>
+        <ng-container *ngIf="argConfig.values != null && argConfig.values.length > 0 && argConfig.name != 'fieldPathCount'; then dropdown; else textInput"></ng-container>
+    </ng-template>
+
+    <!-- To hide fieldPathCount-->
+    <ng-template #fieldPathCount>
+        <ng-container *ngIf="argConfig.name != 'fieldPathCount'; then regular"></ng-container>
+    </ng-template>
   <ng-template #dropdown>
     <label>{{ getLabel(argConfig.name) }}</label>
     <select (change)="actionConfigParamSelectionChanged($event)" [ngModel]="getActionConfigParamVDefault(argConfig, actionIndex, argValIndex)">
@@ -23,6 +32,16 @@
     </select>
   </ng-template>
 
+    <ng-template #dropdownFieldPath>
+        <label>{{ getLabel(argConfig.name) }}</label>
+        <select class="actionDelimiter" name="fieldPaths" id="fieldPaths" [(ngModel)]="action.getArgumentValue(argConfig.name).value">
+    <ng-container *ngFor="let fieldPath of cfg.mappings.activeMapping.sourceFields[0].field.docDef.fieldPaths" id="fieldPath">
+      <option class="actionConfigStyleOptions" *ngIf="modeIsSupported(fieldPath)" [value]="fieldPath">
+        {{ fieldPath }}
+      </option>
+    </ng-container>
+  </select>
+    </ng-template>
   <ng-template #textInput>
     <label>{{ getLabel(argConfig.name) }}: </label>
     <div *ngIf="argConfig.type == 'string'; else rightAlign">

--- a/lib/api/src/main/java/io/atlasmap/spi/AtlasFieldReader.java
+++ b/lib/api/src/main/java/io/atlasmap/spi/AtlasFieldReader.java
@@ -22,4 +22,5 @@ public interface AtlasFieldReader {
 
     Field read(AtlasInternalSession session) throws AtlasException;
 
+	Field readField(AtlasInternalSession session, String fieldPath) throws AtlasException;
 }

--- a/lib/core/src/main/java/io/atlasmap/actions/StringComplexFieldActions.java
+++ b/lib/core/src/main/java/io/atlasmap/actions/StringComplexFieldActions.java
@@ -24,12 +24,14 @@ import io.atlasmap.spi.AtlasFieldAction;
 import io.atlasmap.spi.AtlasActionProcessor;
 import io.atlasmap.v2.Append;
 import io.atlasmap.v2.Concatenate;
+import io.atlasmap.v2.RepeatForFieldPathCount;
 import io.atlasmap.v2.EndsWith;
 import io.atlasmap.v2.FieldType;
 import io.atlasmap.v2.Format;
 import io.atlasmap.v2.GenerateUUID;
 import io.atlasmap.v2.IndexOf;
 import io.atlasmap.v2.LastIndexOf;
+import io.atlasmap.v2.OneToManyAction;
 import io.atlasmap.v2.PadStringLeft;
 import io.atlasmap.v2.PadStringRight;
 import io.atlasmap.v2.Prepend;
@@ -203,6 +205,28 @@ public class StringComplexFieldActions implements AtlasFieldAction {
 
         return input == null ? null : input.toString().split(split.getDelimiter());
     }
+    
+    @AtlasActionProcessor(sourceType = FieldType.ANY)
+    public static String[] repeat(RepeatForFieldPathCount repeat, String input) {
+    	
+    	if (repeat == null) {
+            throw new IllegalArgumentException("repeat is not defined");
+        }
+    	
+    	String[] returnObj = null;
+    	if(repeat instanceof OneToManyAction) {
+    		OneToManyAction repeatAction = (OneToManyAction)repeat;	
+    		
+    		//Get count of fieldpath field count and create an array with count, copy input to array
+    		int count = repeatAction.getFieldPathCount();
+    		
+    		 returnObj = new String[count];
+    	      for(int i = 0; i < count; i++) {
+    	    	  returnObj[i] = input;
+    	      }
+    	}   
+      return returnObj;
+	 }
 
     @AtlasActionProcessor
     public static Boolean startsWith(StartsWith startsWith, String input) {

--- a/lib/core/src/test/java/io/atlasmap/core/BaseDefaultAtlasContextTest.java
+++ b/lib/core/src/test/java/io/atlasmap/core/BaseDefaultAtlasContextTest.java
@@ -250,6 +250,11 @@ public abstract class BaseDefaultAtlasContextTest {
             field.setValue(value);
             return field;
         }
+		@Override
+		public Field readField(AtlasInternalSession session, String fieldPath) throws AtlasException {
+			// TODO Auto-generated method stub
+			return null;
+		}
     }
 
     protected class MockFieldWriter implements AtlasFieldWriter {

--- a/lib/core/src/test/java/io/atlasmap/core/DefaultAtlasSessionTest.java
+++ b/lib/core/src/test/java/io/atlasmap/core/DefaultAtlasSessionTest.java
@@ -243,6 +243,12 @@ public class DefaultAtlasSessionTest {
                 LOG.debug("read method");
                 return session.head().getSourceField();
             }
+
+			@Override
+			public Field readField(AtlasInternalSession session, String fieldPath) throws AtlasException {
+				// TODO Auto-generated method stub
+				return null;
+			}
         };
         session.setFieldReader(AtlasConstants.DEFAULT_SOURCE_DOCUMENT_ID, reader);
         assertNotNull(session.getFieldReader(null));
@@ -259,6 +265,12 @@ public class DefaultAtlasSessionTest {
                 LOG.debug("read method");
                 return session.head().getSourceField();
             }
+
+			@Override
+			public Field readField(AtlasInternalSession session, String fieldPath) throws AtlasException {
+				// TODO Auto-generated method stub
+				return null;
+			}
         };
         session.setFieldReader(null, reader);
         session.setFieldReader("", reader);

--- a/lib/model/src/main/java/io/atlasmap/v2/OneToManyAction.java
+++ b/lib/model/src/main/java/io/atlasmap/v2/OneToManyAction.java
@@ -1,0 +1,46 @@
+package io.atlasmap.v2;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "fieldPaths"
+)
+
+@JsonTypeIdResolver(ActionResolver.class)
+public abstract class OneToManyAction extends Action implements Serializable {
+
+    private final static long serialVersionUID = 1L;
+    
+    protected String fieldPath;
+    private int fieldPathCount;
+
+    @JsonProperty("fieldPath")
+    public String getFieldPath() {
+        return fieldPath;
+    }
+    
+    @JsonPropertyDescription("The fieldPath")
+    @AtlasActionProperty(title = "fieldPath", type = FieldType.STRING)
+    public void setFieldPath(String value) {
+        this.fieldPath = value;
+    }
+    
+    //How to avoid exposing this field to UI?
+    @JsonProperty("fieldPathCount")
+    public int getFieldPathCount() {
+        return fieldPathCount;
+    }
+    
+    @JsonPropertyDescription("fieldPath Count ")
+    @AtlasActionProperty(title = "fieldPathCount", type = FieldType.INTEGER)
+    public void setFieldPathCount(int value) {
+        this.fieldPathCount = value;
+    }
+}

--- a/lib/model/src/main/java/io/atlasmap/v2/RepeatForFieldPathCount.java
+++ b/lib/model/src/main/java/io/atlasmap/v2/RepeatForFieldPathCount.java
@@ -1,0 +1,8 @@
+package io.atlasmap.v2;
+
+import java.io.Serializable;
+
+public class RepeatForFieldPathCount extends OneToManyAction implements Serializable {
+
+    private final static long serialVersionUID = 1L;
+}

--- a/lib/model/src/main/resources/META-INF/services/io.atlasmap.v2.Action
+++ b/lib/model/src/main/resources/META-INF/services/io.atlasmap.v2.Action
@@ -60,3 +60,4 @@ io.atlasmap.v2.TrimLeft
 io.atlasmap.v2.TrimRight
 io.atlasmap.v2.Uppercase
 io.atlasmap.v2.UppercaseChar
+io.atlasmap.v2.RepeatForFieldPathCount

--- a/lib/modules/csv/core/src/main/java/io/atlasmap/csv/core/CsvFieldReader.java
+++ b/lib/modules/csv/core/src/main/java/io/atlasmap/csv/core/CsvFieldReader.java
@@ -65,7 +65,27 @@ public class CsvFieldReader implements AtlasFieldReader {
         }
     }
 
-    @Override
+	@Override
+	public Field readField(AtlasInternalSession session, String fieldPath) throws AtlasException {
+		Field field = new CsvField();
+		field.setPath(fieldPath);
+
+ 		if (document == null) {
+            AtlasUtil.addAudit(session, field.getDocId(),
+                String.format("Cannot read field '%s' of document '%s', document is null",
+                    field.getPath(), field.getDocId()),
+                field.getPath(), AuditStatus.ERROR, null);
+            return field;
+        }
+		
+		if (!(field instanceof CsvField) && !(field instanceof FieldGroup)) {
+			throw new AtlasException(String.format("Unsupported field type '%s'", field.getClass()));
+		}
+		Field readField = readFields((CsvField) field);
+		return readField;
+	}
+
+	@Override
     public Field read(AtlasInternalSession session) throws AtlasException {
         Field field = session.head().getSourceField();
 


### PR DESCRIPTION
one_to_many mapping - repeat source value based on count of fieldPath and do the target transformation. eg : for below mapping, where simple source field is mapped to array field, today there is a limitation, source field value gets copied to only first element of target array transformed data
![image](https://user-images.githubusercontent.com/4685287/81584507-71cd9300-93d0-11ea-992d-0ab51c957be4.png)

In the example, selected fieldPath = "/data<>"
If i send source file which has 'namespace' field value = 'test'
and count of 'data' field is 2, then 'repeat action' gives source transformed data as = ["test", "test"]
this source transformed data is further passed to target action transformation execution

For above mapping, source.json is
{
  "namespace": "iiot.schneider.mct.andon",
  "version": "1.0.0",
  "data": [
    {
      "Shift": 3,
      "ANDON Type": "Facility"
    },
    {
      "Shift": 100,
      "ANDON Type": "Quality-IQC"
    }
  ]
}

 and transformed data is below, where 'iiot.schneider.mct.andon' repeated for all target array elements
{
  "Site-Array" : "[{\"ExternalReference\":\"Facility\",\"ExternalReferenceSource\":\"iiot.schneider.mct.andon\"},{\"ExternalReference\":\"Quality-IQC\"}]",
  "ATLAS_DEFAULT_TARGET_DOC" : "[{\"ExternalReference\":\"Facility\",\"ExternalReferenceSource\":\"iiot.schneider.mct.andon\"},{\"ExternalReference\":\"Quality-IQC\"}]"
}