### PR TITLE
feat: Add runtime support for mapping camel message headers to AtlasM…

### DIFF
--- a/camel3/src/main/java/org/apache/camel/component/atlasmap/CamelAtlasPropertyStrategy.java
+++ b/camel3/src/main/java/org/apache/camel/component/atlasmap/CamelAtlasPropertyStrategy.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.atlasmap;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+
+import io.atlasmap.api.AtlasConversionException;
+import io.atlasmap.api.AtlasSession;
+import io.atlasmap.api.AtlasUnsupportedException;
+import io.atlasmap.core.DefaultAtlasPropertyStrategy;
+import io.atlasmap.v2.PropertyField;
+
+/**
+ * AtlasMap property strategy to map Camel message headers and exchange properties to/from
+ * AtlasMap properties.
+ *
+ */
+public class CamelAtlasPropertyStrategy extends DefaultAtlasPropertyStrategy {
+
+    public static final String SCOPE_EXCHANGE_PROPERTY = "camelExchangeProperty";
+    public static final String SCOPE_CURRENT_MESSAGE_HEADER = "current";
+
+    private Exchange camelExchange;
+    private Map<String, Message> sourceMessageMap = new HashMap<>();
+    private Message camelTargetMessage;
+
+    @Override
+    public void readProperty(AtlasSession session, PropertyField propertyField)
+            throws AtlasUnsupportedException, AtlasConversionException {
+
+        String scope = propertyField.getScope();
+        String key = propertyField.getName();
+        Map<String, Object> target = null;
+        if (scope == null && sourceMessageMap.containsKey(SCOPE_CURRENT_MESSAGE_HEADER)) {
+            target = sourceMessageMap.get(SCOPE_CURRENT_MESSAGE_HEADER).getHeaders();
+        } else if (SCOPE_EXCHANGE_PROPERTY.equals(scope)) {
+            target = this.camelExchange.getProperties();
+        } else if (sourceMessageMap.containsKey(scope)) {
+            target = sourceMessageMap.get(scope).getHeaders();
+        }
+        if (target != null && target.containsKey(key)) {
+            propertyField.setValue(target.get(key));
+        } else {
+            super.readProperty(session, propertyField);
+        }
+    }
+
+    @Override
+    public void writeProperty(AtlasSession session, PropertyField propertyField) {
+        String scope = propertyField.getScope();
+        String key = propertyField.getName();
+        Object value = propertyField.getValue();
+        if (SCOPE_EXCHANGE_PROPERTY.equals(scope)) {
+            this.camelExchange.setProperty(key, value);
+        } else {
+            this.camelTargetMessage.setHeader(key, value);
+        }
+    }
+
+    public void setExchange(Exchange ex) {
+        this.camelExchange = ex;
+    }
+
+    public void setSourceMessage(String documentId, Message msg) {
+        sourceMessageMap.put(documentId, msg);
+    }
+
+    public void setCurrentSourceMessage(Message msg) {
+        sourceMessageMap.put(SCOPE_CURRENT_MESSAGE_HEADER, msg);
+    }
+
+    public void setTargetMessage(Message msg) {
+        this.camelTargetMessage = msg;
+    }
+
+}

--- a/camel3/src/test/java/org/apache/camel/component/atlasmap/AtlasMapMultiDocsTest.java
+++ b/camel3/src/test/java/org/apache/camel/component/atlasmap/AtlasMapMultiDocsTest.java
@@ -77,12 +77,15 @@ public class AtlasMapMultiDocsTest {
         javaSource.setZipCode("JavaZipCode");
         Message msg = new DefaultMessage(camelContext);
         msg.setBody(javaSource);
+        msg.setHeader("testProp", "java-source-header");
         sourceMap.put("DOCID:JAVA:CONTACT:S", msg);
         msg = new DefaultMessage(camelContext);
         msg.setBody(JSON_SOURCE);
+        msg.setHeader("testProp", "json-source-header");
         sourceMap.put("DOCID:JSON:CONTACT:S", msg);
         msg = new DefaultMessage(camelContext);
         msg.setBody(XML_SOURCE);
+        msg.setHeader("testProp", "xml-source-header");
         sourceMap.put("DOCID:XML:CONTACT:S", msg);
 
         ProducerTemplate producerTemplate = camelContext.createProducerTemplate();
@@ -110,6 +113,10 @@ public class AtlasMapMultiDocsTest {
         assertThat(xmlTarget).withNamespaceContext(ns).valueByXPath("/Contact/@firstName").isEqualTo("XmlFirstName");
         assertThat(xmlTarget).withNamespaceContext(ns).valueByXPath("/Contact/@lastName").isEqualTo("JsonLastName");
         assertThat(xmlTarget).withNamespaceContext(ns).valueByXPath("/Contact/@phoneNumber").isEqualTo("JavaPhoneNumber");
+
+        assertEquals("java-source-header", exchange.getProperty("target-exchange"));
+        assertEquals("json-source-header", exchange.getProperty("testProp"));
+        assertEquals("xml-source-header", exchange.getIn().getHeader("testProp"));
     }
 
     @Test

--- a/camel3/src/test/java/org/apache/camel/component/atlasmap/CamelAtlasPropertyStrategyTest.java
+++ b/camel3/src/test/java/org/apache/camel/component/atlasmap/CamelAtlasPropertyStrategyTest.java
@@ -1,0 +1,75 @@
+package org.apache.camel.component.atlasmap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.apache.camel.support.DefaultMessage;
+import org.junit.Test;
+
+import io.atlasmap.api.AtlasSession;
+import io.atlasmap.core.DefaultAtlasSession;
+import io.atlasmap.v2.PropertyField;
+
+public class CamelAtlasPropertyStrategyTest {
+
+    @Test
+    public void testRead() throws Exception {
+        CamelAtlasPropertyStrategy strategy = new CamelAtlasPropertyStrategy();
+        DefaultCamelContext context = new DefaultCamelContext();
+        DefaultExchange exchange = new DefaultExchange(context);
+        exchange.setProperty("testProp", "testProp-exchangeProperty");
+        strategy.setExchange(exchange);
+        DefaultMessage currentMessage = new DefaultMessage(exchange);
+        currentMessage.setHeader("testProp", "testProp-currentMessage");
+        strategy.setCurrentSourceMessage(currentMessage);
+        DefaultMessage message1 = new DefaultMessage(exchange);
+        message1.setHeader("testProp", "testProp-message1");
+        strategy.setSourceMessage("Doc1", message1);
+        DefaultMessage message2 = new DefaultMessage(exchange);
+        message2.setHeader("testProp", "testProp-message2");
+        strategy.setSourceMessage("Doc2", message2);
+        AtlasSession session = mock(AtlasSession.class);
+        when(session.getAtlasPropertyStrategy()).thenReturn(strategy);
+        PropertyField propertyField = new PropertyField();
+        propertyField.setName("testProp");
+        strategy.readProperty(session, propertyField);
+        assertEquals("testProp-currentMessage", propertyField.getValue());
+        propertyField.setScope(CamelAtlasPropertyStrategy.SCOPE_EXCHANGE_PROPERTY);
+        strategy.readProperty(session, propertyField);
+        assertEquals("testProp-exchangeProperty", propertyField.getValue());
+        propertyField.setScope("Doc1");
+        strategy.readProperty(session, propertyField);
+        assertEquals("testProp-message1", propertyField.getValue());
+        propertyField.setScope("Doc2");
+        strategy.readProperty(session, propertyField);
+        assertEquals("testProp-message2", propertyField.getValue());
+    }
+
+    @Test
+    public void testWrite() throws Exception {
+        CamelAtlasPropertyStrategy strategy = new CamelAtlasPropertyStrategy();
+        DefaultCamelContext context = new DefaultCamelContext();
+        DefaultExchange exchange = new DefaultExchange(context);
+        strategy.setExchange(exchange);
+        DefaultMessage message = new DefaultMessage(exchange);
+        strategy.setTargetMessage(message);
+        PropertyField propertyField = new PropertyField();
+        propertyField.setName("testProp-message");
+        propertyField.setValue("testValue");
+        AtlasSession session = mock(DefaultAtlasSession.class);
+        when(session.getAtlasPropertyStrategy()).thenReturn(strategy);
+        strategy.writeProperty(session, propertyField);
+        propertyField.setName("testProp-exchange");
+        propertyField.setScope(CamelAtlasPropertyStrategy.SCOPE_EXCHANGE_PROPERTY);
+        strategy.writeProperty(session, propertyField);
+        assertEquals("testValue", message.getHeader("testProp-message"));
+        assertNull(message.getHeader("testProp-exchange"));
+        assertNull(exchange.getProperty("testProp-message"));
+        assertEquals("testValue", exchange.getProperty("testProp-exchange"));
+    }
+
+}

--- a/camel3/src/test/resources/atlasmapping-multidocs.json
+++ b/camel3/src/test/resources/atlasmapping-multidocs.json
@@ -192,6 +192,56 @@
           "fieldType" : "STRING",
           "name" : "phoneNumber"
         } ]
+      }, {
+        "jsonType" : "io.atlasmap.v2.Mapping",
+        "mappingType" : "MAP",
+        "inputField" : [ {
+          "jsonType" : "io.atlasmap.v2.PropertyField",
+          "path" : "/testProp",
+          "fieldType" : "STRING",
+          "scope" : "DOCID:JAVA:CONTACT:S",
+          "name" : "testProp"
+        } ],
+        "outputField" : [ {
+          "jsonType" : "io.atlasmap.v2.PropertyField",
+          "path" : "/target-exchange",
+          "fieldType" : "STRING",
+          "scope" : "camelExchangeProperty",
+          "name" : "target-exchange"
+        } ]
+      }, {
+        "jsonType" : "io.atlasmap.v2.Mapping",
+        "mappingType" : "MAP",
+        "inputField" : [ {
+          "jsonType" : "io.atlasmap.v2.PropertyField",
+          "path" : "/testProp",
+          "fieldType" : "STRING",
+          "scope" : "DOCID:JSON:CONTACT:S",
+          "name" : "testProp"
+        } ],
+        "outputField" : [ {
+          "jsonType" : "io.atlasmap.v2.PropertyField",
+          "path" : "/testProp",
+          "fieldType" : "STRING",
+          "scope" : "camelExchangeProperty",
+          "name" : "testProp"
+        } ]
+      }, {
+        "jsonType" : "io.atlasmap.v2.Mapping",
+        "mappingType" : "MAP",
+        "inputField" : [ {
+          "jsonType" : "io.atlasmap.v2.PropertyField",
+          "path" : "/testProp",
+          "fieldType" : "STRING",
+          "scope" : "DOCID:XML:CONTACT:S",
+          "name" : "testProp"
+        } ],
+        "outputField" : [ {
+          "jsonType" : "io.atlasmap.v2.PropertyField",
+          "path" : "/testProp",
+          "fieldType" : "STRING",
+          "name" : "testProp"
+        } ]
       } ]
     },
     "lookupTables" : {

--- a/lib/api/src/main/java/io/atlasmap/api/AtlasContextFactory.java
+++ b/lib/api/src/main/java/io/atlasmap/api/AtlasContextFactory.java
@@ -36,6 +36,7 @@ public interface AtlasContextFactory {
 
     AtlasContext createContext(URI atlasMappingUri) throws AtlasException;
 
+    @Deprecated
     AtlasCombineStrategy getCombineStrategy() throws AtlasException;
 
     AtlasConversionService getConversionService() throws AtlasException;
@@ -44,6 +45,9 @@ public interface AtlasContextFactory {
 
     AtlasPropertyStrategy getPropertyStrategy() throws AtlasException;
 
+    void setPropertyStrategy(AtlasPropertyStrategy strategy) throws AtlasException;
+
+    @Deprecated
     AtlasSeparateStrategy getSeparateStrategy() throws AtlasException;
 
     AtlasValidationService getValidationService() throws AtlasException;

--- a/lib/api/src/main/java/io/atlasmap/api/AtlasSession.java
+++ b/lib/api/src/main/java/io/atlasmap/api/AtlasSession.java
@@ -17,13 +17,23 @@ package io.atlasmap.api;
 
 import java.util.Map;
 
+import io.atlasmap.spi.AtlasPropertyStrategy;
 import io.atlasmap.v2.AtlasMapping;
 import io.atlasmap.v2.Audits;
 import io.atlasmap.v2.Validations;
 
 public interface AtlasSession {
 
+    @Deprecated
     Map<String, Object> getProperties();
+
+    Map<String, Object> getSourceProperties();
+
+    Map<String, Object> getTargetProperties();
+
+    AtlasPropertyStrategy getAtlasPropertyStrategy();
+
+    void setAtlasPropertyStrategy(AtlasPropertyStrategy strategy);
 
     AtlasContext getAtlasContext();
 

--- a/lib/api/src/main/java/io/atlasmap/spi/AtlasPropertyStrategy.java
+++ b/lib/api/src/main/java/io/atlasmap/spi/AtlasPropertyStrategy.java
@@ -15,14 +15,33 @@
  */
 package io.atlasmap.spi;
 
-import java.util.Map;
-
 import io.atlasmap.api.AtlasConversionException;
+import io.atlasmap.api.AtlasSession;
 import io.atlasmap.api.AtlasUnsupportedException;
-import io.atlasmap.v2.AtlasMapping;
 import io.atlasmap.v2.PropertyField;
 
+/**
+ * A plug-in interface for property strategy which read a source property and write a target property.
+ *
+ */
 public interface AtlasPropertyStrategy {
-    void processPropertyField(AtlasMapping atlasMapping, PropertyField propertyField,
-            Map<String, Object> runtimeProperties) throws AtlasUnsupportedException, AtlasConversionException;
+
+    /**
+     * Read a source property value and set into source Field.
+     * @param session {@code AtlasSession}
+     * @param propertyField source {@code PropertyField} to set a property value
+     * @throws AtlasUnsupportedException if reading property is not supported
+     * @throws AtlasConversionException if type conversion fails
+     */
+    void readProperty(AtlasSession session, PropertyField propertyField) throws AtlasUnsupportedException, AtlasConversionException;
+
+    /**
+     * Write a target property value from target Field.
+     * @param session {@code AtlasSession}
+     * @param propertyField target {@code PropertyField} to read a property value from
+     * @throws AtlasUnsupportedException if reading property is not supported
+     * @throws AtlasConversionException if type conversion fails
+     */
+    void writeProperty(AtlasSession session, PropertyField propertyField) throws AtlasUnsupportedException, AtlasConversionException;
+
 }

--- a/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasContext.java
+++ b/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasContext.java
@@ -131,12 +131,17 @@ public class DefaultAtlasContext implements AtlasContext, AtlasContextMXBean {
         constant.setConversionService(factory.getConversionService());
         constant.setFieldActionService(factory.getFieldActionService());
         sourceModules.put(CONSTANTS_DOCUMENT_ID, constant);
-        PropertyModule propSource = new PropertyModule(factory.getPropertyStrategy());
-        propSource.setMode(AtlasModuleMode.SOURCE);
-        propSource.setConversionService(factory.getConversionService());
-        propSource.setFieldActionService(factory.getFieldActionService());
-        sourceModules.put(PROPERTIES_DOCUMENT_ID, propSource);
+        PropertyModule property = new PropertyModule(factory.getPropertyStrategy());
+        property.setConversionService(factory.getConversionService());
+        property.setFieldActionService(factory.getFieldActionService());
+        property.setMode(AtlasModuleMode.SOURCE);
+        sourceModules.put(PROPERTIES_DOCUMENT_ID, property);
         targetModules.clear();
+        property = new PropertyModule(factory.getPropertyStrategy());
+        property.setConversionService(factory.getConversionService());
+        property.setFieldActionService(factory.getFieldActionService());
+        property.setMode(AtlasModuleMode.TARGET);
+        targetModules.put(PROPERTIES_DOCUMENT_ID, property);
 
         lookupTables.clear();
         if (mappingDefinition.getLookupTables() != null
@@ -591,7 +596,7 @@ public class DefaultAtlasContext implements AtlasContext, AtlasContextMXBean {
         if (direction == FieldDirection.SOURCE && field instanceof ConstantField) {
             return sourceModules.get(CONSTANTS_DOCUMENT_ID);
         }
-        if (direction == FieldDirection.SOURCE && field instanceof PropertyField) {
+        if (field instanceof PropertyField) {
             return sourceModules.get(PROPERTIES_DOCUMENT_ID);
         }
 

--- a/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasContextFactory.java
+++ b/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasContextFactory.java
@@ -247,6 +247,7 @@ public class DefaultAtlasContextFactory implements AtlasContextFactory, AtlasCon
         return atlasPropertyStrategy;
     }
 
+    @Override
     public void setPropertyStrategy(AtlasPropertyStrategy atlasPropertyStrategy) {
         this.atlasPropertyStrategy = atlasPropertyStrategy;
     }

--- a/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasSession.java
+++ b/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasSession.java
@@ -30,6 +30,7 @@ import io.atlasmap.api.AtlasException;
 import io.atlasmap.spi.AtlasFieldReader;
 import io.atlasmap.spi.AtlasFieldWriter;
 import io.atlasmap.spi.AtlasInternalSession;
+import io.atlasmap.spi.AtlasPropertyStrategy;
 import io.atlasmap.v2.AtlasMapping;
 import io.atlasmap.v2.Audit;
 import io.atlasmap.v2.AuditStatus;
@@ -45,7 +46,9 @@ public class DefaultAtlasSession implements AtlasInternalSession {
     private final AtlasMapping mapping;
     private Audits audits;
     private Validations validations;
-    private Map<String, Object> properties;
+    private Map<String, Object> sourceProperties;
+    private Map<String, Object> targetProperties;
+    private AtlasPropertyStrategy propertyStrategy;
     private Map<String, Object> sourceMap;
     private Map<String, Object> targetMap;
     private Map<String, AtlasFieldReader> fieldReaderMap;
@@ -69,7 +72,8 @@ public class DefaultAtlasSession implements AtlasInternalSession {
     }
 
     protected void initialize() {
-        properties = new ConcurrentHashMap<String, Object>();
+        sourceProperties = new ConcurrentHashMap<String, Object>();
+        targetProperties = new ConcurrentHashMap<String, Object>();
         validations = new Validations();
         audits = new Audits();
         sourceMap = new HashMap<>();
@@ -288,8 +292,28 @@ public class DefaultAtlasSession implements AtlasInternalSession {
     }
 
     @Override
+    @Deprecated
     public Map<String, Object> getProperties() {
-        return this.properties;
+        return getSourceProperties();
+    }
+
+    @Override
+    public Map<String, Object> getSourceProperties() {
+        return this.sourceProperties;
+    }
+
+    @Override
+    public Map<String, Object> getTargetProperties() {
+        return this.targetProperties;
+    }
+
+    @Override
+    public AtlasPropertyStrategy getAtlasPropertyStrategy() {
+        return this.propertyStrategy;
+    }
+    @Override
+    public void setAtlasPropertyStrategy(AtlasPropertyStrategy strategy) {
+        this.propertyStrategy = strategy;
     }
 
     @Override

--- a/lib/core/src/test/java/io/atlasmap/core/AtlasTestData.java
+++ b/lib/core/src/test/java/io/atlasmap/core/AtlasTestData.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import io.atlasmap.api.AtlasSession;
 import io.atlasmap.v2.AtlasMapping;
 import io.atlasmap.v2.AtlasModelFactory;
 import io.atlasmap.v2.FieldType;
@@ -98,5 +99,20 @@ public class AtlasTestData {
         runtimeProps.put("key-string", "foobar");
         runtimeProps.put("dupe-string", "uh oh");
         return runtimeProps;
+    }
+
+    public static AtlasSession generateAtlasSession() throws Exception {
+        AtlasMapping mappings = generateAtlasMapping();
+        Map<String, Object> runtimeProperties = generateRuntimeProperties();
+        return new DefaultAtlasSession(new DefaultAtlasContext(null)) {
+            @Override
+            public Map<String, Object> getSourceProperties() {
+                return runtimeProperties;
+            }
+            @Override
+            public AtlasMapping getMapping() {
+                return mappings;
+            }
+        };
     }
 }

--- a/lib/core/src/test/java/io/atlasmap/core/DefaultAtlasPropertyStrategyTest.java
+++ b/lib/core/src/test/java/io/atlasmap/core/DefaultAtlasPropertyStrategyTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 
 import org.junit.After;
@@ -55,8 +54,7 @@ public class DefaultAtlasPropertyStrategyTest {
         PropertyField propField = AtlasModelFactory.createPropertyField();
         propField.setName("PATH");
 
-        propStrategy.processPropertyField(AtlasTestData.generateAtlasMapping(), propField,
-                AtlasTestData.generateRuntimeProperties());
+        propStrategy.readProperty(null, propField);
 
         assertNotNull(propField);
         assertNotNull(propField.getValue());
@@ -70,8 +68,7 @@ public class DefaultAtlasPropertyStrategyTest {
         propField.setName("PATH");
 
         propStrategy.setEnvironmentPropertiesEnabled(false);
-        propStrategy.processPropertyField(AtlasTestData.generateAtlasMapping(), propField,
-                AtlasTestData.generateRuntimeProperties());
+        propStrategy.readProperty(null, propField);
 
         assertNotNull(propField);
         assertNull(propField.getValue());
@@ -82,8 +79,7 @@ public class DefaultAtlasPropertyStrategyTest {
         PropertyField propField = AtlasModelFactory.createPropertyField();
         propField.setName("XXXXXXXXXXXXXXXXXXXXX");
 
-        propStrategy.processPropertyField(AtlasTestData.generateAtlasMapping(), propField,
-                AtlasTestData.generateRuntimeProperties());
+        propStrategy.readProperty(null, propField);
 
         assertNotNull(propField);
         assertNull(propField.getValue());
@@ -94,8 +90,7 @@ public class DefaultAtlasPropertyStrategyTest {
         PropertyField propField = AtlasModelFactory.createPropertyField();
         propField.setName("java.specification.version");
 
-        propStrategy.processPropertyField(AtlasTestData.generateAtlasMapping(), propField,
-                AtlasTestData.generateRuntimeProperties());
+        propStrategy.readProperty(null, propField);
 
         assertNotNull(propField);
         assertNotNull(propField.getValue());
@@ -109,8 +104,7 @@ public class DefaultAtlasPropertyStrategyTest {
         propField.setName("java.specification.version");
 
         propStrategy.setSystemPropertiesEnabled(false);
-        propStrategy.processPropertyField(AtlasTestData.generateAtlasMapping(), propField,
-                AtlasTestData.generateRuntimeProperties());
+        propStrategy.readProperty(null, propField);
 
         assertNotNull(propField);
         assertNull(propField.getValue());
@@ -121,8 +115,7 @@ public class DefaultAtlasPropertyStrategyTest {
         PropertyField propField = AtlasModelFactory.createPropertyField();
         propField.setName("dupe-string");
 
-        propStrategy.processPropertyField(AtlasTestData.generateAtlasMapping(), propField,
-                AtlasTestData.generateRuntimeProperties());
+        propStrategy.readProperty(AtlasTestData.generateAtlasSession(), propField);
 
         assertNotNull(propField);
         assertNotNull(propField.getValue());
@@ -137,8 +130,7 @@ public class DefaultAtlasPropertyStrategyTest {
 
         propStrategy.setPropertyOrderValue(Arrays.asList(AtlasPropertyType.MAPPING_DEFINED_PROPERTIES.value(),
                 AtlasPropertyType.RUNTIME_PROPERTIES.value()));
-        propStrategy.processPropertyField(AtlasTestData.generateAtlasMapping(), propField,
-                AtlasTestData.generateRuntimeProperties());
+        propStrategy.readProperty(AtlasTestData.generateAtlasSession(), propField);
 
         assertNotNull(propField);
         assertNotNull(propField.getValue());
@@ -148,23 +140,20 @@ public class DefaultAtlasPropertyStrategyTest {
 
     @Test
     public void testProcessPropertyFieldNull() throws Exception {
-        propStrategy.processPropertyField(AtlasTestData.generateAtlasMapping(), null,
-                AtlasTestData.generateRuntimeProperties());
+        propStrategy.readProperty(null, null);
     }
 
     @Test
     public void testProcessPropertyFieldNullName() throws Exception {
         PropertyField propField = AtlasModelFactory.createPropertyField();
-        propStrategy.processPropertyField(AtlasTestData.generateAtlasMapping(), propField,
-                AtlasTestData.generateRuntimeProperties());
+        propStrategy.readProperty(null, propField);
     }
 
     @Test
     public void testProcessPropertyFieldEmptyName() throws Exception {
         PropertyField propField = AtlasModelFactory.createPropertyField();
         propField.setName("");
-        propStrategy.processPropertyField(AtlasTestData.generateAtlasMapping(), propField,
-                AtlasTestData.generateRuntimeProperties());
+        propStrategy.readProperty(null, propField);
     }
 
     @Test
@@ -172,8 +161,7 @@ public class DefaultAtlasPropertyStrategyTest {
         PropertyField propField = AtlasModelFactory.createPropertyField();
         propField.setName("prop-int");
 
-        propStrategy.processPropertyField(AtlasTestData.generateAtlasMapping(), propField,
-                AtlasTestData.generateRuntimeProperties());
+        propStrategy.readProperty(AtlasTestData.generateAtlasSession(), propField);
 
         assertNotNull(propField);
         assertNotNull(propField.getValue());
@@ -187,8 +175,7 @@ public class DefaultAtlasPropertyStrategyTest {
         propField.setName("prop-int");
 
         propStrategy.setMappingDefinedPropertiesEnabled(false);
-        propStrategy.processPropertyField(AtlasTestData.generateAtlasMapping(), propField,
-                AtlasTestData.generateRuntimeProperties());
+        propStrategy.readProperty(null, propField);
 
         assertNotNull(propField);
         assertNull(propField.getValue());
@@ -201,7 +188,7 @@ public class DefaultAtlasPropertyStrategyTest {
 
         AtlasMapping mapping = AtlasTestData.generateAtlasMapping();
         mapping.setProperties(null);
-        propStrategy.processPropertyField(null, propField, AtlasTestData.generateRuntimeProperties());
+        propStrategy.readProperty(null, propField);
 
         assertNotNull(propField);
         assertNull(propField.getValue());
@@ -214,7 +201,7 @@ public class DefaultAtlasPropertyStrategyTest {
 
         AtlasMapping mapping = AtlasTestData.generateAtlasMapping();
         mapping.setProperties(null);
-        propStrategy.processPropertyField(mapping, propField, AtlasTestData.generateRuntimeProperties());
+        propStrategy.readProperty(null, propField);
 
         assertNotNull(propField);
         assertNull(propField.getValue());
@@ -227,7 +214,7 @@ public class DefaultAtlasPropertyStrategyTest {
 
         AtlasMapping mapping = AtlasTestData.generateAtlasMapping();
         mapping.getProperties().getProperty().clear();
-        propStrategy.processPropertyField(mapping, propField, AtlasTestData.generateRuntimeProperties());
+        propStrategy.readProperty(null, propField);
 
         assertNotNull(propField);
         assertNull(propField.getValue());
@@ -238,7 +225,7 @@ public class DefaultAtlasPropertyStrategyTest {
         PropertyField propField = AtlasModelFactory.createPropertyField();
         propField.setName("prop-int");
 
-        propStrategy.processPropertyField(AtlasTestData.generateAtlasMapping(), propField, null);
+        propStrategy.readProperty(AtlasTestData.generateAtlasSession(), propField);
 
         assertNotNull(propField);
         assertNotNull(propField.getValue());
@@ -251,8 +238,7 @@ public class DefaultAtlasPropertyStrategyTest {
         PropertyField propField = AtlasModelFactory.createPropertyField();
         propField.setName("prop-int");
 
-        propStrategy.processPropertyField(AtlasTestData.generateAtlasMapping(), propField,
-                new HashMap<String, Object>());
+        propStrategy.readProperty(AtlasTestData.generateAtlasSession(), propField);
 
         assertNotNull(propField);
         assertNotNull(propField.getValue());
@@ -266,8 +252,7 @@ public class DefaultAtlasPropertyStrategyTest {
         propField.setName("prop-int");
 
         propStrategy.setAtlasConversionService(null);
-        propStrategy.processPropertyField(AtlasTestData.generateAtlasMapping(), propField,
-                AtlasTestData.generateRuntimeProperties());
+        propStrategy.readProperty(AtlasTestData.generateAtlasSession(), propField);
 
         assertNotNull(propField);
         assertNotNull(propField.getValue());
@@ -280,8 +265,7 @@ public class DefaultAtlasPropertyStrategyTest {
         PropertyField propField = AtlasModelFactory.createPropertyField();
         propField.setName("key-float");
 
-        propStrategy.processPropertyField(AtlasTestData.generateAtlasMapping(), propField,
-                AtlasTestData.generateRuntimeProperties());
+        propStrategy.readProperty(AtlasTestData.generateAtlasSession(), propField);
 
         assertNotNull(propField);
         assertNotNull(propField.getValue());
@@ -295,8 +279,7 @@ public class DefaultAtlasPropertyStrategyTest {
         propField.setName("key-float");
 
         propStrategy.setRuntimePropertiesEnabled(false);
-        propStrategy.processPropertyField(AtlasTestData.generateAtlasMapping(), propField,
-                AtlasTestData.generateRuntimeProperties());
+        propStrategy.readProperty(null, propField);
 
         assertNotNull(propField);
         assertNull(propField.getValue());

--- a/lib/model/src/main/java/io/atlasmap/v2/PropertyField.java
+++ b/lib/model/src/main/java/io/atlasmap/v2/PropertyField.java
@@ -9,30 +9,30 @@ public class PropertyField extends Field implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    protected String name;
+    protected String scope;
 
     /**
-     * Gets the value of the name property.
+     * Gets the value of the scope property.
      * 
      * @return
      *     possible object is
      *     {@link String }
      *     
      */
-    public String getName() {
-        return name;
+    public String getScope() {
+        return scope;
     }
 
     /**
-     * Sets the value of the name property.
+     * Sets the value of the scope property.
      * 
-     * @param value
+     * @param scope
      *     allowed object is
      *     {@link String }
      *     
      */
-    public void setName(String value) {
-        this.name = value;
+    public void setScope(String scope) {
+        this.scope = scope;
     }
 
 }


### PR DESCRIPTION
…ap properties

Fixes: #2197
Fixes: #2226
Fixes: #2237

Introduced `scope` on `PropertyField` which specify a Document ID to map Document scoped property. Although DefaultAtlasPropertyStrategy doesn't handle scope, when it runs in Apache Camel, CamelAtlasPropertyStrategy is used and message header is retrieved from the Camel Message which correlates with the Document ID. If scope is not specified, it is retrieved from current incoming message header.
This change also enables target property mapping, where DefaultAtlasPropertyStrategy maps them into target AtlasMap properties held by AtlasSession. In Apache Camel, target properties are populated into outgoing Message header if scope is not specified.
Both of source and target property accepts a special scope `camelExchangeProperty` to map from/to Camel Exchange property when it runs in Apache Camel.