### PR TITLE
Make sure we populate complex field's children

### DIFF
--- a/ui/packages/atlasmap-core/src/models/document-definition.model.ts
+++ b/ui/packages/atlasmap-core/src/models/document-definition.model.ts
@@ -251,6 +251,7 @@ export class DocumentDefinition {
     for (const field of this.fields) {
       this.populateFieldParentPaths(field, null, 0);
       this.populateFieldData(field);
+      this.populateChildren(field);
     }
 
     this.fieldPaths.sort();


### PR DESCRIPTION
Fixes ENTESB-13817

This fragment of HTML from the angular UI was not ported to the React UI:
https://github.com/atlasmap/atlasmap/blob/master/__ui-old/src/app/lib/atlasmap-data-mapper/components/document/document-field-detail.component.html#L21

Even in recursive field references you populate the children once with
cached field children.