### PR TITLE
fix: XML schema inspection type cache disables too many fields for FHIR 

### DIFF
--- a/lib/modules/xml/core/src/main/java/io/atlasmap/xml/inspect/XmlSchemaInspector.java
+++ b/lib/modules/xml/core/src/main/java/io/atlasmap/xml/inspect/XmlSchemaInspector.java
@@ -317,6 +317,7 @@ public class XmlSchemaInspector {
             XmlField xmlField = AtlasXmlModelFactory.createXmlField();
             XSAttributeDecl attributeDecl = aC.getDecl();
             xmlField.setName(getNameNS(attributeDecl));
+            xmlField.setAttribute(true);
             if (attributeDecl.getDefaultValue() != null) {
                 xmlField.setValue(attributeDecl.getDefaultValue().value);
             } else if (attributeDecl.getFixedValue() != null) {

--- a/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/BaseXmlInspectionServiceTest.java
+++ b/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/BaseXmlInspectionServiceTest.java
@@ -34,6 +34,7 @@ public class BaseXmlInspectionServiceTest {
     protected void printXmlField(XmlField xmlField) {
         System.out.println("Name --> " + xmlField.getName());
         System.out.println("Path --> " + xmlField.getPath());
+        System.out.println("Attribute? --> " + xmlField.isAttribute());
         System.out.println("Value --> " + xmlField.getValue());
         if (xmlField.getFieldType() != null) {
             System.out.println("Type --> " + xmlField.getFieldType().name());

--- a/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/XmlSchemaInspectionFhirTest.java
+++ b/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/XmlSchemaInspectionFhirTest.java
@@ -17,23 +17,24 @@ package io.atlasmap.xml.inspect;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.nio.file.Paths;
 
-import org.hamcrest.core.Is;
-import org.junit.Assert;
 import org.junit.Test;
 
-import io.atlasmap.v2.FieldStatus;
+import io.atlasmap.v2.FieldType;
 import io.atlasmap.xml.v2.XmlComplexType;
 import io.atlasmap.xml.v2.XmlDocument;
+import io.atlasmap.xml.v2.XmlField;
 
 public class XmlSchemaInspectionFhirTest extends BaseXmlInspectionServiceTest {
 
     @Test
     public void test() throws Exception {
-        File schemaFile = Paths.get("src/test/resources/inspect/fhir-single.xsd").toFile();
+        File schemaFile = Paths.get("src/test/resources/inspect/fhir-patient.xsd").toFile();
         XmlInspectionService service = new XmlInspectionService();
         XmlDocument xmlDocument = service.inspectSchema(schemaFile);
         assertNotNull(xmlDocument);
@@ -42,9 +43,34 @@ public class XmlSchemaInspectionFhirTest extends BaseXmlInspectionServiceTest {
         XmlComplexType root = (XmlComplexType) xmlDocument.getFields().getField().get(0);
         assertNotNull(root);
         assertEquals(26, root.getXmlFields().getXmlField().size());
+        XmlComplexType id = (XmlComplexType) root.getXmlFields().getXmlField().get(0);
+        assertEquals("tns:id", id.getName());
+        assertEquals(2, id.getXmlFields().getXmlField().size());
+        XmlField value = (XmlField) id.getXmlFields().getXmlField().get(0);
+        assertEquals("tns:value", value.getName());
+        assertTrue(value.isAttribute());
+        XmlComplexType extension = (XmlComplexType) id.getXmlFields().getXmlField().get(1);
+        assertEquals("tns:extension", extension.getName());
+        assertNull(extension.getStatus());
+        assertEquals(40, extension.getXmlFields().getXmlField().size());
         XmlComplexType meta = (XmlComplexType) root.getXmlFields().getXmlField().get(1);
         assertEquals("tns:meta", meta.getName());
-        assertEquals(FieldStatus.CACHED, meta.getStatus());
+        assertNull(meta.getStatus());
+        XmlComplexType name = (XmlComplexType) root.getXmlFields().getXmlField().get(9);
+        assertEquals("tns:name", name.getName());
+        assertEquals(8, name.getXmlFields().getXmlField().size());
+        XmlComplexType family = (XmlComplexType) name.getXmlFields().getXmlField().get(3);
+        assertEquals("tns:family", family.getName());
+        assertEquals(2, family.getXmlFields().getXmlField().size());
+        XmlField familyValue = (XmlField) family.getXmlFields().getXmlField().get(0);
+        assertEquals(FieldType.STRING, familyValue.getFieldType());
+        assertTrue(familyValue.isAttribute());
+        XmlComplexType given = (XmlComplexType) name.getXmlFields().getXmlField().get(4);
+        assertEquals("tns:given", given.getName());
+        assertEquals(2, given.getXmlFields().getXmlField().size());
+        XmlField givenValue = (XmlField) given.getXmlFields().getXmlField().get(0);
+        assertEquals(FieldType.STRING, givenValue.getFieldType());
+        assertTrue(givenValue.isAttribute());
     }
 
 }

--- a/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/XmlSchemaInspectionTest.java
+++ b/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/XmlSchemaInspectionTest.java
@@ -15,10 +15,14 @@
  */
 package io.atlasmap.xml.inspect;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.nio.file.Paths;
 
-import org.hamcrest.core.Is;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -49,12 +53,12 @@ public class XmlSchemaInspectionTest extends BaseXmlInspectionServiceTest {
 
         XmlInspectionService service = new XmlInspectionService();
         XmlDocument xmlDocument = service.inspectSchema(source);
-        Assert.assertNotNull(xmlDocument);
-        Assert.assertNotNull(xmlDocument.getFields());
-        Assert.assertThat(xmlDocument.getFields().getField().size(), Is.is(1));
+        assertNotNull(xmlDocument);
+        assertNotNull(xmlDocument.getFields());
+        assertEquals(1, xmlDocument.getFields().getField().size());
         XmlComplexType root = (XmlComplexType) xmlDocument.getFields().getField().get(0);
-        Assert.assertNotNull(root);
-        Assert.assertThat(root.getXmlFields().getXmlField().size(), Is.is(8));
+        assertNotNull(root);
+        assertEquals(8, root.getXmlFields().getXmlField().size());
         // debugFields(xmlDocument.getFields());
     }
 
@@ -63,12 +67,12 @@ public class XmlSchemaInspectionTest extends BaseXmlInspectionServiceTest {
         File schemaFile = Paths.get("src/test/resources/inspect/simple-schema.xsd").toFile();
         XmlInspectionService service = new XmlInspectionService();
         XmlDocument xmlDocument = service.inspectSchema(schemaFile);
-        Assert.assertNotNull(xmlDocument);
-        Assert.assertNotNull(xmlDocument.getFields());
-        Assert.assertThat(xmlDocument.getFields().getField().size(), Is.is(1));
+        assertNotNull(xmlDocument);
+        assertNotNull(xmlDocument.getFields());
+        assertEquals(1, xmlDocument.getFields().getField().size());
         XmlComplexType root = (XmlComplexType) xmlDocument.getFields().getField().get(0);
-        Assert.assertNotNull(root);
-        Assert.assertThat(root.getXmlFields().getXmlField().size(), Is.is(8));
+        assertNotNull(root);
+        assertEquals(8, root.getXmlFields().getXmlField().size());
         // debugFields(xmlDocument.getFields());
     }
 
@@ -79,12 +83,12 @@ public class XmlSchemaInspectionTest extends BaseXmlInspectionServiceTest {
         XmlInspectionService service = new XmlInspectionService();
         XmlDocument xmlDocument = service.inspectSchema(schemaFile);
 
-        Assert.assertNotNull(xmlDocument);
-        Assert.assertNotNull(xmlDocument.getFields());
-        Assert.assertThat(xmlDocument.getFields().getField().size(), Is.is(1));
+        assertNotNull(xmlDocument);
+        assertNotNull(xmlDocument.getFields());
+        assertEquals(1, xmlDocument.getFields().getField().size());
         XmlComplexType root = (XmlComplexType) xmlDocument.getFields().getField().get(0);
-        Assert.assertNotNull(root);
-        Assert.assertThat(root.getXmlFields().getXmlField().size(), Is.is(9));
+        assertNotNull(root);
+        assertEquals(9, root.getXmlFields().getXmlField().size());
         // debugFields(xmlDocument.getFields());
     }
 
@@ -95,16 +99,16 @@ public class XmlSchemaInspectionTest extends BaseXmlInspectionServiceTest {
         XmlInspectionService service = new XmlInspectionService();
         XmlDocument xmlDocument = service.inspectSchema(schemaFile);
 
-        Assert.assertNotNull(xmlDocument);
-        Assert.assertNotNull(xmlDocument.getFields());
-        Assert.assertThat(xmlDocument.getFields().getField().size(), Is.is(1));
+        assertNotNull(xmlDocument);
+        assertNotNull(xmlDocument.getFields());
+        assertEquals(1, xmlDocument.getFields().getField().size());
 
-        Assert.assertNotNull(xmlDocument.getXmlNamespaces());
-        Assert.assertThat(xmlDocument.getXmlNamespaces().getXmlNamespace().size(), Is.is(1));
+        assertNotNull(xmlDocument.getXmlNamespaces());
+        assertEquals(1, xmlDocument.getXmlNamespaces().getXmlNamespace().size());
 
         XmlNamespace namespace = xmlDocument.getXmlNamespaces().getXmlNamespace().get(0);
-        Assert.assertThat(namespace.getAlias(), Is.is("tns"));
-        Assert.assertThat(namespace.getUri(), Is.is("http://example.com/"));
+        assertEquals("tns", namespace.getAlias());
+        assertEquals("http://example.com/", namespace.getUri());
         // debugFields(xmlDocument.getFields());
     }
 
@@ -115,37 +119,39 @@ public class XmlSchemaInspectionTest extends BaseXmlInspectionServiceTest {
         XmlInspectionService service = new XmlInspectionService();
         XmlDocument xmlDocument = service.inspectSchema(schemaFile);
 
-        Assert.assertNotNull(xmlDocument);
-        Assert.assertNotNull(xmlDocument.getFields());
-        Assert.assertThat(xmlDocument.getFields().getField().size(), Is.is(1));
+        assertNotNull(xmlDocument);
+        assertNotNull(xmlDocument.getFields());
+        assertEquals(1, xmlDocument.getFields().getField().size());
         XmlComplexType root = (XmlComplexType) xmlDocument.getFields().getField().get(0);
-        Assert.assertNotNull(root);
-        Assert.assertThat(root.getXmlFields().getXmlField().size(), Is.is(4));
+        assertNotNull(root);
+        assertEquals(4, root.getXmlFields().getXmlField().size());
 
         // @orderId
         XmlField orderIdAttr = root.getXmlFields().getXmlField().get(0);
-        Assert.assertNotNull(orderIdAttr);
-        Assert.assertThat(orderIdAttr.getName(), Is.is("orderid"));
-        Assert.assertThat(orderIdAttr.getValue(), Is.is("2"));
-        Assert.assertThat(orderIdAttr.getPath(), Is.is("/shiporder/@orderid"));
-        Assert.assertThat(orderIdAttr.getFieldType(), Is.is(FieldType.STRING));
+        assertNotNull(orderIdAttr);
+        assertEquals("orderid", orderIdAttr.getName());
+        assertEquals("2", orderIdAttr.getValue());
+        assertEquals("/shiporder/@orderid", orderIdAttr.getPath());
+        assertEquals(FieldType.STRING, orderIdAttr.getFieldType());
+        assertEquals(true, orderIdAttr.isAttribute());
         // orderperson
         XmlField orderPerson = root.getXmlFields().getXmlField().get(1);
-        Assert.assertNotNull(orderPerson);
-        Assert.assertThat(orderPerson.getName(), Is.is("orderperson"));
-        Assert.assertNull(orderPerson.getValue());
-        Assert.assertThat(orderPerson.getPath(), Is.is("/shiporder/orderperson"));
-        Assert.assertThat(orderPerson.getFieldType(), Is.is(FieldType.STRING));
+        assertNotNull(orderPerson);
+        assertEquals("orderperson", orderPerson.getName());
+        assertNull(orderPerson.getValue());
+        assertEquals("/shiporder/orderperson", orderPerson.getPath());
+        assertEquals(FieldType.STRING, orderPerson.getFieldType());
+        assertEquals(false, orderPerson.isAttribute());
         // shipTo
         XmlField shipTo = root.getXmlFields().getXmlField().get(2);
-        Assert.assertNotNull(shipTo);
-        Assert.assertTrue(shipTo instanceof XmlComplexType);
-        Assert.assertThat(((XmlComplexType) shipTo).getXmlFields().getXmlField().size(), Is.is(4));
+        assertNotNull(shipTo);
+        assertTrue(shipTo instanceof XmlComplexType);
+        assertEquals(4, ((XmlComplexType) shipTo).getXmlFields().getXmlField().size());
         // item
         XmlField item = root.getXmlFields().getXmlField().get(3);
-        Assert.assertNotNull(item);
-        Assert.assertTrue(item instanceof XmlComplexType);
-        Assert.assertThat(((XmlComplexType) item).getXmlFields().getXmlField().size(), Is.is(4));
+        assertNotNull(item);
+        assertTrue(item instanceof XmlComplexType);
+        assertEquals(4, ((XmlComplexType) item).getXmlFields().getXmlField().size());
 
         // debugFields(xmlDocument.getFields());
     }
@@ -157,166 +163,183 @@ public class XmlSchemaInspectionTest extends BaseXmlInspectionServiceTest {
         XmlInspectionService service = new XmlInspectionService();
         XmlDocument xmlDocument = service.inspectSchema(schemaFile);
 
-        Assert.assertNotNull(xmlDocument);
-        Assert.assertNotNull(xmlDocument.getFields());
-        Assert.assertThat(xmlDocument.getFields().getField().size(), Is.is(2));
+        assertNotNull(xmlDocument);
+        assertNotNull(xmlDocument.getFields());
+        assertEquals(2, xmlDocument.getFields().getField().size());
 
         // PurchaseOrderType
         XmlComplexType purchaseOrder = (XmlComplexType) xmlDocument.getFields().getField().get(0);
-        Assert.assertNotNull(purchaseOrder);
-        Assert.assertThat(purchaseOrder.getXmlFields().getXmlField().size(), Is.is(5));
+        assertNotNull(purchaseOrder);
+        assertEquals(5, purchaseOrder.getXmlFields().getXmlField().size());
 
         // orderDate
         XmlField orderDateAttr = purchaseOrder.getXmlFields().getXmlField().get(0);
-        Assert.assertNotNull(orderDateAttr);
-        Assert.assertThat(orderDateAttr.getName(), Is.is("tns:orderDate"));
-        Assert.assertNull(orderDateAttr.getValue());
-        Assert.assertThat(orderDateAttr.getPath(), Is.is("/tns:purchaseOrder/@tns:orderDate"));
-        Assert.assertThat(orderDateAttr.getFieldType(), Is.is(FieldType.DATE));
+        assertNotNull(orderDateAttr);
+        assertEquals("tns:orderDate", orderDateAttr.getName());
+        assertNull(orderDateAttr.getValue());
+        assertEquals("/tns:purchaseOrder/@tns:orderDate", orderDateAttr.getPath());
+        assertEquals(FieldType.DATE, orderDateAttr.getFieldType());
+        assertEquals(true, orderDateAttr.isAttribute());
 
         // shipTo
         XmlField shipTo = purchaseOrder.getXmlFields().getXmlField().get(1);
-        Assert.assertNotNull(shipTo);
-        Assert.assertThat(shipTo.getName(), Is.is("tns:shipTo"));
-        Assert.assertNull(shipTo.getValue());
-        Assert.assertThat(shipTo.getPath(), Is.is("/tns:purchaseOrder/tns:shipTo"));
-        Assert.assertThat(shipTo.getFieldType(), Is.is(FieldType.COMPLEX));
-        Assert.assertThat(((XmlComplexType) shipTo).getXmlFields().getXmlField().size(), Is.is(6));
+        assertNotNull(shipTo);
+        assertEquals("tns:shipTo", shipTo.getName());
+        assertNull(shipTo.getValue());
+        assertEquals("/tns:purchaseOrder/tns:shipTo", shipTo.getPath());
+        assertEquals(FieldType.COMPLEX, shipTo.getFieldType());
+        assertEquals(6, ((XmlComplexType) shipTo).getXmlFields().getXmlField().size());
         // shipTo/@country
         XmlField shipToCountry = ((XmlComplexType) shipTo).getXmlFields().getXmlField().get(0);
-        Assert.assertNotNull(shipTo);
-        Assert.assertThat(shipToCountry.getName(), Is.is("tns:country"));
-        Assert.assertThat(shipToCountry.getValue(), Is.is("US"));
-        Assert.assertThat(shipToCountry.getPath(), Is.is("/tns:purchaseOrder/tns:shipTo/@tns:country"));
-        Assert.assertThat(shipToCountry.getFieldType(), Is.is(FieldType.UNSUPPORTED));
+        assertNotNull(shipTo);
+        assertEquals("tns:country", shipToCountry.getName());
+        assertEquals("US", shipToCountry.getValue());
+        assertEquals("/tns:purchaseOrder/tns:shipTo/@tns:country", shipToCountry.getPath());
+        assertEquals(FieldType.UNSUPPORTED, shipToCountry.getFieldType());
+        assertEquals(true, shipToCountry.isAttribute());
 
         XmlField shipToName = ((XmlComplexType) shipTo).getXmlFields().getXmlField().get(1);
-        Assert.assertNotNull(shipToName);
-        Assert.assertThat(shipToName.getName(), Is.is("tns:name"));
-        Assert.assertNull(shipToName.getValue());
-        Assert.assertThat(shipToName.getPath(), Is.is("/tns:purchaseOrder/tns:shipTo/tns:name"));
-        Assert.assertThat(shipToName.getFieldType(), Is.is(FieldType.STRING));
+        assertNotNull(shipToName);
+        assertEquals("tns:name", shipToName.getName());
+        assertNull(shipToName.getValue());
+        assertEquals("/tns:purchaseOrder/tns:shipTo/tns:name", shipToName.getPath());
+        assertEquals(FieldType.STRING, shipToName.getFieldType());
+        assertEquals(false, shipToName.isAttribute());
 
         XmlField shipToStreet = ((XmlComplexType) shipTo).getXmlFields().getXmlField().get(2);
-        Assert.assertNotNull(shipToStreet);
-        Assert.assertThat(shipToStreet.getName(), Is.is("tns:street"));
-        Assert.assertNull(shipToStreet.getValue());
-        Assert.assertThat(shipToStreet.getPath(), Is.is("/tns:purchaseOrder/tns:shipTo/tns:street"));
-        Assert.assertThat(shipToStreet.getFieldType(), Is.is(FieldType.STRING));
+        assertNotNull(shipToStreet);
+        assertEquals("tns:street", shipToStreet.getName());
+        assertNull(shipToStreet.getValue());
+        assertEquals("/tns:purchaseOrder/tns:shipTo/tns:street", shipToStreet.getPath());
+        assertEquals(FieldType.STRING, shipToStreet.getFieldType());
+        assertEquals(false, shipToStreet.isAttribute());
 
         XmlField shipToCity = ((XmlComplexType) shipTo).getXmlFields().getXmlField().get(3);
-        Assert.assertNotNull(shipToCity);
-        Assert.assertThat(shipToCity.getName(), Is.is("tns:city"));
-        Assert.assertNull(shipToCity.getValue());
-        Assert.assertThat(shipToCity.getPath(), Is.is("/tns:purchaseOrder/tns:shipTo/tns:city"));
-        Assert.assertThat(shipToCity.getFieldType(), Is.is(FieldType.STRING));
+        assertNotNull(shipToCity);
+        assertEquals("tns:city", shipToCity.getName());
+        assertNull(shipToCity.getValue());
+        assertEquals("/tns:purchaseOrder/tns:shipTo/tns:city", shipToCity.getPath());
+        assertEquals(FieldType.STRING, shipToCity.getFieldType());
+        assertEquals(false, shipToCity.isAttribute());
 
         XmlField shipToState = ((XmlComplexType) shipTo).getXmlFields().getXmlField().get(4);
-        Assert.assertNotNull(shipToState);
-        Assert.assertThat(shipToState.getName(), Is.is("tns:state"));
-        Assert.assertNull(shipToState.getValue());
-        Assert.assertThat(shipToState.getPath(), Is.is("/tns:purchaseOrder/tns:shipTo/tns:state"));
-        Assert.assertThat(shipToState.getFieldType(), Is.is(FieldType.STRING));
+        assertNotNull(shipToState);
+        assertEquals("tns:state", shipToState.getName());
+        assertNull(shipToState.getValue());
+        assertEquals("/tns:purchaseOrder/tns:shipTo/tns:state", shipToState.getPath());
+        assertEquals(FieldType.STRING, shipToState.getFieldType());
+        assertEquals(false, shipToState.isAttribute());
 
         XmlField shipToZip = ((XmlComplexType) shipTo).getXmlFields().getXmlField().get(5);
-        Assert.assertNotNull(shipToZip);
-        Assert.assertThat(shipToZip.getName(), Is.is("tns:zip"));
-        Assert.assertNull(shipToZip.getValue());
-        Assert.assertThat(shipToZip.getPath(), Is.is("/tns:purchaseOrder/tns:shipTo/tns:zip"));
-        Assert.assertThat(shipToZip.getFieldType(), Is.is(FieldType.DECIMAL));
+        assertNotNull(shipToZip);
+        assertEquals("tns:zip", shipToZip.getName());
+        assertNull(shipToZip.getValue());
+        assertEquals("/tns:purchaseOrder/tns:shipTo/tns:zip", shipToZip.getPath());
+        assertEquals(FieldType.DECIMAL, shipToZip.getFieldType());
+        assertEquals(false, shipToZip.isAttribute());
 
         // comment
         XmlField comment = purchaseOrder.getXmlFields().getXmlField().get(3);
-        Assert.assertNotNull(comment);
-        Assert.assertThat(comment.getName(), Is.is("tns:comment"));
-        Assert.assertNull(comment.getValue());
-        Assert.assertThat(comment.getPath(), Is.is("/tns:purchaseOrder/tns:comment"));
-        Assert.assertThat(comment.getFieldType(), Is.is(FieldType.STRING));
+        assertNotNull(comment);
+        assertEquals("tns:comment", comment.getName());
+        assertNull(comment.getValue());
+        assertEquals("/tns:purchaseOrder/tns:comment", comment.getPath());
+        assertEquals(FieldType.STRING, comment.getFieldType());
+        assertEquals(false, comment.isAttribute());
+
         // items
         XmlField items = purchaseOrder.getXmlFields().getXmlField().get(4);
-        Assert.assertNotNull(items);
-        Assert.assertThat(items.getName(), Is.is("tns:items"));
-        Assert.assertNull(items.getValue());
-        Assert.assertThat(items.getPath(), Is.is("/tns:purchaseOrder/tns:items"));
-        Assert.assertThat(items.getFieldType(), Is.is(FieldType.COMPLEX));
+        assertNotNull(items);
+        assertEquals("tns:items", items.getName());
+        assertNull(items.getValue());
+        assertEquals("/tns:purchaseOrder/tns:items", items.getPath());
+        assertEquals(FieldType.COMPLEX, items.getFieldType());
+        assertEquals(false, items.isAttribute());
 
-        Assert.assertThat(((XmlComplexType) items).getXmlFields().getXmlField().size(), Is.is(1));
+        assertEquals(1, ((XmlComplexType) items).getXmlFields().getXmlField().size());
 
         // items/item
         XmlComplexType item = (XmlComplexType) ((XmlComplexType) items).getXmlFields().getXmlField().get(0);
-        Assert.assertNotNull(item);
-        Assert.assertThat(item.getName(), Is.is("tns:item"));
-        Assert.assertNull(item.getValue());
-        Assert.assertThat(item.getPath(), Is.is("/tns:purchaseOrder/tns:items/tns:item"));
-        Assert.assertThat(item.getFieldType(), Is.is(FieldType.COMPLEX));
-        Assert.assertThat(item.getCollectionType(), Is.is(CollectionType.LIST));
-        Assert.assertThat(item.getXmlFields().getXmlField().size(), Is.is(6));
+        assertNotNull(item);
+        assertEquals("tns:item", item.getName());
+        assertNull(item.getValue());
+        assertEquals("/tns:purchaseOrder/tns:items/tns:item", item.getPath());
+        assertEquals(FieldType.COMPLEX, item.getFieldType());
+        assertEquals(false, item.isAttribute());
+        assertEquals(CollectionType.LIST, item.getCollectionType());
+        assertEquals(6, item.getXmlFields().getXmlField().size());
 
         // partNum
         XmlField partNum = item.getXmlFields().getXmlField().get(0);
-        Assert.assertNotNull(partNum);
-        Assert.assertThat(partNum.getName(), Is.is("tns:partNum"));
-        Assert.assertNull(partNum.getValue());
-        Assert.assertThat(partNum.getPath(), Is.is("/tns:purchaseOrder/tns:items/tns:item/@tns:partNum"));
-        Assert.assertThat(partNum.getFieldType(), Is.is(FieldType.STRING));
-        Assert.assertThat(partNum.getTypeName(), Is.is("SKU"));
+        assertNotNull(partNum);
+        assertEquals("tns:partNum", partNum.getName());
+        assertNull(partNum.getValue());
+        assertEquals("/tns:purchaseOrder/tns:items/tns:item/@tns:partNum", partNum.getPath());
+        assertEquals(FieldType.STRING, partNum.getFieldType());
+        assertEquals("SKU", partNum.getTypeName());
+        assertEquals(true, partNum.isAttribute());
 
         // productName
         XmlField productName = item.getXmlFields().getXmlField().get(1);
-        Assert.assertNotNull(productName);
-        Assert.assertThat(productName.getName(), Is.is("tns:productName"));
-        Assert.assertNull(productName.getValue());
-        Assert.assertThat(productName.getPath(), Is.is("/tns:purchaseOrder/tns:items/tns:item/tns:productName"));
-        Assert.assertThat(productName.getFieldType(), Is.is(FieldType.STRING));
+        assertNotNull(productName);
+        assertEquals("tns:productName", productName.getName());
+        assertNull(productName.getValue());
+        assertEquals("/tns:purchaseOrder/tns:items/tns:item/tns:productName", productName.getPath());
+        assertEquals(FieldType.STRING, productName.getFieldType());
+        assertEquals(false, productName.isAttribute());
 
         // quantity
         XmlField quantity = item.getXmlFields().getXmlField().get(2);
-        Assert.assertNotNull(quantity);
-        Assert.assertThat(quantity.getName(), Is.is("tns:quantity"));
-        Assert.assertNull(quantity.getValue());
-        Assert.assertThat(quantity.getPath(), Is.is("/tns:purchaseOrder/tns:items/tns:item/tns:quantity"));
-        Assert.assertThat(quantity.getFieldType(), Is.is(FieldType.BIG_INTEGER));
-        Assert.assertNotNull(quantity.getRestrictions().getRestriction());
-        Assert.assertThat(quantity.getRestrictions().getRestriction().size(), Is.is(1));
+        assertNotNull(quantity);
+        assertEquals("tns:quantity", quantity.getName());
+        assertNull(quantity.getValue());
+        assertEquals("/tns:purchaseOrder/tns:items/tns:item/tns:quantity", quantity.getPath());
+        assertEquals(FieldType.BIG_INTEGER, quantity.getFieldType());
+        assertEquals(false, quantity.isAttribute());
+        assertNotNull(quantity.getRestrictions().getRestriction());
+        assertEquals(1, quantity.getRestrictions().getRestriction().size());
         Restriction qRestriction = quantity.getRestrictions().getRestriction().get(0);
-        Assert.assertNotNull(qRestriction);
-        Assert.assertNotNull(qRestriction.getType());
-        Assert.assertThat(qRestriction.getType(), Is.is(RestrictionType.MAX_EXCLUSIVE));
-        Assert.assertNotNull(qRestriction.getValue());
-        Assert.assertThat(qRestriction.getValue(), Is.is("99"));
+        assertNotNull(qRestriction);
+        assertNotNull(qRestriction.getType());
+        assertEquals(RestrictionType.MAX_EXCLUSIVE, qRestriction.getType());
+        assertNotNull(qRestriction.getValue());
+        assertEquals("99", qRestriction.getValue());
 
         // USPrice
         XmlField usPrice = item.getXmlFields().getXmlField().get(3);
-        Assert.assertNotNull(usPrice);
-        Assert.assertThat(usPrice.getName(), Is.is("tns:USPrice"));
-        Assert.assertNull(usPrice.getValue());
-        Assert.assertThat(usPrice.getPath(), Is.is("/tns:purchaseOrder/tns:items/tns:item/tns:USPrice"));
-        Assert.assertThat(usPrice.getFieldType(), Is.is(FieldType.DECIMAL));
+        assertNotNull(usPrice);
+        assertEquals("tns:USPrice", usPrice.getName());
+        assertNull(usPrice.getValue());
+        assertEquals("/tns:purchaseOrder/tns:items/tns:item/tns:USPrice", usPrice.getPath());
+        assertEquals(FieldType.DECIMAL, usPrice.getFieldType());
+        assertEquals(false, usPrice.isAttribute());
 
         // comment
         XmlField itemComment = item.getXmlFields().getXmlField().get(4);
         Assert.assertNotNull(itemComment);
-        Assert.assertThat(itemComment.getName(), Is.is("tns:comment"));
-        Assert.assertNull(itemComment.getValue());
-        Assert.assertThat(itemComment.getPath(), Is.is("/tns:purchaseOrder/tns:items/tns:item/tns:comment"));
-        Assert.assertThat(itemComment.getFieldType(), Is.is(FieldType.STRING));
+        assertEquals("tns:comment", itemComment.getName());
+        assertNull(itemComment.getValue());
+        assertEquals("/tns:purchaseOrder/tns:items/tns:item/tns:comment", itemComment.getPath());
+        assertEquals(FieldType.STRING, itemComment.getFieldType());
+        assertEquals(false, itemComment.isAttribute());
 
         // shipDate
         XmlField shipDate = item.getXmlFields().getXmlField().get(5);
-        Assert.assertNotNull(shipDate);
-        Assert.assertThat(shipDate.getName(), Is.is("tns:shipDate"));
-        Assert.assertNull(shipDate.getValue());
-        Assert.assertThat(shipDate.getPath(), Is.is("/tns:purchaseOrder/tns:items/tns:item/tns:shipDate"));
-        Assert.assertThat(shipDate.getFieldType(), Is.is(FieldType.DATE));
+        assertNotNull(shipDate);
+        assertEquals("tns:shipDate", shipDate.getName());
+        assertNull(shipDate.getValue());
+        assertEquals("/tns:purchaseOrder/tns:items/tns:item/tns:shipDate", shipDate.getPath());
+        assertEquals(FieldType.DATE, shipDate.getFieldType());
+        assertEquals(false, shipDate.isAttribute());
 
         // namespaces
         Assert.assertNotNull(xmlDocument.getXmlNamespaces());
-        Assert.assertThat(xmlDocument.getXmlNamespaces().getXmlNamespace().size(), Is.is(1));
+        assertEquals(1, xmlDocument.getXmlNamespaces().getXmlNamespace().size());
 
         XmlNamespace namespace = xmlDocument.getXmlNamespaces().getXmlNamespace().get(0);
 
-        Assert.assertThat(namespace.getAlias(), Is.is("tns"));
-        Assert.assertThat(namespace.getUri(), Is.is("http://tempuri.org/po.xsd"));
+        assertEquals("tns", namespace.getAlias());
+        assertEquals("http://tempuri.org/po.xsd", namespace.getUri());
 
         // debugFields(xmlDocument.getFields());
     }

--- a/lib/modules/xml/core/src/test/resources/inspect/fhir-patient.xsd
+++ b/lib/modules/xml/core/src/test/resources/inspect/fhir-patient.xsd
@@ -409,11 +409,11 @@
                             <xs:documentation xml:lang="en">The status of the narrative - whether it's entirely generated (from just the defined data or the extensions too), or whether a human authored it and it may contain additional data.</xs:documentation>
                         </xs:annotation>
                     </xs:element>
-                    <xs:element ref="xhtml:div" minOccurs="1" maxOccurs="1">
+                    <!--  <xs:element ref="xhtml:div" minOccurs="1" maxOccurs="1">
                         <xs:annotation>
                             <xs:documentation xml:lang="en">The actual narrative content, a stripped down version of XHTML.</xs:documentation>
                         </xs:annotation>
-                    </xs:element>
+                    </xs:element> -->
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>

--- a/lib/modules/xml/model/src/main/java/io/atlasmap/xml/v2/XmlField.java
+++ b/lib/modules/xml/model/src/main/java/io/atlasmap/xml/v2/XmlField.java
@@ -22,7 +22,7 @@ public class XmlField extends Field implements Serializable {
 
     protected Boolean userCreated;
 
-    protected Boolean attribute;
+    protected Boolean attribute = false;
 
     /**
      * Gets the value of the annotations property.

--- a/ui/test-resources/xml/schema/fhir-patient.xsd
+++ b/ui/test-resources/xml/schema/fhir-patient.xsd
@@ -409,11 +409,11 @@
                             <xs:documentation xml:lang="en">The status of the narrative - whether it's entirely generated (from just the defined data or the extensions too), or whether a human authored it and it may contain additional data.</xs:documentation>
                         </xs:annotation>
                     </xs:element>
-                    <xs:element ref="xhtml:div" minOccurs="1" maxOccurs="1">
+                    <!--  <xs:element ref="xhtml:div" minOccurs="1" maxOccurs="1">
                         <xs:annotation>
                             <xs:documentation xml:lang="en">The actual narrative content, a stripped down version of XHTML.</xs:documentation>
                         </xs:annotation>
-                    </xs:element>
+                    </xs:element> -->
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>


### PR DESCRIPTION
Fixes: #2406
Narrowed element/type caching to only apply vertically to avoid recursion. It causes OOM if it runs with the previous FHIR XSD, but it turned out the `xhtml:div` involved in FHIR XSD (!!!!!) is disabled in Syndesis FHIR connector. Did the same thing and now response time of FHIR inspection is realistic.