### PR TITLE
fix: Corrects d&d on Chrome.

### DIFF
--- a/ui/packages/atlasmap/src/UI/dnd/FieldsDndProvider.tsx
+++ b/ui/packages/atlasmap/src/UI/dnd/FieldsDndProvider.tsx
@@ -11,22 +11,17 @@ import { IDragAndDropField } from "./models";
 
 const probablyTouch =
   window.matchMedia &&
-  window.matchMedia("(pointer: none)").matches &&
+  (window.matchMedia("(pointer: none)").matches ||
+    window.matchMedia("(pointer: coarse)").matches) &&
   window.matchMedia("(hover: none)").matches;
-const maybeTouch =
-  window.matchMedia &&
-  (window.matchMedia("(pointer: coarse)").matches ||
-    window.matchMedia("(hover: none)").matches); // iOS is triggering this check, probably because it supports the Apple Pencil
 
-const TouchOnlyProvider: FunctionComponent = ({ children }) => (
-  <DndProvider backend={TouchBackend}>{children}</DndProvider>
-);
-
-const TouchAndPointerProvider: FunctionComponent = ({ children }) => (
-  <DndProvider backend={TouchBackend} options={{ enableMouseEvents: true }}>
-    {children}
-  </DndProvider>
-);
+const TouchAndPointerProvider: FunctionComponent = ({ children }) => {
+  return (
+    <DndProvider backend={TouchBackend} options={{ enableMouseEvents: true }}>
+      {children}
+    </DndProvider>
+  );
+};
 
 const MouseOnlyProvider: FunctionComponent = ({ children }) => (
   <DndProvider backend={Html5Backend}>{children}</DndProvider>
@@ -44,11 +39,7 @@ export const FieldsDndProvider: FunctionComponent = ({ children }) => {
   const getHoveredTarget = () => hoveredTarget.current;
   const setHoveredTarget = (target: IDragAndDropField | null) =>
     (hoveredTarget.current = target);
-  const Provider = probablyTouch
-    ? TouchOnlyProvider
-    : maybeTouch
-    ? TouchAndPointerProvider
-    : MouseOnlyProvider;
+  const Provider = probablyTouch ? TouchAndPointerProvider : MouseOnlyProvider;
   return (
     <Provider>
       <FieldsDndContext.Provider value={{ getHoveredTarget, setHoveredTarget }}>


### PR DESCRIPTION
Fixes: #2307

@riccardo-forina - please see if d&d still behaves correctly on Apple - don't have one to try.  This now works on Chrome and Firefox ok,  It's triggering through TouchBackend (enableMouseEvents = true).