### PR TITLE
fix: Remove docker dependency for release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,22 +57,15 @@ push_images: &push_images
       if [ "${CIRCLE_PROJECT_USERNAME}" != "atlasmap" ]; then
         exit 0
       fi
-
-      cd standalone
-      curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz | tar xz -C /usr/bin --strip-components 1
-
-      if [ "${CIRCLE_BRANCH}" == "master" ]; then
-        DOCKER_IMAGE_TAG="latest"
-      elif [[ "${CIRCLE_TAG}" =~ ^[0-9]+(\.[0-9]+){2} ]]; then
-        DOCKER_IMAGE_TAG="${CIRCLE_TAG}"
-      fi
-
-      if [ -z "${DOCKER_IMAGE_TAG}" ]; then
+      if [ "${CIRCLE_BRANCH}" != "master" ]; then
         exit 0
       fi
 
-      docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-      docker push atlasmap/atlasmap:${DOCKER_IMAGE_TAG} | cat -
+      cd standalone
+      ../mvnw --batch-mode -Pdocker \
+      -Djkube.docker.username=${DOCKER_USERNAME} \
+      -Djkube.docker.password=${DOCKER_PASSWORD} \
+      k8s:build k8s:push
 
 publish_npm: &publish_npm
   deploy:
@@ -119,7 +112,6 @@ jobs:
     environment:
       <<: *common_env
     steps:
-      - setup_remote_docker
       - checkout
       - restore_cache:
           key: atlasmap-mvn-{{ checksum "pom.xml" }}
@@ -132,7 +124,7 @@ jobs:
       - run:
           name: Build AtlasMap
           command: |
-            ./mvnw --batch-mode -Pcoverage,fabric8 -Dfabric8.mode=kubernetes -Dwebdriver.chrome.driver=/usr/bin/chromedriver clean install | tee -a build_log.txt
+            ./mvnw --batch-mode -Pcoverage -Dwebdriver.chrome.driver=/usr/bin/chromedriver clean install | tee -a build_log.txt
       - store_artifacts:
           path: build_log.txt
       - <<: *save_junit

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -42,7 +42,7 @@
     <camel.version>2.23.4</camel.version>
     <camel3.version>3.3.0</camel3.version>
     <daffodil.version>2.7.0</daffodil.version>
-    <fabric8-maven-plugin.version>4.4.1</fabric8-maven-plugin.version>
+    <kubernetes-maven-plugin.version>1.0.0</kubernetes-maven-plugin.version>
     <jackson.version>2.11.2</jackson.version>
     <jackson.databind.version>2.11.2</jackson.databind.version>
     <jackson.version.range>[2.6,3)</jackson.version.range>
@@ -640,9 +640,9 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>io.fabric8</groupId>
-          <artifactId>fabric8-maven-plugin</artifactId>
-          <version>${fabric8-maven-plugin.version}</version>
+          <groupId>org.eclipse.jkube</groupId>
+          <artifactId>kubernetes-maven-plugin</artifactId>
+          <version>${kubernetes-maven-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>io.github.swagger2markup</groupId>

--- a/release.sh
+++ b/release.sh
@@ -61,7 +61,7 @@ function init_options() {
 
   # Internal variable default values
   OC_OPTS=""
-  MAVEN_PARAMETERS="--batch-mode -Dfabric8.mode=kubernetes -Pfabric8,release,community-release"
+  MAVEN_PARAMETERS="--batch-mode -Prelease,community-release"
   MAVEN_CMD="${MAVEN_CMD:-${BASEDIR}/mvnw}"
 }
 
@@ -99,17 +99,16 @@ echo "=========================================================="
 echo "=========================================================="
 echo "Pushing docker images to Docker Hub...."
 echo "=========================================================="
+pushd standalone
 ATLASMAP_IMAGE="atlasmap/atlasmap"
 MAJOR_MINOR_VERSION=$(echo $RELEASE_VERSION | cut -f1,2 -d'.')
 
-if [ -n "$DOCKER_USER" ] && [ -n "$DOCKER_PASSWORD" ]; then
-    echo "==== Login to Docker Hub"
-    docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-fi
-
-docker tag "${ATLASMAP_IMAGE}:${RELEASE_VERSION}" "${ATLASMAP_IMAGE}:${MAJOR_MINOR_VERSION}"
-  docker push "${ATLASMAP_IMAGE}:${RELEASE_VERSION}"
-  docker push "${ATLASMAP_IMAGE}:${MAJOR_MINOR_VERSION}"
+"${MAVEN_CMD}" $MAVEN_PARAMETERS -Pdocker \
+               -Djkube.docker.username=${DOCKER_USER} \
+               -Djkube.docker.password=${DOCKER_PASSWORD} \
+               -Dimage.tag.secondary=${MAJOR_MINOR_VERSION} \
+               k8s:build k8s:push
+popd
 
 echo "=========================================================="
 echo "Publishing NPM package of AtlasMap UI...."

--- a/standalone/pom.xml
+++ b/standalone/pom.xml
@@ -37,11 +37,8 @@
     <from.image>fabric8/java-jboss-openjdk8-jdk</from.image>
     <docker.image>atlasmap/atlasmap:%l</docker.image>
     <from.image.version>1.3</from.image.version>
-    <fabric8.mode>kubernetes</fabric8.mode>
-    <temporary-docker-image>atlas-runtime-temporary</temporary-docker-image>
-    <docker.maven.plugin.version>0.23.0</docker.maven.plugin.version>
     <license.dir>${project.basedir}/src/main/resources/license</license.dir>
-    <license.output.dir>${project.build.directory}/licenses</license.output.dir>
+    <license.output.dir>${project.build.directory}/classes/licenses</license.output.dir>
   </properties>
 
   <build>
@@ -157,7 +154,7 @@
       <groupId>io.atlasmap</groupId>
       <artifactId>atlas-dfdl-service</artifactId>
     </dependency>
-     <dependency>
+    <dependency>
       <groupId>io.atlasmap</groupId>
       <artifactId>atlas-service</artifactId>
     </dependency>
@@ -248,59 +245,43 @@
       </properties>
     </profile>
     <profile>
-      <id>fabric8</id>
+      <id>docker</id>
       <build>
         <plugins>
           <plugin>
-            <groupId>io.fabric8</groupId>
-            <artifactId>fabric8-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>fmp</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>build</goal>
-                </goals>
-              </execution>
-            </executions>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>kubernetes-maven-plugin</artifactId>
             <configuration>
-              <generator>
-                <config>
-                  <spring-boot>
-                    <name>${docker.image}</name>
-                    <from>${temporary-docker-image}</from>
-                  </spring-boot>
-                </config>
-              </generator>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>io.fabric8</groupId>
-            <artifactId>docker-maven-plugin</artifactId>
-            <version>${docker.maven.plugin.version}</version>
-            <configuration>
+              <buildStrategy>jib</buildStrategy>
               <images>
                 <image>
-                  <name>${temporary-docker-image}</name>
+                  <name>${docker.image}</name>
                   <build>
                     <from>${from.image}:${from.image.version}</from>
+                    <tags>
+                      <tag>${image.tag.secondary}</tag>
+                      <tag>${image.tag.tertiary}</tag>
+                    </tags>
                     <assembly>
-                      <basedir>/</basedir>
-                      <descriptor>${project.basedir}/src/main/resources/license-custom-assembly.xml</descriptor>
+                      <inline>
+                        <id>copy-files</id>
+                        <fileSets>
+                          <fileSet>
+                            <directory>${license.output.dir}/licenses</directory>
+                            <outputDirectory>licenses</outputDirectory>
+                          </fileSet>
+                        </fileSets>
+                      </inline>
+                      <targetDir>/deployments</targetDir>
                     </assembly>
+                    <cmd>java -jar /deployments/${project.artifactId}.jar</cmd>
+                    <ports>
+                      <port>8585</port>
+                    </ports>
                   </build>
                 </image>
               </images>
             </configuration>
-            <executions>
-              <execution>
-                <id>docker-image</id>
-                <phase>compile</phase>
-                <goals>
-                  <goal>build</goal>
-                </goals>
-              </execution>
-            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Fixes: #2369
Fixes: #2368
Using eclipse/jkube with Jib strategy, docker image build&push no longer requires local docker daemon instance.