### PR TITLE
feat(ui): group notifications inside the mapping details

### DIFF
--- a/ui/packages/atlasmap/src/UI/Document.tsx
+++ b/ui/packages/atlasmap/src/UI/Document.tsx
@@ -23,26 +23,37 @@ import { AngleDownIcon, AngleRightIcon } from "@patternfly/react-icons";
 import { TruncatedString } from "./TruncatedString";
 
 const styles = StyleSheet.create({
-  card: {},
+  card: {
+    padding: "0 !important",
+  },
   stacked: {
     margin: "1rem 0",
   },
   head: {
-    paddingLeft: "0.5rem !important",
-    paddingRight: "0.5rem !important",
+    padding: "0.5rem 0 !important",
   },
   header: {
     width: "100%",
     overflow: "hidden",
   },
+  actions: {
+    alignSelf: "center",
+  },
   headerButton: {
     maxWidth: "100%",
   },
-  noPadding: {
+  bodyNoPadding: {
     padding: "0 !important",
   },
+  bodyWithPadding: {
+    padding: "0 1rem 1rem !important",
+  },
+  noCardPadding: {},
   hidden: {
     display: "none",
+  },
+  noShadows: {
+    boxShadow: "none !important",
   },
   dropTarget: {
     "&:before": {
@@ -68,6 +79,7 @@ export interface IDocumentProps
   stacked?: boolean;
   scrollIntoView?: boolean;
   noPadding?: boolean;
+  noShadows?: boolean;
   startExpanded?: boolean;
   onSelect?: () => void;
   onDeselect?: () => void;
@@ -90,6 +102,7 @@ export const Document = forwardRef<
       selectable = false,
       scrollIntoView = false,
       noPadding = false,
+      noShadows = false,
       startExpanded = true,
       onSelect,
       onDeselect,
@@ -144,6 +157,7 @@ export const Document = forwardRef<
           isCompact={true}
           className={css(
             styles.card,
+            noShadows && styles.noShadows,
             dropAccepted && !dropTarget && styles.dropAccepted,
             dropTarget && styles.dropTarget,
           )}
@@ -153,7 +167,9 @@ export const Document = forwardRef<
         >
           {(title || actions) && (
             <CardHead className={css(styles.head)}>
-              <CardActions>{actions?.filter((a) => a)}</CardActions>
+              <CardActions className={css(styles.actions)}>
+                {actions?.filter((a) => a)}
+              </CardActions>
               {title && (
                 <CardHeader className={css(styles.header)}>
                   <Button
@@ -176,7 +192,7 @@ export const Document = forwardRef<
           )}
           <CardBody
             className={css(
-              noPadding && styles.noPadding,
+              noPadding ? styles.bodyNoPadding : styles.bodyWithPadding,
               !isExpanded && styles.hidden,
             )}
           >

--- a/ui/packages/atlasmap/src/UI/MappingTransformation.tsx
+++ b/ui/packages/atlasmap/src/UI/MappingTransformation.tsx
@@ -24,7 +24,9 @@ export interface ITransformationArgument {
 }
 
 const styles = StyleSheet.create({
-  wrapper: {
+  wrapper: {},
+  wrapperPadded: {
+    padding: "1rem",
     "& + &": {
       borderTop:
         "var(--pf-global--BorderWidth--md) solid var(--pf-global--BorderColor--300)",
@@ -33,9 +35,6 @@ const styles = StyleSheet.create({
       borderBottom:
         "var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100)",
     },
-  },
-  wrapperPadded: {
-    padding: "1rem",
   },
   spaced: {
     margin: "var(--pf-global--spacer--form-element) 0",

--- a/ui/packages/atlasmap/src/UI/Tree/Tree.tsx
+++ b/ui/packages/atlasmap/src/UI/Tree/Tree.tsx
@@ -7,7 +7,7 @@ import { TreeFocusProvider } from "./TreeFocusProvider";
 
 const styles = StyleSheet.create({
   accordion: {
-    padding: "0 1.3rem 0 0.5rem !important",
+    padding: "0 1rem 0 0 !important", // TODO: this padding should be 0 and the right spacing should be given by DocumentGroup
   },
 });
 

--- a/ui/packages/atlasmap/src/Views/MappingDetailsView.tsx
+++ b/ui/packages/atlasmap/src/Views/MappingDetailsView.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from "react";
 
-import { Alert, AlertActionCloseButton } from "@patternfly/react-core";
+import { Alert, AlertActionCloseButton, Badge } from "@patternfly/react-core";
 
 import { MappingDetailsSidebar } from "../Layout";
 import {
@@ -9,6 +9,7 @@ import {
   MappingField,
   MappingFields,
   MappingTransformation,
+  Document,
 } from "../UI";
 import { IAtlasmapField, IAtlasmapMappedField, INotification } from "./models";
 
@@ -81,15 +82,17 @@ export const MappingDetailsView: FunctionComponent<IMappingDetailsViewProps> = (
   multiplicity,
 }) => {
   const mappingAction = multiplicity && (
-    <MappingTransformation
-      name={multiplicity.name}
-      disableTransformation={mappingExpressionEnabled}
-      transformationsOptions={multiplicity.transformationsOptions}
-      transformationsArguments={multiplicity.transformationsArguments}
-      onTransformationChange={multiplicity.onChange}
-      onTransformationArgumentChange={multiplicity.onArgumentChange}
-      noPaddings={true}
-    />
+    <div style={{ margin: "1rem 0" }}>
+      <MappingTransformation
+        name={multiplicity.name}
+        disableTransformation={mappingExpressionEnabled}
+        transformationsOptions={multiplicity.transformationsOptions}
+        transformationsArguments={multiplicity.transformationsArguments}
+        onTransformationChange={multiplicity.onChange}
+        onTransformationArgumentChange={multiplicity.onArgumentChange}
+        noPaddings={true}
+      />
+    </div>
   );
 
   const renderMappingField = (
@@ -157,24 +160,35 @@ export const MappingDetailsView: FunctionComponent<IMappingDetailsViewProps> = (
     index: number,
   ) => renderMappingField(false, showTargetsIndex, f, index);
 
+  const errors = notifications.filter((n) => n.variant === "danger");
+  const warnings = notifications.filter((n) => n.variant === "warning");
+  const messages = notifications.filter(
+    (n) => n.variant !== "warning" && n.variant !== "danger",
+  );
+
   return (
     <MappingDetailsSidebar onDelete={onRemoveMapping} onClose={onClose}>
-      {notifications.map((n, idx) => (
-        <Alert
-          key={idx}
-          variant={n.variant}
-          title={n.description}
-          isInline={true}
-          action={
-            <AlertActionCloseButton
-              title={n.title}
-              variantLabel={`${n.variant} alert`}
-              onClose={() => onNotificationRead(n.id)}
-              data-testid={`dismiss-mapping-notification-${n.id}`}
-            />
-          }
+      {errors.length > 0 && (
+        <NotificationsGroup
+          notifications={errors}
+          title={"Errors"}
+          onNotificationRead={onNotificationRead}
         />
-      ))}
+      )}
+      {warnings.length > 0 && (
+        <NotificationsGroup
+          notifications={warnings}
+          title={"Warnings"}
+          onNotificationRead={onNotificationRead}
+        />
+      )}
+      {messages.length > 0 && (
+        <NotificationsGroup
+          notifications={messages}
+          title={"Messages"}
+          onNotificationRead={onNotificationRead}
+        />
+      )}
       {mappingAction}
       <MappingFields title={"Sources"}>
         {sources.map(renderSourceMappingField)}
@@ -207,5 +221,45 @@ export const MappingDetailsView: FunctionComponent<IMappingDetailsViewProps> = (
         )}
       </MappingFields>
     </MappingDetailsSidebar>
+  );
+};
+
+interface INotificationsGroupProps {
+  title: string;
+  notifications: INotification[];
+  onNotificationRead: (id: string) => void;
+}
+
+const NotificationsGroup: FunctionComponent<INotificationsGroupProps> = ({
+  title,
+  notifications,
+  onNotificationRead,
+}) => {
+  return (
+    <Document
+      title={title}
+      noShadows={true}
+      noPadding={true}
+      actions={[<Badge key={1}>{notifications.length}</Badge>]}
+    >
+      <div style={{ maxHeight: 200, overflow: "auto" }}>
+        {notifications.map((n, idx) => (
+          <Alert
+            key={idx}
+            variant={n.variant}
+            title={n.description}
+            isInline={true}
+            action={
+              <AlertActionCloseButton
+                title={n.title}
+                variantLabel={`${n.variant} alert`}
+                onClose={() => onNotificationRead(n.id)}
+                data-testid={`dismiss-mapping-notification-${n.id}`}
+              />
+            }
+          />
+        ))}
+      </div>
+    </Document>
   );
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/966316/82454790-7e2dac00-9ab2-11ea-8d6e-78464e3bd747.png)

This is a workaround 'til the [Notification Drawer](https://patternfly-react.surge.sh/documentation/react/components/notificationdrawer) from the next major release of PatternFly lands.

Ref ENTESB-13740