### PR TITLE
fix: Correct UI circular dependency in MappingField.tsx

### DIFF
--- a/ui/packages/atlasmap/src/UI/MappingField.tsx
+++ b/ui/packages/atlasmap/src/UI/MappingField.tsx
@@ -12,8 +12,9 @@ import {
 } from "@patternfly/react-core";
 import { BoltIcon, TrashIcon, InfoAltIcon } from "@patternfly/react-icons";
 import { css, StyleSheet } from "@patternfly/react-styles";
-import { DraggableField, FieldDropTarget, NodeRef } from ".";
-import { IAtlasmapField } from "src/Views";
+import { IAtlasmapField } from "../../src/Views/models";
+import { DraggableField, FieldDropTarget } from "./dnd";
+import { NodeRef } from "./Canvas/NodeRef";
 
 const styles = StyleSheet.create({
   field: {


### PR DESCRIPTION
Fixes: #2622

The build warning circ dependency is a bug in shelljs (fixed in v0.8.4).  It requires a new storybook and tsdx which then requires new jest, etc.  Recommend tacking this upgrade when we do the patternfly upgrade.