### PR TITLE
fix: Handle multiple properties with the same name.

### DIFF
--- a/ui/packages/atlasmap/src/Atlasmap/utils/field.ts
+++ b/ui/packages/atlasmap/src/Atlasmap/utils/field.ts
@@ -12,6 +12,10 @@ import {
   ErrorType,
 } from "@atlasmap/core";
 
+function decorateProperty(name: string, scope: string): string {
+  return name + "<" + scope + ">";
+}
+
 export function createConstant(constValue: string, constType: string): void {
   const cfg = ConfigModel.getConfig();
   let field = cfg.constantDoc.getField(constValue);
@@ -96,7 +100,7 @@ export function createProperty(
   if (!field) {
     field = new Field();
   }
-  field.name = propName;
+  field.name = decorateProperty(propName, propScope);
   field.type = propType;
   field.scope = propScope;
   field.userCreated = true;
@@ -151,7 +155,9 @@ export function editProperty(
     return;
   }
   if (propName !== newName) {
-    field.name = newName;
+    field.name = decorateProperty(propName, propScope);
+  } else if (field.scope !== propScope) {
+    field.name = decorateProperty(field.name.split("<")[0], propScope);
   }
   field.type = propType;
   field.scope = propScope;

--- a/ui/packages/atlasmap/src/Views/ColumnMapperView/Columns/TreeItemFieldAndNodeRefsAndDnD.tsx
+++ b/ui/packages/atlasmap/src/Views/ColumnMapperView/Columns/TreeItemFieldAndNodeRefsAndDnD.tsx
@@ -93,7 +93,7 @@ export const TreeItemWithFieldAndNodeRefsAndDnD: FunctionComponent<ITreeItemFiel
                 {({ focused }) => (
                   <>
                     <DocumentField
-                      name={field.name}
+                      name={field.name.split("<")[0]}
                       icon={
                         isDroppable || isTarget ? (
                           <Button


### PR DESCRIPTION
Fixes: #2348

Since the name and path are identical, use the decorated (with scope) name as the property name internally.