### PR TITLE
fix(ui): address UXD feedback for toolbars

### DIFF
--- a/standalone/src/test/java/io/atlasmap/standalone/E2ETest.java
+++ b/standalone/src/test/java/io/atlasmap/standalone/E2ETest.java
@@ -90,7 +90,10 @@ public class E2ETest {
         driver.get("http://127.0.0.1:" + port);
         WebDriverWait waitForLoad = new WebDriverWait(driver, 5);
         waitForLoad.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//article[@aria-label='Properties']")));
-        WebElement importBtn = driver.findElement(By.xpath("//button[@data-testid='import-mappings-button']"));
+        WebElement atlasmapMenuBtn = driver.findElement(By.xpath("//button[@data-testid='atlasmap-menu-button']"));
+        atlasmapMenuBtn.click();
+        waitForLoad.until(ExpectedConditions.elementToBeClickable(By.xpath("//a[@data-testid='import-mappings-button']")));
+        WebElement importBtn = driver.findElement(By.xpath("//a[@data-testid='import-mappings-button']"));
         importBtn.click();
         WebElement fileInput = driver.findElement(By.xpath("//div[@id='data-toolbar']//input[@type='file']"));
         String cwd = System.getProperty("user.dir");
@@ -114,7 +117,10 @@ public class E2ETest {
             "//div[@role='dialog']//div[@aria-labelledby='mapping-field-city']")));
         assertNotNull(detailsCity);
 
-        WebElement exportBtn = driver.findElement(By.xpath("//button[@data-testid='export-mappings-button']"));
+        atlasmapMenuBtn = driver.findElement(By.xpath("//button[@data-testid='atlasmap-menu-button']"));
+        atlasmapMenuBtn.click();
+        waitForLoad.until(ExpectedConditions.elementToBeClickable(By.xpath("//a[@data-testid='export-mappings-button']")));
+        WebElement exportBtn = driver.findElement(By.xpath("//a[@data-testid='export-mappings-button']"));
         exportBtn.click();
         WebElement dialogDiv = driver.findElement(By.xpath("//div[@role='dialog' and @aria-label='Export Mappings and Documents.']"));
         WebElement exportInput = dialogDiv.findElement(By.id("filename"));

--- a/ui/packages/atlasmap/src/Atlasmap/Atlasmap.stories.tsx
+++ b/ui/packages/atlasmap/src/Atlasmap/Atlasmap.stories.tsx
@@ -95,7 +95,7 @@ export const wiredToTheBackend = () => (
         ),
         showToggleMappingColumnToolbarItem: boolean(
           "showToggleMappingColumnToolbarItem",
-          true,
+          false,
         ),
         showMappingTableViewToolbarItem: boolean(
           "showToggleMappingTableToolbarItem",
@@ -114,7 +114,10 @@ export const wiredToTheBackend = () => (
           "showToggleUnmappedFieldsToolbarItem",
           true,
         ),
-        showFreeViewToolbarItem: boolean("showToggleFreeViewToolbarItem", true),
+        showFreeViewToolbarItem: boolean(
+          "showToggleFreeViewToolbarItem",
+          false,
+        ),
       }}
     />
   </AtlasmapProvider>

--- a/ui/packages/atlasmap/src/Atlasmap/Atlasmap.tsx
+++ b/ui/packages/atlasmap/src/Atlasmap/Atlasmap.tsx
@@ -60,6 +60,7 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
     onFieldPreviewChange,
     searchSources,
     searchTargets,
+    importAtlasFile,
     // expression
     currentMappingExpression,
     executeFieldSearch,
@@ -91,10 +92,12 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
     contextToolbar,
   } = useContextToolbar({
     showImportAtlasFileToolbarItem: allowImport,
+    showImportJarFileToolbarItem: allowImport,
     showExportAtlasFileToolbarItem: allowExport,
     showResetToolbarItem: allowReset,
     ...toolbarOptions,
     onImportAtlasFile: handlers.onImportAtlasCatalog,
+    onImportJarFile: (file) => importAtlasFile(file, false),
     onExportAtlasFile: handlers.onExportAtlasCatalog,
     onResetAtlasmap: handlers.onResetAtlasmap,
   });
@@ -111,18 +114,20 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
   const viewToolbar = (
     <ViewToolbar>
       <ConditionalExpressionInput
-        mappingExpression={currentMappingExpression}
+        mappingExpression={
+          mappingExpressionEnabled ? currentMappingExpression : undefined
+        }
         executeFieldSearch={executeFieldSearch}
         mappingExpressionAddField={mappingExpressionAddField}
         mappingExpressionClearText={mappingExpressionClearText}
         isMappingExpressionEmpty={isMappingExpressionEmpty}
-        mappingExpressionEnabled={mappingExpressionEnabled}
         mappingExpressionInit={mappingExpressionInit}
         mappingExpressionInsertText={mappingExpressionInsertText}
         mappingExpressionObservable={mappingExpressionObservable}
         mappingExpressionRemoveField={mappingExpressionRemoveField}
-        onToggleExpressionMode={handlers.onToggleExpressionMode}
         trailerId={trailerId}
+        disabled={!selectedMapping}
+        onToggle={handlers.onToggleExpressionMode}
       />
     </ViewToolbar>
   );

--- a/ui/packages/atlasmap/src/Atlasmap/toolbarItems.tsx
+++ b/ui/packages/atlasmap/src/Atlasmap/toolbarItems.tsx
@@ -1,7 +1,16 @@
 import React, { FunctionComponent, useEffect, useRef } from "react";
 import { useFilePicker } from "react-sage";
 
-import { Button, ToolbarItem, Tooltip } from "@patternfly/react-core";
+import {
+  Button,
+  ToolbarItem,
+  Tooltip,
+  Dropdown,
+  DropdownToggle,
+  DropdownItem,
+  DropdownSeparator,
+  DropdownItemIcon,
+} from "@patternfly/react-core";
 import {
   BezierCurveIcon,
   CodeIcon,
@@ -15,17 +24,98 @@ import {
   TableIcon,
   ColumnsIcon,
   TrashIcon,
+  CaretDownIcon,
 } from "@patternfly/react-icons";
 import { css, StyleSheet } from "@patternfly/react-styles";
+import { useToggle } from "../UI";
 
 const styles = StyleSheet.create({
   toggled: { color: "var(--pf-global--primary-color--100) !important" },
 });
 
+export interface IAtlasmapToolbarItemProps {
+  showImportAtlasFileToolbarItem: boolean;
+  showImportJarFileToolbarItem: boolean;
+  showExportAtlasFileToolbarItem: boolean;
+  showResetToolbarItem: boolean;
+  onImportAtlasFile: (file: File) => void;
+  onImportJarFile: (file: File) => void;
+  onExportAtlasFile: () => void;
+  onResetAtlasmap: () => void;
+}
+export const AtlasmapToolbarItem: FunctionComponent<IAtlasmapToolbarItemProps> = ({
+  showImportAtlasFileToolbarItem,
+  showImportJarFileToolbarItem,
+  showExportAtlasFileToolbarItem,
+  showResetToolbarItem,
+  onImportAtlasFile,
+  onImportJarFile,
+  onExportAtlasFile,
+  onResetAtlasmap,
+}) => {
+  const { state: isOpen, toggle: onToggle, toggleOff } = useToggle(false);
+  const runAndClose = (cb: (...args: any[]) => any) => {
+    return (...args: any[]) => {
+      cb(...args);
+      toggleOff();
+    };
+  };
+  const dropdownItems = [
+    showImportAtlasFileToolbarItem && (
+      <ImportAtlasFileToolbarItem
+        onFile={runAndClose(onImportAtlasFile)}
+        key="import-catalog"
+      />
+    ),
+    showImportJarFileToolbarItem && (
+      <ImportJarFileToolbarItem
+        onFile={runAndClose(onImportJarFile)}
+        key="import-java-archive"
+      />
+    ),
+    (showImportAtlasFileToolbarItem || showImportJarFileToolbarItem) && (
+      <DropdownSeparator key="import-separator" />
+    ),
+    showExportAtlasFileToolbarItem && (
+      <ExportAtlasFileToolbarItem
+        onClick={runAndClose(onExportAtlasFile)}
+        key={"export-catalog"}
+      />
+    ),
+    showExportAtlasFileToolbarItem && (
+      <DropdownSeparator key="export-separator" />
+    ),
+    showResetToolbarItem && (
+      <ResetToolbarItem
+        onClick={runAndClose(onResetAtlasmap)}
+        key="reset-catalog"
+      />
+    ),
+  ].filter((f) => f);
+  return (
+    <ToolbarItem>
+      <Dropdown
+        toggle={
+          <DropdownToggle
+            id="atlasmap-toggle"
+            onToggle={onToggle}
+            iconComponent={CaretDownIcon}
+            data-testid="atlasmap-menu-button"
+          >
+            AtlasMap
+          </DropdownToggle>
+        }
+        isOpen={isOpen}
+        dropdownItems={dropdownItems}
+        isPlain={true}
+      />
+    </ToolbarItem>
+  );
+};
+
 export const ImportAtlasFileToolbarItem: FunctionComponent<{
-  disabled?: boolean;
   onFile: (file: File) => void;
-}> = ({ disabled = false, onFile }) => {
+}> = ({ onFile }) => {
   const { files, onClick, HiddenFileInput } = useFilePicker({
     maxFileSize: 1,
   });
@@ -35,87 +125,72 @@ export const ImportAtlasFileToolbarItem: FunctionComponent<{
     if (previouslyUploadedFiles.current !== files) {
       previouslyUploadedFiles.current = files;
       if (files?.length === 1) {
+        previouslyUploadedFiles.current = null;
         onFile(files[0]);
       }
     }
   }, [files, onFile]);
 
   return (
-    <ToolbarItem>
-      <Tooltip
-        position={"auto"}
-        enableFlip={true}
-        content={
-          <div>
-            Import an AtlasMap mappings catalog file (.adm) or Java archive
-            (.jar).
-          </div>
-        }
-      >
-        <Button
-          variant={"plain"}
-          aria-label="Import mappings"
-          isDisabled={disabled}
-          data-testid="import-mappings-button"
-          onClick={onClick}
-        >
-          <ImportIcon />
-        </Button>
-      </Tooltip>
-      <HiddenFileInput accept=".adm, .jar" multiple={false} />
-    </ToolbarItem>
+    <DropdownItem onClick={onClick} data-testid="import-mappings-button">
+      <DropdownItemIcon>
+        <ImportIcon />
+      </DropdownItemIcon>
+      Import a catalog (.adm)
+      <HiddenFileInput accept=".adm" multiple={false} />
+    </DropdownItem>
+  );
+};
+
+export const ImportJarFileToolbarItem: FunctionComponent<{
+  onFile: (file: File) => void;
+}> = ({ onFile }) => {
+  const { files, onClick, HiddenFileInput } = useFilePicker({
+    maxFileSize: 1,
+  });
+  const previouslyUploadedFiles = useRef<File[] | null>(null);
+
+  useEffect(() => {
+    if (previouslyUploadedFiles.current !== files) {
+      previouslyUploadedFiles.current = files;
+      if (files?.length === 1) {
+        previouslyUploadedFiles.current = null;
+        onFile(files[0]);
+      }
+    }
+  }, [files, onFile]);
+
+  return (
+    <DropdownItem onClick={onClick} data-testid="import-archive-button">
+      <DropdownItemIcon>
+        <ImportIcon />
+      </DropdownItemIcon>
+      Import a Java archive (.jar)
+      <HiddenFileInput accept=".jar" multiple={false} />
+    </DropdownItem>
   );
 };
 
 export const ExportAtlasFileToolbarItem: FunctionComponent<{
-  disabled?: boolean;
   onClick: () => void;
-}> = ({ disabled = false, onClick }) => (
-  <ToolbarItem>
-    <Tooltip
-      position={"auto"}
-      enableFlip={true}
-      content={
-        <div>
-          Export the current mappings and support files into a catalog (.adm)
-          file.
-        </div>
-      }
-    >
-      <Button
-        variant={"plain"}
-        aria-label="Export mappings"
-        onClick={onClick}
-        isDisabled={disabled}
-        data-testid="export-mappings-button"
-      >
-        <ExportIcon />
-      </Button>
-    </Tooltip>
-  </ToolbarItem>
+}> = ({ onClick }) => (
+  <DropdownItem onClick={onClick} data-testid="export-mappings-button">
+    <DropdownItemIcon>
+      <ExportIcon />
+    </DropdownItemIcon>
+    Export the current mappings and support files into a catalog (.adm)
+  </DropdownItem>
 );
 
 export const ResetToolbarItem: FunctionComponent<{
-  disabled?: boolean;
   onClick: () => void;
-}> = ({ disabled = false, onClick }) => (
-  <ToolbarItem>
-    <Tooltip
-      position={"auto"}
-      enableFlip={true}
-      content={<div>Reset all mappings and clear all imported documents</div>}
-    >
-      <Button
-        variant={"plain"}
-        aria-label="Reset all"
-        onClick={onClick}
-        isDisabled={disabled}
-        data-testid="reset-all-button"
-      >
-        <TrashIcon />
-      </Button>
-    </Tooltip>
-  </ToolbarItem>
+}> = ({ onClick }) => (
+  <DropdownItem onClick={onClick} data-testid="reset-all-button">
+    <DropdownItemIcon>
+      <TrashIcon />
+    </DropdownItemIcon>
+    Reset all mappings and clear all imported documents
+  </DropdownItem>
 );
 
 export const ToggleMappingColumnToolbarItem: FunctionComponent<{

--- a/ui/packages/atlasmap/src/Atlasmap/useContextToolbar.tsx
+++ b/ui/packages/atlasmap/src/Atlasmap/useContextToolbar.tsx
@@ -5,9 +5,6 @@ import { ToolbarGroup } from "@patternfly/react-core";
 import { ContextToolbar } from "../Layout";
 import { useToggle } from "../UI";
 import {
-  ExportAtlasFileToolbarItem,
-  ImportAtlasFileToolbarItem,
-  ResetToolbarItem,
   ToggleColumnMapperViewToolbarItem,
   ToggleFreeViewToolbarItem,
   ToggleMappedFieldsToolbarItem,
@@ -17,6 +14,7 @@ import {
   ToggleNamespaceTableViewToolbarItem,
   ToggleTypesToolbarItem,
   ToggleUnmappedFieldsToolbarItem,
+  AtlasmapToolbarItem,
 } from "./toolbarItems";
 import { useAtlasmap } from "./AtlasmapProvider";
 
@@ -28,12 +26,14 @@ export type Views =
 
 export interface IUseContextToolbarHandlers {
   onImportAtlasFile: (file: File) => void;
+  onImportJarFile: (file: File) => void;
   onExportAtlasFile: () => void;
   onResetAtlasmap: () => void;
 }
 
 export interface IUseContextToolbarData {
   showImportAtlasFileToolbarItem?: boolean;
+  showImportJarFileToolbarItem?: boolean;
   showExportAtlasFileToolbarItem?: boolean;
   showResetToolbarItem?: boolean;
 
@@ -51,6 +51,7 @@ export interface IUseContextToolbarData {
 
 export function useContextToolbar({
   showImportAtlasFileToolbarItem = true,
+  showImportJarFileToolbarItem = true,
   showExportAtlasFileToolbarItem = true,
   showResetToolbarItem = true,
 
@@ -66,6 +67,7 @@ export function useContextToolbar({
   showToggleUnmappedFieldsToolbarItem = true,
 
   onImportAtlasFile,
+  onImportJarFile,
   onExportAtlasFile,
   onResetAtlasmap,
 }: IUseContextToolbarData & IUseContextToolbarHandlers) {
@@ -97,43 +99,54 @@ export function useContextToolbar({
   const contextToolbar = useMemo(
     () => (
       <ContextToolbar>
-        <ToolbarGroup>
-          {showImportAtlasFileToolbarItem && (
-            <ImportAtlasFileToolbarItem onFile={onImportAtlasFile} />
-          )}
-          {showExportAtlasFileToolbarItem && (
-            <ExportAtlasFileToolbarItem onClick={onExportAtlasFile} />
-          )}
-          {showResetToolbarItem && (
-            <ResetToolbarItem onClick={onResetAtlasmap} />
-          )}
-        </ToolbarGroup>
-        <ToolbarGroup>
-          {showColumnMapperViewToolbarItem && (
-            <ToggleColumnMapperViewToolbarItem
-              toggled={activeView === "ColumnMapper"}
-              onClick={() => setActiveView("ColumnMapper")}
+        {(showImportAtlasFileToolbarItem ||
+          showImportJarFileToolbarItem ||
+          showExportAtlasFileToolbarItem ||
+          showResetToolbarItem) && (
+          <ToolbarGroup>
+            <AtlasmapToolbarItem
+              showImportAtlasFileToolbarItem={showImportAtlasFileToolbarItem}
+              showImportJarFileToolbarItem={showImportJarFileToolbarItem}
+              showExportAtlasFileToolbarItem={showExportAtlasFileToolbarItem}
+              showResetToolbarItem={showResetToolbarItem}
+              onImportAtlasFile={onImportAtlasFile}
+              onImportJarFile={onImportJarFile}
+              onExportAtlasFile={onExportAtlasFile}
+              onResetAtlasmap={onResetAtlasmap}
             />
-          )}
-          {showMappingTableViewToolbarItem && (
-            <ToggleMappingTableViewToolbarItem
-              toggled={activeView === "MappingTable"}
-              onClick={() => setActiveView("MappingTable")}
-            />
-          )}
-          {showFreeViewToolbarItem && (
-            <ToggleFreeViewToolbarItem
-              toggled={activeView === "FreeView"}
-              onClick={() => setActiveView("FreeView")}
-            />
-          )}
-          {showNamespaceTableViewToolbarItem && (
-            <ToggleNamespaceTableViewToolbarItem
-              toggled={activeView === "NamespaceTable"}
-              onClick={() => setActiveView("NamespaceTable")}
-            />
-          )}
-        </ToolbarGroup>
+          </ToolbarGroup>
+        )}
+        {(showColumnMapperViewToolbarItem ||
+          showMappingTableViewToolbarItem ||
+          showFreeViewToolbarItem ||
+          showNamespaceTableViewToolbarItem) && (
+          <ToolbarGroup>
+            {showColumnMapperViewToolbarItem && (
+              <ToggleColumnMapperViewToolbarItem
+                toggled={activeView === "ColumnMapper"}
+                onClick={() => setActiveView("ColumnMapper")}
+              />
+            )}
+            {showMappingTableViewToolbarItem && (
+              <ToggleMappingTableViewToolbarItem
+                toggled={activeView === "MappingTable"}
+                onClick={() => setActiveView("MappingTable")}
+              />
+            )}
+            {showFreeViewToolbarItem && (
+              <ToggleFreeViewToolbarItem
+                toggled={activeView === "FreeView"}
+                onClick={() => setActiveView("FreeView")}
+              />
+            )}
+            {showNamespaceTableViewToolbarItem && (
+              <ToggleNamespaceTableViewToolbarItem
+                toggled={activeView === "NamespaceTable"}
+                onClick={() => setActiveView("NamespaceTable")}
+              />
+            )}
+          </ToolbarGroup>
+        )}
         <ToolbarGroup>
           {showToggleMappingColumnToolbarItem &&
             activeView === "ColumnMapper" && (
@@ -177,16 +190,18 @@ export function useContextToolbar({
     ),
     [
       showImportAtlasFileToolbarItem,
-      onImportAtlasFile,
+      showImportJarFileToolbarItem,
       showExportAtlasFileToolbarItem,
-      onExportAtlasFile,
       showResetToolbarItem,
+      onImportAtlasFile,
+      onImportJarFile,
+      onExportAtlasFile,
       onResetAtlasmap,
       showColumnMapperViewToolbarItem,
-      activeView,
       showMappingTableViewToolbarItem,
-      showNamespaceTableViewToolbarItem,
       showFreeViewToolbarItem,
+      showNamespaceTableViewToolbarItem,
+      activeView,
       showToggleMappingColumnToolbarItem,
       showMappingColumn,
       toggleShowMappingColumn,

--- a/ui/packages/atlasmap/src/Layout/MainLayout.tsx
+++ b/ui/packages/atlasmap/src/Layout/MainLayout.tsx
@@ -8,6 +8,7 @@ import { Sidebar } from "./Sidebar";
 
 const styles = StyleSheet.create({
   view: {
+    background: "#fff",
     "& .pf-topology-container": {
       overflow: "hidden",
     },

--- a/ui/packages/atlasmap/src/UI/ConditionalExpressionInput.tsx
+++ b/ui/packages/atlasmap/src/UI/ConditionalExpressionInput.tsx
@@ -1,10 +1,5 @@
 import React, { FunctionComponent } from "react";
-import {
-  ToolbarGroup,
-  ToolbarItem,
-  Button,
-  Tooltip,
-} from "@patternfly/react-core";
+import { ToolbarGroup, ToolbarItem } from "@patternfly/react-core";
 import { css, StyleSheet } from "@patternfly/react-styles";
 import {
   ExpressionContent,
@@ -16,10 +11,7 @@ const styles = StyleSheet.create({
 });
 
 export interface IConditionalExpressionInputProps
-  extends IExpressionContentProps {
-  mappingExpressionEnabled: boolean;
-  onToggleExpressionMode: () => void;
-}
+  extends IExpressionContentProps {}
 
 export const ConditionalExpressionInput: FunctionComponent<IConditionalExpressionInputProps> = ({
   executeFieldSearch,
@@ -31,52 +23,27 @@ export const ConditionalExpressionInput: FunctionComponent<IConditionalExpressio
   mappingExpressionObservable,
   mappingExpressionRemoveField,
   mappingExpression,
-  mappingExpressionEnabled,
-  onToggleExpressionMode,
   trailerId,
+  disabled,
+  onToggle,
 }) => {
-  function onToggle() {
-    onToggleExpressionMode();
-  }
-
   return (
     <ToolbarGroup className={css(styles.toolbarItem)} role={"form"}>
-      <ToolbarItem>
-        <Tooltip
-          content={"Enable/ Disable conditional mapping expression."}
-          enableFlip={true}
-          entryDelay={1000}
-          position={"left"}
-        >
-          <Button
-            variant={"plain"}
-            aria-label="Enable/ Disable conditional mapping expression"
-            tabIndex={-1}
-            onClick={onToggle}
-            disabled={!mappingExpressionEnabled}
-            data-testid={"enable-disable-conditional-mapping-expression-button"}
-          >
-            <i>
-              f<sub>(x)</sub>
-            </i>
-          </Button>
-        </Tooltip>
-      </ToolbarItem>
       <ToolbarItem className={css(styles.toolbarItem)}>
-        {mappingExpressionEnabled && (
-          <ExpressionContent
-            executeFieldSearch={executeFieldSearch}
-            mappingExpressionAddField={mappingExpressionAddField}
-            mappingExpressionClearText={mappingExpressionClearText}
-            isMappingExpressionEmpty={isMappingExpressionEmpty}
-            mappingExpressionInit={mappingExpressionInit}
-            mappingExpressionInsertText={mappingExpressionInsertText}
-            mappingExpressionObservable={mappingExpressionObservable}
-            mappingExpressionRemoveField={mappingExpressionRemoveField}
-            mappingExpression={mappingExpression}
-            trailerId={trailerId}
-          />
-        )}
+        <ExpressionContent
+          disabled={disabled}
+          executeFieldSearch={executeFieldSearch}
+          mappingExpressionAddField={mappingExpressionAddField}
+          mappingExpressionClearText={mappingExpressionClearText}
+          isMappingExpressionEmpty={isMappingExpressionEmpty}
+          mappingExpressionInit={mappingExpressionInit}
+          mappingExpressionInsertText={mappingExpressionInsertText}
+          mappingExpressionObservable={mappingExpressionObservable}
+          mappingExpressionRemoveField={mappingExpressionRemoveField}
+          mappingExpression={mappingExpression}
+          trailerId={trailerId}
+          onToggle={onToggle}
+        />
       </ToolbarItem>
     </ToolbarGroup>
   );

--- a/ui/packages/atlasmap/src/UI/ExpressionContent.stories.tsx
+++ b/ui/packages/atlasmap/src/UI/ExpressionContent.stories.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+
+import { boolean, text } from "@storybook/addon-knobs";
+import { action } from "@storybook/addon-actions";
+
+import { ExpressionContent } from "./ExpressionContent";
+
+export default {
+  title: "UI|Mapping expression",
+};
+
+const executeFieldSearch = (): string[][] => {
+  return [
+    ["foo", "Foo"],
+    ["bar", "Bar"],
+    ["baz", "Baz"],
+  ];
+};
+
+export const disabled = () => (
+  <ExpressionContent
+    executeFieldSearch={executeFieldSearch}
+    mappingExpressionAddField={action("mappingExpressionAddField")}
+    mappingExpressionClearText={() => ({ str: "", uuid: "123" })}
+    isMappingExpressionEmpty={boolean("isMappingExpressionEmpty", true)}
+    mappingExpressionInit={action("mappingExpressionInit")}
+    mappingExpressionInsertText={action("mappingExpressionInsertText")}
+    mappingExpressionObservable={() => null}
+    mappingExpressionRemoveField={action("mappingExpressionRemoveField")}
+    mappingExpression={text("Mapping expression", "")}
+    trailerId={text("Trailer id", "expression-trailer")}
+    disabled={boolean("Disabled", true)}
+    onToggle={action("onToggle")}
+  />
+);
+
+export const enabledWithExpression = () => (
+  <ExpressionContent
+    executeFieldSearch={executeFieldSearch}
+    mappingExpressionAddField={action("mappingExpressionAddField")}
+    mappingExpressionClearText={() => ({ str: "", uuid: "123" })}
+    isMappingExpressionEmpty={boolean("isMappingExpressionEmpty", true)}
+    mappingExpressionInit={action("mappingExpressionInit")}
+    mappingExpressionInsertText={action("mappingExpressionInsertText")}
+    mappingExpressionObservable={() => null}
+    mappingExpressionRemoveField={action("mappingExpressionRemoveField")}
+    mappingExpression={text(
+      "Mapping expression",
+      "if (prop-city== Boston, city, state)",
+    )}
+    trailerId={text("Trailer id", "expression-trailer")}
+    disabled={boolean("Disabled", false)}
+    onToggle={action("onToggle")}
+  />
+);
+
+export const enabledWithoutExpression = () => (
+  <ExpressionContent
+    executeFieldSearch={executeFieldSearch}
+    mappingExpressionAddField={action("mappingExpressionAddField")}
+    mappingExpressionClearText={() => ({ str: "", uuid: "123" })}
+    isMappingExpressionEmpty={boolean("isMappingExpressionEmpty", true)}
+    mappingExpressionInit={action("mappingExpressionInit")}
+    mappingExpressionInsertText={action("mappingExpressionInsertText")}
+    mappingExpressionObservable={() => null}
+    mappingExpressionRemoveField={action("mappingExpressionRemoveField")}
+    mappingExpression={text("Mapping expression", "")}
+    trailerId={text("Trailer id", "expression-trailer")}
+    disabled={boolean("Disabled", false)}
+    onToggle={action("onToggle")}
+  />
+);

--- a/ui/packages/atlasmap/src/UI/ExpressionContent.tsx
+++ b/ui/packages/atlasmap/src/UI/ExpressionContent.tsx
@@ -1,7 +1,22 @@
-import { FunctionComponent, useEffect, useCallback } from "react";
-import React, { KeyboardEvent } from "react";
-import { Tooltip, Form, FormGroup } from "@patternfly/react-core";
-import { Subscription, Observable } from "rxjs";
+import React, {
+  FunctionComponent,
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+} from "react";
+import { Observable, Subscription } from "rxjs";
+
+import {
+  Button,
+  Form,
+  FormGroup,
+  InputGroup,
+  Tooltip,
+  TextInput,
+} from "@patternfly/react-core";
+import { css } from "@patternfly/react-styles";
+import styles from "@patternfly/react-styles/css/components/FormControl/form-control";
+
 import { ExpressionFieldSearch } from "./ExpressionFieldSearch";
 
 let atIndex = -1;
@@ -56,6 +71,8 @@ export interface IExpressionContentProps {
   ) => void;
   mappingExpression?: string;
   trailerId: string;
+  disabled: boolean;
+  onToggle: () => void;
 }
 
 function updateExpressionMarkup(reset?: boolean) {
@@ -144,6 +161,8 @@ export const ExpressionContent: FunctionComponent<IExpressionContentProps> = ({
   mappingExpressionRemoveField,
   mappingExpression,
   trailerId,
+  disabled,
+  onToggle,
 }) => {
   let selectedField: string;
 
@@ -438,36 +457,72 @@ export const ExpressionContent: FunctionComponent<IExpressionContentProps> = ({
   };
 
   useEffect(() => {
-    initMappingExpression();
-    return () => uninitializeMappingExpression();
-  }, [initMappingExpression, mappingExpression]);
+    if (mappingExpression !== undefined) {
+      initMappingExpression();
+      return () => uninitializeMappingExpression();
+    }
+    return;
+  }, [mappingExpression, initMappingExpression]);
 
   return (
     <>
       <Form>
         <FormGroup fieldId="expressionContent">
-          <Tooltip
-            content={"Enter text or '@' for source fields menu."}
-            enableFlip={true}
-            entryDelay={2000}
-            position={"left"}
-          >
-            <div
-              id="expressionMarkup"
-              key="expressionMarkup-div"
-              aria-label="Expression Content"
-              contentEditable
-              className="ExpressionFieldSearch"
-              suppressContentEditableWarning={true}
-              onChange={onChange}
-              onKeyDown={onKeyDown}
-              onKeyPress={onKeyPress}
-              onPaste={onPaste}
-              ref={(el) => (markup = el)}
-              tabIndex={-1}
-              style={{ paddingLeft: 8 }}
-            />
-          </Tooltip>
+          <InputGroup>
+            <Tooltip
+              content={"Enable/ Disable conditional mapping expression."}
+              enableFlip={true}
+              entryDelay={1000}
+              position={"left"}
+            >
+              <Button
+                variant={"control"}
+                aria-label="Enable/ Disable conditional mapping expression"
+                tabIndex={-1}
+                onClick={onToggle}
+                data-testid={
+                  "enable-disable-conditional-mapping-expression-button"
+                }
+                isDisabled={disabled}
+              >
+                <i>
+                  f
+                  <small style={{ position: "relative", bottom: -3 }}>
+                    (x)
+                  </small>
+                </i>
+              </Button>
+            </Tooltip>
+            {!disabled && mappingExpression !== undefined ? (
+              <Tooltip
+                content={"Enter text or '@' for source fields menu."}
+                enableFlip={true}
+                entryDelay={2000}
+                position={"left"}
+              >
+                <div
+                  id="expressionMarkup"
+                  key="expressionMarkup-div"
+                  aria-label="Expression Content"
+                  contentEditable
+                  className={css(styles.formControl, "ExpressionFieldSearch")}
+                  suppressContentEditableWarning={true}
+                  onChange={onChange}
+                  onKeyDown={onKeyDown}
+                  onKeyPress={onKeyPress}
+                  onPaste={onPaste}
+                  ref={(el) => (markup = el)}
+                  tabIndex={-1}
+                  style={{ paddingLeft: 8 }}
+                />
+              </Tooltip>
+            ) : (
+              <TextInput
+                isDisabled={true}
+                aria-label={"Expression content"}
+              /> /* this to render a disabled field */
+            )}
+          </InputGroup>
         </FormGroup>
       </Form>
       <div>


### PR DESCRIPTION
Toolbars background is now white, fixes #2122
The main actions (import, export, reset)  are now grouped in a menu,
fixes #2123.
The "Import catalog" doesn't allow for jar files, a new "Import Java archive" voice has been added to do that, fixes ##2110.
Align the conditional expression control to PatternFly guidelines, fixes
 #2124.