### PR TITLE
fix: When creating a new property, set focus in first field

### DIFF
--- a/ui/packages/atlasmap/src/UI/useInputTextSelectDialog.tsx
+++ b/ui/packages/atlasmap/src/UI/useInputTextSelectDialog.tsx
@@ -169,6 +169,7 @@ export function useInputTextSelectDialog({
             isDisabled={text1ReadOnly}
             placeholder={textLabel1}
             data-testid={"itsd-value1-text-input"}
+            autoFocus
           />
         </>
       )}


### PR DESCRIPTION
Fixes #2055 