### PR TITLE
chore(ui): load sourcemaps only for our own packages

### DIFF
--- a/ui/packages/atlasmap/.storybook/webpack.config.js
+++ b/ui/packages/atlasmap/.storybook/webpack.config.js
@@ -31,7 +31,10 @@ module.exports = ({ config }) => {
   config.module.rules.push({
     test: /\.js$/,
     use: ["source-map-loader"],
-    enforce: "pre"
+    enforce: "pre",
+    include: [
+      path.resolve(__dirname, "..")
+    ]
   })
   
 


### PR DESCRIPTION
This gets rid of the warnings when building and running Storybook.