### PR TITLE
fix: XML schema inspection type cache disables too many fields for FHIR

### DIFF
--- a/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/XmlSchemaInspectionFhirTest.java
+++ b/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/XmlSchemaInspectionFhirTest.java
@@ -17,22 +17,24 @@ package io.atlasmap.xml.inspect;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.nio.file.Paths;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-import io.atlasmap.v2.FieldStatus;
+import io.atlasmap.v2.FieldType;
 import io.atlasmap.xml.v2.XmlComplexType;
 import io.atlasmap.xml.v2.XmlDocument;
+import io.atlasmap.xml.v2.XmlField;
 
 public class XmlSchemaInspectionFhirTest extends BaseXmlInspectionServiceTest {
 
     @Test
     public void test() throws Exception {
-        File schemaFile = Paths.get("src/test/resources/inspect/fhir-single.xsd").toFile();
+        File schemaFile = Paths.get("src/test/resources/inspect/fhir-patient.xsd").toFile();
         XmlInspectionService service = new XmlInspectionService();
         XmlDocument xmlDocument = service.inspectSchema(schemaFile);
         assertNotNull(xmlDocument);
@@ -41,9 +43,34 @@ public class XmlSchemaInspectionFhirTest extends BaseXmlInspectionServiceTest {
         XmlComplexType root = (XmlComplexType) xmlDocument.getFields().getField().get(0);
         assertNotNull(root);
         assertEquals(26, root.getXmlFields().getXmlField().size());
+        XmlComplexType id = (XmlComplexType) root.getXmlFields().getXmlField().get(0);
+        assertEquals("tns:id", id.getName());
+        assertEquals(2, id.getXmlFields().getXmlField().size());
+        XmlField value = (XmlField) id.getXmlFields().getXmlField().get(0);
+        assertEquals("tns:value", value.getName());
+        assertTrue(value.isAttribute());
+        XmlComplexType extension = (XmlComplexType) id.getXmlFields().getXmlField().get(1);
+        assertEquals("tns:extension", extension.getName());
+        assertNull(extension.getStatus());
+        assertEquals(40, extension.getXmlFields().getXmlField().size());
         XmlComplexType meta = (XmlComplexType) root.getXmlFields().getXmlField().get(1);
         assertEquals("tns:meta", meta.getName());
-        assertEquals(FieldStatus.CACHED, meta.getStatus());
+        assertNull(meta.getStatus());
+        XmlComplexType name = (XmlComplexType) root.getXmlFields().getXmlField().get(9);
+        assertEquals("tns:name", name.getName());
+        assertEquals(8, name.getXmlFields().getXmlField().size());
+        XmlComplexType family = (XmlComplexType) name.getXmlFields().getXmlField().get(3);
+        assertEquals("tns:family", family.getName());
+        assertEquals(2, family.getXmlFields().getXmlField().size());
+        XmlField familyValue = (XmlField) family.getXmlFields().getXmlField().get(0);
+        assertEquals(FieldType.STRING, familyValue.getFieldType());
+        assertTrue(familyValue.isAttribute());
+        XmlComplexType given = (XmlComplexType) name.getXmlFields().getXmlField().get(4);
+        assertEquals("tns:given", given.getName());
+        assertEquals(2, given.getXmlFields().getXmlField().size());
+        XmlField givenValue = (XmlField) given.getXmlFields().getXmlField().get(0);
+        assertEquals(FieldType.STRING, givenValue.getFieldType());
+        assertTrue(givenValue.isAttribute());
     }
 
 }

--- a/lib/modules/xml/core/src/test/resources/inspect/fhir-patient.xsd
+++ b/lib/modules/xml/core/src/test/resources/inspect/fhir-patient.xsd
@@ -409,11 +409,11 @@
                             <xs:documentation xml:lang="en">The status of the narrative - whether it's entirely generated (from just the defined data or the extensions too), or whether a human authored it and it may contain additional data.</xs:documentation>
                         </xs:annotation>
                     </xs:element>
-                    <xs:element ref="xhtml:div" minOccurs="1" maxOccurs="1">
+                    <!--  <xs:element ref="xhtml:div" minOccurs="1" maxOccurs="1">
                         <xs:annotation>
                             <xs:documentation xml:lang="en">The actual narrative content, a stripped down version of XHTML.</xs:documentation>
                         </xs:annotation>
-                    </xs:element>
+                    </xs:element> -->
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>

--- a/ui/test-resources/xml/schema/fhir-patient.xsd
+++ b/ui/test-resources/xml/schema/fhir-patient.xsd
@@ -409,11 +409,11 @@
                             <xs:documentation xml:lang="en">The status of the narrative - whether it's entirely generated (from just the defined data or the extensions too), or whether a human authored it and it may contain additional data.</xs:documentation>
                         </xs:annotation>
                     </xs:element>
-                    <xs:element ref="xhtml:div" minOccurs="1" maxOccurs="1">
+                    <!--  <xs:element ref="xhtml:div" minOccurs="1" maxOccurs="1">
                         <xs:annotation>
                             <xs:documentation xml:lang="en">The actual narrative content, a stripped down version of XHTML.</xs:documentation>
                         </xs:annotation>
-                    </xs:element>
+                    </xs:element> -->
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>


### PR DESCRIPTION
Fixes: #2406
Narrowed element/type caching to only apply vertically to avoid recursion. It causes OOM if it runs with the previous FHIR XSD, but it turned out the `xhtml:div` involved in FHIR XSD (!!!!!) is disabled in Syndesis FHIR connector. Did the same thing and now response time of FHIR inspection is realistic.