### PR TITLE
fix: Syndesis: one-to-many transformation disappears upon reopen

### DIFF
--- a/ui/packages/atlasmap-core/src/models/field-action.model.ts
+++ b/ui/packages/atlasmap-core/src/models/field-action.model.ts
@@ -87,7 +87,7 @@ export class FieldAction {
   static create(definition: FieldActionDefinition): FieldAction {
     const instance = new FieldAction();
     instance.definition = definition;
-    instance.name = definition.name;
+    instance.name = definition?.name;
     return instance;
   }
 

--- a/ui/packages/atlasmap-core/src/services/initialization.service.ts
+++ b/ui/packages/atlasmap-core/src/services/initialization.service.ts
@@ -869,6 +869,7 @@ ${error.status} ${error.statusText}`,
           d.updateFromMappings(this.cfg.mappings);
         }
         MappingUtil.removeStaleMappings(this.cfg);
+        this.cfg.mappingService.updateMappingsTransition();
       }
       this.updateInitComplete();
     }

--- a/ui/packages/atlasmap-core/src/services/mapping-management.service.ts
+++ b/ui/packages/atlasmap-core/src/services/mapping-management.service.ts
@@ -159,9 +159,7 @@ export class MappingManagementService {
             this.cfg.mappings = mappingDefinition;
             MappingSerializer.deserializeMappingServiceJSON(d, this.cfg);
           }
-          this.cfg
-            .mappings!.getAllMappings(true)
-            .forEach((m) => this.updateTransition(m)); // TODO: check this non null operator
+          this.updateMappingsTransition();
           observer.next(true);
           observer.complete();
         })
@@ -170,6 +168,12 @@ export class MappingManagementService {
           observer.complete();
         });
     }).pipe(timeout(this.cfg.initCfg.admHttpTimeout));
+  }
+
+  updateMappingsTransition() {
+    this.cfg
+      .mappings!.getAllMappings(true)
+      .forEach((m) => this.updateTransition(m)); // TODO: check this non null operator
   }
 
   /**
@@ -951,6 +955,7 @@ export class MappingManagementService {
       if (
         !mapping.transition.enableExpression &&
         (!mapping.transition.transitionFieldAction ||
+          !mapping.transition.transitionFieldAction.definition ||
           mapping.transition.transitionFieldAction.definition.multiplicity !==
             Multiplicity.MANY_TO_ONE)
       ) {


### PR DESCRIPTION
Fixes: #2624