### PR TITLE
feat(ui): make tree items lazy

### DIFF
--- a/ui/packages/atlasmap/src/Views/ColumnMapperView/Columns/TreeGroupAndNodeRefsAndDnD.tsx
+++ b/ui/packages/atlasmap/src/Views/ColumnMapperView/Columns/TreeGroupAndNodeRefsAndDnD.tsx
@@ -8,6 +8,7 @@ import {
   FieldDropTarget,
   NodeRef,
   TreeGroup,
+  ITreeGroupProps,
 } from "../../../UI";
 import { AtlasmapDocumentType, IAtlasmapGroup } from "../../../Views";
 
@@ -23,6 +24,7 @@ export interface ITreeGroupAndNodeRefsAndDnDProps {
   level?: number;
   position?: number;
   setSize?: number;
+  children: ITreeGroupProps["children"];
 }
 
 export const TreeGroupAndNodeRefsAndDnD: FunctionComponent<ITreeGroupAndNodeRefsAndDnDProps> = ({
@@ -63,7 +65,7 @@ export const TreeGroupAndNodeRefsAndDnD: FunctionComponent<ITreeGroupAndNodeRefs
               level={level}
               position={position}
               setSize={setSize}
-              expanded={isOver === true}
+              expanded={isOver === true ? true : undefined}
               renderLabel={({ expanded }) => (
                 <DocumentGroup
                   name={group.name}
@@ -74,7 +76,7 @@ export const TreeGroupAndNodeRefsAndDnD: FunctionComponent<ITreeGroupAndNodeRefs
                 />
               )}
             >
-              {() => children}
+              {children}
             </TreeGroup>
           </NodeRef>
         )}


### PR DESCRIPTION
Also preserve the previously expanded state when ending a drag&drop
interaction.

This fixes loading the FHIR document, and in general improves performance.

![2020-05-13 at 11 42 13 - Red Penguin](https://user-images.githubusercontent.com/966316/81797382-fc1c1100-950e-11ea-938f-85f6953a2f81.gif)
