### PR TITLE
fix: The delete/transform icons in mapping details page are not aligned

### DIFF
--- a/ui/packages/atlasmap/src/UI/MappingField.tsx
+++ b/ui/packages/atlasmap/src/UI/MappingField.tsx
@@ -110,8 +110,8 @@ export const MappingField: FunctionComponent<IMappingFieldProps> = ({
             </Tooltip>
           </Title>
         </SplitItem>
-        <SplitItem>
-          {onNewTransformation && (
+        {onNewTransformation && (
+          <SplitItem>
             <Button
               variant={"plain"}
               onClick={onNewTransformation}
@@ -120,7 +120,9 @@ export const MappingField: FunctionComponent<IMappingFieldProps> = ({
             >
               <BoltIcon />
             </Button>
-          )}
+          </SplitItem>
+        )}
+        <SplitItem>
           <Button
             variant={"plain"}
             onClick={onDelete}


### PR DESCRIPTION
Fixes #2114 