### PR TITLE
fix: Wrong use of float/double MIN/MAX

### DIFF
--- a/lib/core/src/main/java/io/atlasmap/converters/BigDecimalConverter.java
+++ b/lib/core/src/main/java/io/atlasmap/converters/BigDecimalConverter.java
@@ -100,12 +100,12 @@ public class BigDecimalConverter implements AtlasConverter<BigInteger> {
     }
 
     @AtlasConversionInfo(sourceType = FieldType.DECIMAL, targetType = FieldType.DOUBLE,
-            concerns = {AtlasConversionConcern.RANGE, AtlasConversionConcern.FRACTIONAL_PART})
+            concerns = {AtlasConversionConcern.RANGE})
     public Double toDouble(BigDecimal value) throws AtlasConversionException {
         if (value == null) {
             return null;
         }
-        Double answer = value.toBigInteger().doubleValue();
+        Double answer = value.doubleValue();
         if (answer == Double.NEGATIVE_INFINITY || answer == Double.POSITIVE_INFINITY) {
             throw new AtlasConversionException(String.format(
                     "BigDecimal %s is greater than Double.MAX_VALUE or less than Double.MIN_VALUE", value));

--- a/lib/core/src/main/java/io/atlasmap/converters/CharSequenceConverter.java
+++ b/lib/core/src/main/java/io/atlasmap/converters/CharSequenceConverter.java
@@ -148,21 +148,25 @@ public class CharSequenceConverter implements AtlasConverter<CharSequence> {
         }
 
         String str = value.toString();
+        double parsedDouble = 0.0d;
         try {
-            Double.parseDouble(str);
+            parsedDouble = Double.parseDouble(str);
         } catch (NumberFormatException nfe) {
             throw new AtlasConversionException(nfe);
         }
 
-        if (Double.valueOf(str) == 0.0d || Double.valueOf(str) == -0.0d) {
-            return Double.valueOf(str);
+        double absParsedDouble = Math.abs(parsedDouble);
+        if (absParsedDouble == 0.0d) {
+            return parsedDouble;
         }
-        if (Double.valueOf(str) < Double.MIN_VALUE || Double.valueOf(str) > Double.MAX_VALUE) {
+        if (absParsedDouble < Double.MIN_VALUE || absParsedDouble > Double.MAX_VALUE) {
             throw new AtlasConversionException(
-                    String.format("String %s is greater than Double.MAX_VALUE  or less than Double.MIN_VALUE", value));
+                    String.format(
+                            "String %s is greater than Double.MAX_VALUE  or less than Double.MIN_VALUE",
+                            str));
         }
 
-        return Double.valueOf(str);
+        return parsedDouble;
     }
 
     @AtlasConversionInfo(sourceType = FieldType.STRING, targetType = FieldType.FLOAT, concerns = {
@@ -171,24 +175,25 @@ public class CharSequenceConverter implements AtlasConverter<CharSequence> {
         if (value == null) {
             return null;
         }
-        // check we can make a float of the String
+
         String str = value.toString();
+        float parsedFloat = 0.0f;
         try {
-            Float.parseFloat(str);
+            parsedFloat = Float.parseFloat(str);
         } catch (NumberFormatException nfe) {
             throw new AtlasConversionException(nfe);
         }
 
-        BigDecimal bd = new BigDecimal(str);
-
-        // handle 0.0f && -0.0 (floats suck)
-        if (bd.floatValue() == 0.0f || bd.floatValue() == -0.0) {
-            return Float.valueOf(str);
+        float absParsedFloat = Math.abs(parsedFloat);
+        if (absParsedFloat == 0.0f) {
+            return parsedFloat;
         }
 
-        if (bd.floatValue() < Float.MIN_VALUE || bd.floatValue() > Float.MAX_VALUE) {
+        if (absParsedFloat < Float.MIN_VALUE || absParsedFloat > Float.MAX_VALUE) {
             throw new AtlasConversionException(
-                    String.format("String %s is greater than Float.MAX_VALUE  or less than Float.MIN_VALUE", str));
+                    String.format(
+                            "String %s is greater than Float.MAX_VALUE  or less than Float.MIN_VALUE",
+                            str));
         }
 
         return Float.valueOf(str);

--- a/lib/core/src/main/java/io/atlasmap/converters/DoubleConverter.java
+++ b/lib/core/src/main/java/io/atlasmap/converters/DoubleConverter.java
@@ -107,7 +107,8 @@ public class DoubleConverter implements AtlasConverter<Double> {
         if (value == null) {
             return null;
         }
-        if (value > Float.MAX_VALUE || (value < Float.MIN_VALUE && value != 0)) {
+        double absValue = Math.abs(value);
+        if (absValue > Float.MAX_VALUE || (absValue < Float.MIN_VALUE && value != 0)) {
             throw new AtlasConversionException(
                     String.format("Double %s is greater than Float.MAX_VALUE or less than Float.MIN_VALUE", value));
         }

--- a/lib/core/src/test/java/io/atlasmap/core/DefaultAtlasConversionServiceTest.java
+++ b/lib/core/src/test/java/io/atlasmap/core/DefaultAtlasConversionServiceTest.java
@@ -457,6 +457,10 @@ public class DefaultAtlasConversionServiceTest {
         assertEquals((short)1, service.convertType(BigDecimal.valueOf(1), FieldType.DECIMAL, FieldType.SHORT));
         assertEquals("1", service.convertType(BigDecimal.valueOf(1), FieldType.DECIMAL, FieldType.STRING));
         assertEquals(LocalTime.class, service.convertType(BigDecimal.valueOf(1), FieldType.DECIMAL, FieldType.TIME).getClass());
+        assertEquals(-1.68d, service.convertType(BigDecimal.valueOf(-1.68d), null, FieldType.DOUBLE, null));
+        assertEquals(-1.68f, service.convertType(BigDecimal.valueOf(-1.68f), null, FieldType.FLOAT, null));
+        assertEquals(new Float(-1.68f).doubleValue(), service.convertType(BigDecimal.valueOf(-1.68f), null, FieldType.DOUBLE, null));
+        assertEquals(-1.68f, service.convertType(BigDecimal.valueOf(-1.68d), null, FieldType.FLOAT, null));
     }
 
     @Test
@@ -479,6 +483,8 @@ public class DefaultAtlasConversionServiceTest {
         assertEquals((short)1, service.convertType(BigInteger.valueOf(1), FieldType.BIG_INTEGER, FieldType.SHORT));
         assertEquals("1", service.convertType(BigInteger.valueOf(1), FieldType.BIG_INTEGER, FieldType.STRING));
         assertEquals(LocalTime.class, service.convertType(BigInteger.valueOf(1), FieldType.BIG_INTEGER, FieldType.TIME).getClass());
+        assertEquals(-2.0d, service.convertType(BigInteger.valueOf(-2), null, FieldType.DOUBLE, null));
+        assertEquals(-2.0f, service.convertType(BigInteger.valueOf(-2), null, FieldType.FLOAT, null));
     }
 
     @Test
@@ -576,6 +582,7 @@ public class DefaultAtlasConversionServiceTest {
         assertEquals((short)1, service.convertType(new Double(1), FieldType.DOUBLE, FieldType.SHORT));
         assertEquals("1.0", service.convertType(new Double(1), FieldType.DOUBLE, FieldType.STRING));
         assertEquals(LocalTime.class, service.convertType(new Double(1), FieldType.DOUBLE, FieldType.TIME).getClass());
+        assertEquals(-1.68f, service.convertType(-1.68d, null, FieldType.FLOAT, null));
     }
 
     @Test
@@ -598,6 +605,7 @@ public class DefaultAtlasConversionServiceTest {
         assertEquals((short)1, service.convertType(new Float(1), FieldType.FLOAT, FieldType.SHORT));
         assertEquals("1.0", service.convertType(new Float(1), FieldType.FLOAT, FieldType.STRING));
         assertEquals(LocalTime.class, service.convertType(new Float(1), FieldType.FLOAT, FieldType.TIME).getClass());
+        assertEquals(new Float(-1.68f).doubleValue(), service.convertType(-1.68f, null, FieldType.DOUBLE, null));
     }
 
     @Test
@@ -742,6 +750,8 @@ public class DefaultAtlasConversionServiceTest {
         assertEquals((short)1, service.convertType("1", FieldType.STRING, FieldType.SHORT));
         assertEquals("1", service.convertType("1", FieldType.STRING, FieldType.STRING));
         assertEquals(LocalTime.class, service.convertType("00:00:00.000", FieldType.STRING, FieldType.TIME).getClass());
+        assertEquals(-1.68d, service.convertType("-1.68", null, FieldType.DOUBLE, null));
+        assertEquals(-1.68f, service.convertType("-1.68", null, FieldType.FLOAT, null));
     }
 
     @Test


### PR DESCRIPTION
Fixes: #2647

fix: `BigDecimalConverter#toDouble()` unnecessarily loses fractional part
Fixes: #2648