### PR TITLE
fix: Preview contains unexpected 'Space' terms with Combine mappings

### DIFF
--- a/lib/core/src/main/java/io/atlasmap/actions/StringComplexFieldActions.java
+++ b/lib/core/src/main/java/io/atlasmap/actions/StringComplexFieldActions.java
@@ -73,15 +73,13 @@ public class StringComplexFieldActions implements AtlasFieldAction {
 
         String delim = concat.getDelimiter() == null ? "" : concat.getDelimiter();
         StringBuilder builder = new StringBuilder();
-        boolean isFirst = true;
         for (String entry : inputs) {
-            if (!isFirst) {
-                builder.append(delim);
-            }
-            if (entry != null) {
+            if (entry != null && !entry.isEmpty()) {
+                if (builder.length()  > 0) {
+                    builder.append(delim);
+                }
                 builder.append(entry);
             }
-            isFirst = false;
         }
 
         return builder.toString();

--- a/lib/core/src/test/java/io/atlasmap/core/DefaultAtlasContextTest.java
+++ b/lib/core/src/test/java/io/atlasmap/core/DefaultAtlasContextTest.java
@@ -578,7 +578,7 @@ public class DefaultAtlasContextTest extends BaseDefaultAtlasContextTest {
         target.setFieldType(FieldType.STRING);
         m.getOutputField().add(target);
         context.processPreview(m);
-        assertEquals("-one--two--six", target.getValue());
+        assertEquals("one-two-six", target.getValue());
     }
 
     @Test


### PR DESCRIPTION
Fixes: #2422 

This does NOT fix the issue that the delimiter name, 'Space', is being used as the delimiter rather than an actual space. I need to research the expected behavior more for this, so will create a subsequent issue for that.