### PR TITLE
fix(ui): make drag & drop quicker

### DIFF
--- a/ui/packages/atlasmap/src/UI/dnd/DraggedField.tsx
+++ b/ui/packages/atlasmap/src/UI/dnd/DraggedField.tsx
@@ -8,7 +8,7 @@ export interface IIDraggedFieldChildrenProps {
   isDragging: boolean;
   currentOffset: XYCoord | null;
   draggedField: IDragAndDropField | null;
-  hoveredTarget: IDragAndDropField | null;
+  getHoveredTarget: () => IDragAndDropField | null;
 }
 
 export interface IDraggedFieldProps {
@@ -18,14 +18,19 @@ export interface IDraggedFieldProps {
 export const DraggedField: FunctionComponent<IDraggedFieldProps> = ({
   children,
 }) => {
-  const { hoveredTarget } = useFieldsDnd();
+  const { getHoveredTarget } = useFieldsDnd();
   const { isDragging, draggedField, currentOffset } = useDragLayer<
-    Omit<IIDraggedFieldChildrenProps, "hoveredTarget">
+    Omit<IIDraggedFieldChildrenProps, "getHoveredTarget">
   >((monitor) => ({
     draggedField: monitor.getItem(),
     currentOffset: monitor.getClientOffset(),
     isDragging: monitor.isDragging(),
   }));
 
-  return children({ isDragging, currentOffset, draggedField, hoveredTarget });
+  return children({
+    isDragging,
+    currentOffset,
+    draggedField,
+    getHoveredTarget,
+  });
 };

--- a/ui/packages/atlasmap/src/UI/dnd/FieldDropTarget.tsx
+++ b/ui/packages/atlasmap/src/UI/dnd/FieldDropTarget.tsx
@@ -29,7 +29,7 @@ export interface IFieldDropTargetProps
 
 export const FieldDropTarget = forwardRef<HTMLElement, IFieldDropTargetProps>(
   ({ accept, target, canDrop, as: As = "div", children, ...props }, ref) => {
-    const { setHoveredTarget, hoveredTarget } = useFieldsDnd();
+    const { setHoveredTarget } = useFieldsDnd();
     const [{ isOver, isDroppable, isTarget, field }, dropRef] = useDrop<
       IDragAndDropField,
       IDragAndDropField,
@@ -67,7 +67,7 @@ export const FieldDropTarget = forwardRef<HTMLElement, IFieldDropTargetProps>(
         wasOver.current = isOver;
         wasTarget.current = isTarget;
       }
-    }, [hoveredTarget, isOver, isTarget, setHoveredTarget, target]);
+    }, [isOver, isTarget, setHoveredTarget, target]);
 
     return (
       <As ref={handleRef} {...props}>

--- a/ui/packages/atlasmap/src/UI/dnd/FieldsDndProvider.tsx
+++ b/ui/packages/atlasmap/src/UI/dnd/FieldsDndProvider.tsx
@@ -1,33 +1,60 @@
 import React, {
   FunctionComponent,
   createContext,
-  useState,
+  useRef,
   useContext,
 } from "react";
 import { DndProvider } from "react-dnd";
 import TouchBackend from "react-dnd-touch-backend";
+import Html5Backend from "react-dnd-html5-backend";
 import { IDragAndDropField } from "./models";
 
+const probablyTouch =
+  window.matchMedia &&
+  window.matchMedia("(pointer: none)").matches &&
+  window.matchMedia("(hover: none)").matches;
+const maybeTouch =
+  window.matchMedia &&
+  (window.matchMedia("(pointer: coarse)").matches ||
+    window.matchMedia("(hover: none)").matches); // iOS is triggering this check, probably because it supports the Apple Pencil
+
+const TouchOnlyProvider: FunctionComponent = ({ children }) => (
+  <DndProvider backend={TouchBackend}>{children}</DndProvider>
+);
+
+const TouchAndPointerProvider: FunctionComponent = ({ children }) => (
+  <DndProvider backend={TouchBackend} options={{ enableMouseEvents: true }}>
+    {children}
+  </DndProvider>
+);
+
+const MouseOnlyProvider: FunctionComponent = ({ children }) => (
+  <DndProvider backend={Html5Backend}>{children}</DndProvider>
+);
+
 interface IFieldsDndContext {
-  hoveredTarget: IDragAndDropField | null;
+  getHoveredTarget: () => IDragAndDropField | null;
   setHoveredTarget: (target: IDragAndDropField | null) => void;
 }
 
 const FieldsDndContext = createContext<IFieldsDndContext | null>(null);
 
 export const FieldsDndProvider: FunctionComponent = ({ children }) => {
-  const [hoveredTarget, setHoveredTarget] = useState<IDragAndDropField | null>(
-    null,
-  );
+  const hoveredTarget = useRef<IDragAndDropField | null>(null);
+  const getHoveredTarget = () => hoveredTarget.current;
+  const setHoveredTarget = (target: IDragAndDropField | null) =>
+    (hoveredTarget.current = target);
+  const Provider = probablyTouch
+    ? TouchOnlyProvider
+    : maybeTouch
+    ? TouchAndPointerProvider
+    : MouseOnlyProvider;
   return (
-    <DndProvider
-      backend={TouchBackend}
-      options={{ enableMouseEvents: true, delay: window.Touch ? 100 : 0 }}
-    >
-      <FieldsDndContext.Provider value={{ hoveredTarget, setHoveredTarget }}>
+    <Provider>
+      <FieldsDndContext.Provider value={{ getHoveredTarget, setHoveredTarget }}>
         {children}
       </FieldsDndContext.Provider>
-    </DndProvider>
+    </Provider>
   );
 };
 

--- a/ui/packages/atlasmap/src/Views/ColumnMapperView/Columns/MappingsColumn.tsx
+++ b/ui/packages/atlasmap/src/Views/ColumnMapperView/Columns/MappingsColumn.tsx
@@ -53,10 +53,8 @@ export const MappingsColumn: FunctionComponent<
             </div>
           </NodeRef>
           <DraggedField>
-            {({ draggedField, hoveredTarget }) =>
-              draggedField &&
-              hoveredTarget &&
-              hoveredTarget.type !== "mapping" ? (
+            {({ draggedField, getHoveredTarget }) =>
+              draggedField && getHoveredTarget()?.type !== "mapping" ? (
                 <NodeRef
                   id={["dnd-new-mapping"]}
                   boundaryId={MAPPINGS_HEIGHT_BOUNDARY_ID}


### PR DESCRIPTION
The backend used by the DndProvider was the Touch one with support for
mouse events enabled. The Touch backend isn't the best when used on
"pure desktop" environments because of the need to understand if the
user is performing a click or a drag, which introduces some lag.

With this we perform some device capability detection relying on CSS
media query on the `hover` and `pointer` capabilities. This isn't
bulletproof but should make for a better experience than before.

Fixes #2053.