### PR TITLE
fix: Avoid undefined reference when calling unsetRef on reset command.

### DIFF
--- a/ui/packages/atlasmap/src/UI/Canvas/NodeRefProvider.tsx
+++ b/ui/packages/atlasmap/src/UI/Canvas/NodeRefProvider.tsx
@@ -71,7 +71,7 @@ export const NodeRefProvider: FunctionComponent = ({ children }) => {
     const ids = Array.isArray(id) ? id : [id];
     for (let index = 0; index < ids.length; index++) {
       const curId = ids[index];
-      if (curId && nodes.current[curId].key === key) {
+      if (curId && nodes.current[curId]?.key === key) {
         delete nodes.current[curId];
       }
     }


### PR DESCRIPTION
Fixes: #2333

Wasn't able to reproduce but from call stack this should correct the issue.
