### PR TITLE
Fixes: #1518

### DIFF
--- a/ui/packages/atlasmap-core/src/models/document-definition.model.ts
+++ b/ui/packages/atlasmap-core/src/models/document-definition.model.ts
@@ -453,7 +453,7 @@ export class DocumentDefinition {
         ? this.LEFT_BRACKET + this.RIGHT_BRACKET
         : '<>';
     }
-    if (field.isAttribute) {
+    if (field.isAttribute && field.name[0] !== '@') {
       field.path = parentPath += '@' + field.name;
     }
     if (field.serviceObject) {

--- a/ui/packages/atlasmap/src/Views/ColumnMapperView/Columns/TreeItemFieldAndNodeRefsAndDnD.tsx
+++ b/ui/packages/atlasmap/src/Views/ColumnMapperView/Columns/TreeItemFieldAndNodeRefsAndDnD.tsx
@@ -129,6 +129,8 @@ export const TreeItemWithFieldAndNodeRefsAndDnD: FunctionComponent<ITreeItemFiel
                             key="connected"
                             position={"auto"}
                             enableFlip={true}
+                            entryDelay={750}
+                            exitDelay={100}
                             content={<div>This field is connected</div>}
                           >
                             <CircleIcon
@@ -143,6 +145,8 @@ export const TreeItemWithFieldAndNodeRefsAndDnD: FunctionComponent<ITreeItemFiel
                             key={"collection"}
                             position={"auto"}
                             enableFlip={true}
+                            entryDelay={750}
+                            exitDelay={100}
                             content={<div>This field is a collection</div>}
                           >
                             <LayerGroupIcon
@@ -157,6 +161,8 @@ export const TreeItemWithFieldAndNodeRefsAndDnD: FunctionComponent<ITreeItemFiel
                             key={"transformations"}
                             position={"auto"}
                             enableFlip={true}
+                            entryDelay={750}
+                            exitDelay={100}
                             content={<div>This field has transformations</div>}
                           >
                             <BoltIcon


### PR DESCRIPTION
Correct cascading '@' chars prepended to attribute fields.
Trivial change to avoid adding a new '@' every time the adm file is loaded.  Also evened out the tooltips.