### PR TITLE
fix: Custom action causes mapping definition deserialization error

### DIFF
--- a/lib/core/src/main/java/io/atlasmap/core/ADMArchiveHandler.java
+++ b/lib/core/src/main/java/io/atlasmap/core/ADMArchiveHandler.java
@@ -188,15 +188,16 @@ public class ADMArchiveHandler {
         Path mdPath = this.persistDirectory.resolve(getMappingDefinitionFileName());
         if (getMappingDefinitionBytes() != null) {
             try {
-                jsonMapper.readValue(getMappingDefinitionBytes(), AtlasMapping.class);
+                this.mappingDefinition = jsonMapper.readValue(getMappingDefinitionBytes(), AtlasMapping.class);
             } catch (Exception e) {
                 LOG.warn("Invalid serialized mapping definition content detected, discarding");
                 this.mappingDefinitionBytes = null;
+                this.mappingDefinition = null;
             }
         }
-        if (getMappingDefinitionBytes() != null) {
-            try (FileOutputStream out = new FileOutputStream(mdPath.toFile())) {
-                out.write(getMappingDefinitionBytes());
+        if (this.mappingDefinition  != null) {
+            try {
+                jsonMapper.writeValue(mdPath.toFile(), this.mappingDefinition);
             } catch (Exception e) {
                 LOG.warn("Failed to persist mapping definition", e);
             }

--- a/lib/model/src/main/java/io/atlasmap/v2/ActionResolver.java
+++ b/lib/model/src/main/java/io/atlasmap/v2/ActionResolver.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.atlasmap.v2;
 
 import java.io.IOException;
@@ -5,10 +20,10 @@ import java.io.IOException;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.DatabindContext;
 import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
-public class ActionResolver implements TypeIdResolver {
+public class ActionResolver extends TypeIdResolverBase {
 
     private static ActionResolver instance;
     private SimpleResolver delegate;

--- a/lib/model/src/main/java/io/atlasmap/v2/AtlasHandlerInstantiator.java
+++ b/lib/model/src/main/java/io/atlasmap/v2/AtlasHandlerInstantiator.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atlasmap.v2;
+
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.cfg.HandlerInstantiator;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
+
+public class AtlasHandlerInstantiator extends HandlerInstantiator {
+
+    private ClassLoader classLoader;
+
+    AtlasHandlerInstantiator(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
+
+    @Override
+    public JsonDeserializer<?> deserializerInstance(DeserializationConfig config, Annotated annotated,
+            Class<?> deserClass) {
+        if (ActionListUpgradeDeserializer.class == deserClass) {
+            return new ActionListUpgradeDeserializer(classLoader);
+        }
+        return null;
+    }
+
+    @Override
+    public KeyDeserializer keyDeserializerInstance(DeserializationConfig config, Annotated annotated,
+            Class<?> keyDeserClass) {
+        return null;
+    }
+
+    @Override
+    public JsonSerializer<?> serializerInstance(SerializationConfig config, Annotated annotated,
+            Class<?> serClass) {
+        return null;
+    }
+
+    @Override
+    public TypeResolverBuilder<?> typeResolverBuilderInstance(MapperConfig<?> config, Annotated annotated,
+            Class<?> builderClass) {
+        return null;
+    }
+
+    @Override
+    public TypeIdResolver typeIdResolverInstance(MapperConfig<?> config, Annotated annotated,
+            Class<?> resolverClass) {
+        if (ActionResolver.class == resolverClass) {
+            return ActionResolver.getInstance(classLoader);
+        }
+        return null;
+    }
+    
+}

--- a/lib/model/src/main/java/io/atlasmap/v2/Json.java
+++ b/lib/model/src/main/java/io/atlasmap/v2/Json.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.atlasmap.v2;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -24,6 +39,9 @@ public class Json {
     }
 
     public static ObjectMapper withClassLoader(ClassLoader classLoader) {
-        return OBJECT_MAPPER.setTypeFactory(TypeFactory.defaultInstance().withClassLoader(classLoader));
+        OBJECT_MAPPER.setTypeFactory(TypeFactory.defaultInstance().withClassLoader(classLoader));
+        OBJECT_MAPPER.setHandlerInstantiator(new AtlasHandlerInstantiator(classLoader));
+        return OBJECT_MAPPER;
     }
+
 }

--- a/lib/model/src/main/java/io/atlasmap/v2/SimpleResolver.java
+++ b/lib/model/src/main/java/io/atlasmap/v2/SimpleResolver.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.atlasmap.v2;
 
 import java.io.IOException;
@@ -8,10 +23,10 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.DatabindContext;
 import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
-public class SimpleResolver implements TypeIdResolver {
+public class SimpleResolver extends TypeIdResolverBase {
 
     protected final HashMap<Class<?>, String> typeToId = new HashMap<Class<?>, String>();
     protected final HashMap<String, JavaType> idToType = new HashMap<String, JavaType>();

--- a/lib/service/src/main/java/io/atlasmap/service/AtlasService.java
+++ b/lib/service/src/main/java/io/atlasmap/service/AtlasService.java
@@ -625,9 +625,9 @@ public class AtlasService {
                     buf.append(line);
                 }
                 LOG.debug(buf.toString());
-                return Json.mapper().readValue(buf.toString(), clazz);
+                return Json.withClassLoader(this.libraryLoader).readValue(buf.toString(), clazz);
             }
-            return Json.mapper().readValue(value, clazz);
+            return Json.withClassLoader(this.libraryLoader).readValue(value, clazz);
         } catch (IOException e) {
             throw new WebApplicationException(e, Status.BAD_REQUEST);
         }

--- a/lib/service/src/test/java/io/atlasmap/service/AtlasServiceTest.java
+++ b/lib/service/src/test/java/io/atlasmap/service/AtlasServiceTest.java
@@ -172,6 +172,10 @@ public class AtlasServiceTest {
         assertEquals(200, resFA.getStatus());
         String responseJson = new String((byte[])resFA.getEntity());
         assertTrue(responseJson, responseJson.contains("myCustomFieldAction"));
+
+        in = new BufferedInputStream(new FileInputStream("src/test/resources/mappings/atlasmapping-custom-action.json"));
+        Response resVD = service.validateMappingRequest(in, 0, null);
+        assertEquals(200, resVD.getStatus());
     }
 
     protected UriInfo generateTestUriInfo(String baseUri, String absoluteUri) throws Exception {

--- a/lib/service/src/test/resources/mappings/atlasmapping-custom-action.json
+++ b/lib/service/src/test/resources/mappings/atlasmapping-custom-action.json
@@ -1,0 +1,65 @@
+{
+    "AtlasMapping": {
+        "jsonType": "io.atlasmap.v2.AtlasMapping",
+        "dataSource": [
+            {
+                "jsonType": "io.atlasmap.json.v2.JsonDataSource",
+                "id": "complex-object-rooted",
+                "uri": "atlas:json:complex-object-rooted",
+                "dataSourceType": "SOURCE"
+            },
+            {
+                "jsonType": "io.atlasmap.v2.DataSource",
+                "id": "complex-schema",
+                "uri": "atlas:xml:complex-schema",
+                "dataSourceType": "TARGET"
+            }
+        ],
+        "mappings": {
+            "mapping": [
+                {
+                    "jsonType": "io.atlasmap.v2.Mapping",
+                    "id": "mapping.89188",
+                    "inputField": [
+                        {
+                            "jsonType": "io.atlasmap.json.v2.JsonField",
+                            "name": "addressLine1",
+                            "path": "/order/address/addressLine1",
+                            "fieldType": "STRING",
+                            "docId": "complex-object-rooted",
+                            "userCreated": false,
+                            "actions": [
+                                {
+                                    "param": "test",
+                                    "@type": "io.atlasmap.service.my.MyFieldActionsModel"
+                                }
+                            ]
+                        }
+                    ],
+                    "outputField": [
+                        {
+                            "jsonType": "io.atlasmap.xml.v2.XmlField",
+                            "name": "stringField",
+                            "path": "/data/stringField",
+                            "fieldType": "STRING",
+                            "docId": "complex-schema"
+                        }
+                    ]
+                }
+            ]
+        },
+        "name": "UI.0",
+        "lookupTables": {
+            "lookupTable": [
+            ]
+        },
+        "constants": {
+            "constant": [
+            ]
+        },
+        "properties": {
+            "property": [
+            ]
+        }
+    }
+}

--- a/ui/packages/atlasmap-core/src/utils/mapping-serializer.ts
+++ b/ui/packages/atlasmap-core/src/utils/mapping-serializer.ts
@@ -615,15 +615,7 @@ export class MappingSerializer {
 
   private static serializeAction(action: FieldAction, cfg: ConfigModel): any {
     let actionJson: any = MappingSerializer.processActionArguments(action, cfg);
-    if (action.definition.isCustom) {
-      actionJson = []; // ref https://github.com/atlasmap/atlasmap/issues/1757
-      actionJson['@type'] = 'CustomAction';
-      actionJson['name'] = action.definition.serviceObject.name;
-      actionJson['className'] = action.definition.serviceObject.className;
-      actionJson['methodName'] = action.definition.serviceObject.method;
-    } else {
-      actionJson['@type'] = action.definition.name;
-    }
+    actionJson['@type'] = action.definition.name;
     return actionJson;
   }
 


### PR DESCRIPTION
Fixes: #1757
I guess this was caused by the jackson upgrade, it seems the class loader used for custom TypeIdResolver has been changed. But haven't nailed it down to the specific spot. Anyway this change solves the problem.