### PR TITLE
feat: Add support resolving Document from Camel Message header and Ex…

### DIFF
--- a/camel3/src/main/java/org/apache/camel/component/atlasmap/AtlasComponent.java
+++ b/camel3/src/main/java/org/apache/camel/component/atlasmap/AtlasComponent.java
@@ -20,6 +20,7 @@ package org.apache.camel.component.atlasmap;
 import java.util.Map;
 
 import org.apache.camel.Endpoint;
+import org.apache.camel.component.atlasmap.AtlasEndpoint.TargetMapMode;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.support.DefaultComponent;
 import org.apache.camel.support.ResourceHelper;
@@ -50,6 +51,7 @@ public class AtlasComponent extends DefaultComponent {
         boolean cache = getAndRemoveParameter(parameters, "contentCache", Boolean.class, Boolean.TRUE);
         String sourceMapName = getAndRemoveParameter(parameters, "sourceMapName", String.class);
         String targetMapName = getAndRemoveParameter(parameters, "targetMapName", String.class);
+        TargetMapMode targetMapMode = getAndRemoveParameter(parameters, "targetMapMode", TargetMapMode.class);
 
         AtlasEndpoint endpoint = new AtlasEndpoint(uri, this, remaining);
         setProperties(endpoint, parameters);
@@ -57,6 +59,9 @@ public class AtlasComponent extends DefaultComponent {
         endpoint.setSourceMapName(sourceMapName);
         endpoint.setTargetMapName(targetMapName);
         endpoint.setAtlasContextFactory(getAtlasContextFactory());
+        if (targetMapMode != null) {
+            endpoint.setTargetMapMode(targetMapMode);
+        }
 
         // if its a http resource then append any remaining parameters and update the
         // resource uri

--- a/camel3/src/test/resources/org/apache/camel/component/atlasmap/AtlasMapMultiDocsTest-context.xml
+++ b/camel3/src/test/resources/org/apache/camel/component/atlasmap/AtlasMapMultiDocsTest-context.xml
@@ -16,6 +16,16 @@
             <to uri="atlas:atlasmapping-multidocs.json" />
             <to uri="mock:result-body" />
         </route>
+        <route>
+            <from uri="direct:start-header" />
+            <to uri="atlas:atlasmapping-multidocs.json?targetMapMode=MESSAGE_HEADER" />
+            <to uri="mock:result-body" />
+        </route>
+        <route>
+            <from uri="direct:start-exchange-property" />
+            <to uri="atlas:atlasmapping-multidocs.json?targetMapMode=EXCHANGE_PROPERTY" />
+            <to uri="mock:result-body" />
+        </route>
     </camelContext>
 
 </beans>

--- a/docs/src/main/asciidoc/developer-guide/openapi/core/index.adoc
+++ b/docs/src/main/asciidoc/developer-guide/openapi/core/index.adoc
@@ -2058,6 +2058,12 @@ endif::internal-generation[]
 | 
 |  
 
+| docName 
+|  
+| String  
+| 
+|  
+
 | path 
 |  
 | String  
@@ -2196,6 +2202,18 @@ endif::internal-generation[]
 | Field Name| Required| Type| Description| Format
 
 | id 
+|  
+| String  
+| 
+|  
+
+| name 
+|  
+| String  
+| 
+|  
+
+| description 
 |  
 | String  
 | 
@@ -2859,6 +2877,18 @@ endif::internal-generation[]
 |  
 
 | id 
+|  
+| String  
+| 
+|  
+
+| docId 
+|  
+| String  
+| 
+|  
+
+| docName 
 |  
 | String  
 | 

--- a/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasSession.java
+++ b/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasSession.java
@@ -53,7 +53,7 @@ public class DefaultAtlasSession implements AtlasInternalSession {
     private Map<String, Object> targetMap;
     private Map<String, AtlasFieldReader> fieldReaderMap;
     private Map<String, AtlasFieldWriter> fieldWriterMap;
-    private Head head = new HeadImpl();
+    private Head head = new HeadImpl(this);
 
     public DefaultAtlasSession(DefaultAtlasContext context) throws AtlasException {
         this.atlasContext = context;
@@ -359,11 +359,16 @@ public class DefaultAtlasSession implements AtlasInternalSession {
     }
 
     private class HeadImpl implements Head {
+        private DefaultAtlasSession session;
         private Mapping mapping;
         private LookupTable lookupTable;
         private Field sourceField;
         private Field targetField;
         private List<Audit> audits = new LinkedList<Audit>();
+
+        public HeadImpl(DefaultAtlasSession session) {
+            this.session = session;
+        }
 
         @Override
         public Mapping getMapping() {
@@ -430,7 +435,8 @@ public class DefaultAtlasSession implements AtlasInternalSession {
 
         @Override
         public Head addAudit(AuditStatus status, String docId, String path, String message) {
-            Audit audit = AtlasUtil.createAudit(status, docId, path, null, message);
+            String docName = AtlasUtil.getDocumentNameById(session.getMapping(), docId);
+            Audit audit = AtlasUtil.createAudit(status, docId, docName, path, null, message);
             this.audits.add(audit);
             return this;
         }

--- a/lib/model/src/main/java/io/atlasmap/v2/Audit.java
+++ b/lib/model/src/main/java/io/atlasmap/v2/Audit.java
@@ -10,6 +10,8 @@ public class Audit implements Serializable {
 
     protected String docId;
 
+    protected String docName;
+
     protected String path;
 
     protected String value;
@@ -62,6 +64,30 @@ public class Audit implements Serializable {
      */
     public void setDocId(String value) {
         this.docId = value;
+    }
+
+    /**
+     * Gets the value of the docName property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getDocName() {
+        return docName;
+    }
+
+    /**
+     * Sets the value of the docName property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setDocName(String value) {
+        this.docName = value;
     }
 
     /**

--- a/lib/model/src/main/java/io/atlasmap/v2/DataSource.java
+++ b/lib/model/src/main/java/io/atlasmap/v2/DataSource.java
@@ -11,6 +11,10 @@ public class DataSource implements Serializable {
 
     protected String id;
 
+    protected String name;
+
+    protected String description;
+
     protected String uri;
 
     protected DataSourceType dataSourceType;
@@ -37,6 +41,54 @@ public class DataSource implements Serializable {
      */
     public void setId(String value) {
         this.id = value;
+    }
+
+    /**
+     * Gets the value of the name property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the value of the name property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setName(String value) {
+        this.name = value;
+    }
+
+    /**
+     * Gets the value of the description property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Sets the value of the description property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setDescription(String value) {
+        this.description = value;
     }
 
     /**

--- a/lib/model/src/main/java/io/atlasmap/v2/Validation.java
+++ b/lib/model/src/main/java/io/atlasmap/v2/Validation.java
@@ -10,7 +10,12 @@ public class Validation implements Serializable {
     private static final long serialVersionUID = 1L;
     protected String message;
 
+    @Deprecated
     protected String id;
+
+    protected String docId;
+
+    protected String docName;
 
     protected ValidationScope scope;
 
@@ -42,26 +47,80 @@ public class Validation implements Serializable {
 
     /**
      * Gets the value of the id property.
+     * @deprecated Use {@link #getDocId()} instead
      * 
      * @return
      *     possible object is
      *     {@link String }
      *     
      */
+    @Deprecated
     public String getId() {
-        return id;
+        return docId != null ? docId : id;
     }
 
     /**
      * Sets the value of the id property.
+     * @deprecated Use {@link #setDocId(String)} instead
      * 
      * @param value
      *     allowed object is
      *     {@link String }
      *     
      */
+    @Deprecated
     public void setId(String value) {
         this.id = value;
+        this.docId = value;
+    }
+
+    /**
+     * Gets the value of the docId property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getDocId() {
+        return docId != null ? docId : id;
+    }
+
+    /**
+     * Sets the value of the docId property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setDocId(String value) {
+        this.docId = value;
+        this.id = value;
+    }
+
+    /**
+     * Gets the value of the docName property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getDocName() {
+        return docName;
+    }
+
+    /**
+     * Sets the value of the docName property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setDocName(String value) {
+        this.docName = value;
     }
 
     /**

--- a/ui/packages/atlasmap-core/src/utils/mapping-serializer.ts
+++ b/ui/packages/atlasmap-core/src/utils/mapping-serializer.ts
@@ -410,6 +410,8 @@ export class MappingSerializer {
       const serializedDoc: any = {
         jsonType: 'io.atlasmap.v2.DataSource',
         id: doc.id,
+        name: doc.name,
+        description: doc.description,
         uri: doc.uri,
         dataSourceType: docType,
       };
@@ -671,6 +673,8 @@ export class MappingSerializer {
       doc.isSource = docRef.dataSourceType === 'SOURCE';
       doc.uri = docRef.uri;
       doc.id = docRef.id;
+      doc.name = docRef.name;
+      doc.description = docRef.description;
       if (docRef.xmlNamespaces && docRef.xmlNamespaces.xmlNamespace) {
         for (const svcNS of docRef.xmlNamespaces.xmlNamespace) {
           const ns: NamespaceModel = new NamespaceModel();


### PR DESCRIPTION
…change property

Fixes: #1473
Fixes: #506
Fixes: https://issues.redhat.com/browse/ENTESB-14385

When message map is not available in exchange property or as an IN message body, AtlasEndpoint looks for Document object in Message header and Exchange property as fallback.
Also added `name` and `description` on `DataSource` so that human readable name and description could be delivered into mapping definition.