### PR TITLE
fix: Correct intermittent e2etest failure.

### DIFF
--- a/standalone/src/test/java/io/atlasmap/standalone/E2ETest.java
+++ b/standalone/src/test/java/io/atlasmap/standalone/E2ETest.java
@@ -106,6 +106,9 @@ public class E2ETest {
         WebElement confirmBtn = driver.findElement(By.xpath("//button[@data-testid='confirmation-dialog-confirm-button']"));
         confirmBtn.click();
         waitForLoad.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//article[@aria-label='JSONSchemaSource']")));
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e1) { }
 
         // Check custom action param
         WebElement orderBtn = driver.findElement(By.xpath("//button[@id='sources-field-atlas:json:JSONSchemaSource:source:/order-toggle']"));


### PR DESCRIPTION
Fixes: #2527

It appears the ` waitForLoad` method doesn't always wait long enough.  I dropped in a 1 second sleep to get the e2e test to behave.