### PR TITLE
fix: XML Schema: Support form/elementFormDefault/attributeFormDefault

### DIFF
--- a/lib/modules/dfdl/service/src/test/java/io/atlasmap/dfdl/service/DfdlServiceTest.java
+++ b/lib/modules/dfdl/service/src/test/java/io/atlasmap/dfdl/service/DfdlServiceTest.java
@@ -57,20 +57,19 @@ public class DfdlServiceTest {
         assertEquals("tns:file", file.getName());
         assertEquals(2, file.getXmlFields().getXmlField().size());
         XmlComplexType record = (XmlComplexType) file.getXmlFields().getXmlField().get(1);
-        assertEquals("tns:record", record.getName());
+        assertEquals("record", record.getName());
         assertEquals(3, record.getXmlFields().getXmlField().size());
         XmlField header1 = (XmlField) record.getXmlFields().getXmlField().get(0);
-        assertEquals("tns:header1", header1.getName());
+        assertEquals("header1", header1.getName());
         assertEquals(FieldType.STRING, header1.getFieldType());
         XmlField header2 = (XmlField) record.getXmlFields().getXmlField().get(1);
-        assertEquals("tns:header2", header2.getName());
+        assertEquals("header2", header2.getName());
         assertEquals(FieldType.STRING, header2.getFieldType());
         XmlField header3 = (XmlField) record.getXmlFields().getXmlField().get(2);
-        assertEquals("tns:header3", header3.getName());
+        assertEquals("header3", header3.getName());
         assertEquals(FieldType.STRING, header3.getFieldType());
     }
 
-    @Ignore("https://github.com/atlasmap/atlasmap/issues/1470")
     @Test
     public void testInstance() throws Exception {
         final String source =
@@ -94,19 +93,19 @@ public class DfdlServiceTest {
         assertNotNull(root);
         assertEquals(1, xmlDoc.getFields().getField().size());
         XmlComplexType file = (XmlComplexType) xmlDoc.getFields().getField().get(0);
-        assertEquals("tns:file", file.getName());
+        assertEquals("atlas:file", file.getName());
         assertEquals(2, file.getXmlFields().getXmlField().size());
         XmlComplexType record = (XmlComplexType) file.getXmlFields().getXmlField().get(1);
-        assertEquals("tns:record", record.getName());
+        assertEquals("record", record.getName());
         assertEquals(3, record.getXmlFields().getXmlField().size());
         XmlField header1 = (XmlField) record.getXmlFields().getXmlField().get(0);
-        assertEquals("tns:header1", header1.getName());
+        assertEquals("header1", header1.getName());
         assertEquals(FieldType.STRING, header1.getFieldType());
         XmlField header2 = (XmlField) record.getXmlFields().getXmlField().get(1);
-        assertEquals("tns:header2", header2.getName());
+        assertEquals("header2", header2.getName());
         assertEquals(FieldType.STRING, header2.getFieldType());
         XmlField header3 = (XmlField) record.getXmlFields().getXmlField().get(2);
-        assertEquals("tns:header3", header3.getName());
+        assertEquals("header3", header3.getName());
         assertEquals(FieldType.STRING, header3.getFieldType());
     }
 

--- a/lib/modules/xml/core/src/main/java/io/atlasmap/xml/inspect/XmlSchemaInspector.java
+++ b/lib/modules/xml/core/src/main/java/io/atlasmap/xml/inspect/XmlSchemaInspector.java
@@ -157,9 +157,6 @@ public class XmlSchemaInspector {
             return null;
         }
         String targetNamespace = decl.getTargetNamespace();
-        if (targetNamespace == null || targetNamespace.isEmpty()) {
-            targetNamespace = decl.getOwnerSchema().getTargetNamespace();
-        }
         if (targetNamespace != null && !targetNamespace.isEmpty()) {
             String prefix = namespaceContext.getPrefix(targetNamespace);
             if (prefix == null || prefix.isEmpty()) {

--- a/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/XmlSchemaInspection2372Test.java
+++ b/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/XmlSchemaInspection2372Test.java
@@ -40,9 +40,9 @@ public class XmlSchemaInspection2372Test extends BaseXmlInspectionServiceTest {
         XmlComplexType fault = (XmlComplexType) body.getXmlFields().getXmlField().get(1);
         assertEquals("tns:Fault", fault.getName());
         XmlField faultstring = fault.getXmlFields().getXmlField().get(1);
-        assertEquals("tns:faultstring", faultstring.getName());
+        assertEquals("faultstring", faultstring.getName());
         XmlComplexType detail = (XmlComplexType) fault.getXmlFields().getXmlField().get(3);
-        assertEquals("tns:detail", detail.getName());
+        assertEquals("detail", detail.getName());
         XmlComplexType bankException = (XmlComplexType) detail.getXmlFields().getXmlField().get(0);
         assertEquals("ns1:bankException", bankException.getName());
         XmlField code = (XmlField) bankException.getXmlFields().getXmlField().get(0);

--- a/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/XmlSchemaInspectionFhirTest.java
+++ b/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/XmlSchemaInspectionFhirTest.java
@@ -47,7 +47,7 @@ public class XmlSchemaInspectionFhirTest extends BaseXmlInspectionServiceTest {
         assertEquals("tns:id", id.getName());
         assertEquals(2, id.getXmlFields().getXmlField().size());
         XmlField value = (XmlField) id.getXmlFields().getXmlField().get(0);
-        assertEquals("tns:value", value.getName());
+        assertEquals("value", value.getName());
         assertTrue(value.isAttribute());
         XmlComplexType extension = (XmlComplexType) id.getXmlFields().getXmlField().get(1);
         assertEquals("tns:extension", extension.getName());

--- a/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/XmlSchemaInspectionFormTest.java
+++ b/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/XmlSchemaInspectionFormTest.java
@@ -1,0 +1,131 @@
+package io.atlasmap.xml.inspect;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+
+import io.atlasmap.xml.v2.XmlComplexType;
+import io.atlasmap.xml.v2.XmlDocument;
+import io.atlasmap.xml.v2.XmlField;
+
+public class XmlSchemaInspectionFormTest extends BaseXmlInspectionServiceTest {
+
+    @Test
+    public void testInspectSchemaFileFormNoDefault() throws Exception {
+        File schemaFile = Paths.get("src/test/resources/inspect/form-no-default-schema.xsd").toFile();
+        XmlInspectionService service = new XmlInspectionService();
+        XmlDocument xmlDocument = service.inspectSchema(schemaFile);
+        assertDefaultUnqualified(xmlDocument);
+    }
+
+    @Test
+    public void testInspectSchemaFileFormDefaultUnqualified() throws Exception {
+        File schemaFile = Paths.get("src/test/resources/inspect/form-default-unqualified-schema.xsd").toFile();
+        XmlInspectionService service = new XmlInspectionService();
+        XmlDocument xmlDocument = service.inspectSchema(schemaFile);
+        assertDefaultUnqualified(xmlDocument);
+    }
+
+    private void assertDefaultUnqualified(XmlDocument xmlDocument) throws Exception {
+        assertNotNull(xmlDocument);
+        assertNotNull(xmlDocument.getFields());
+        assertEquals(1, xmlDocument.getFields().getField().size());
+        XmlComplexType a = (XmlComplexType) xmlDocument.getFields().getField().get(0);
+        assertNotNull(a);
+        assertEquals("tns:a", a.getName());
+        assertEquals(6, a.getXmlFields().getXmlField().size());
+        XmlComplexType aa = (XmlComplexType) a.getXmlFields().getXmlField().get(3);
+        assertEquals("aa", aa.getName());
+        assertEquals(4, aa.getXmlFields().getXmlField().size());
+        XmlField aaa = aa.getXmlFields().getXmlField().get(1);
+        assertEquals("aaa", aaa.getName());
+        XmlField aab = aa.getXmlFields().getXmlField().get(2);
+        assertEquals("tns:aab", aab.getName());
+        XmlField aac = aa.getXmlFields().getXmlField().get(3);
+        assertEquals("aac", aac.getName());
+        XmlField aad = aa.getXmlFields().getXmlField().get(0);
+        assertEquals("aad", aad.getName());
+        XmlComplexType ab = (XmlComplexType) a.getXmlFields().getXmlField().get(4);
+        assertEquals("tns:ab", ab.getName());
+        XmlField aba = ab.getXmlFields().getXmlField().get(1);
+        assertEquals("aba", aba.getName());
+        XmlField abb = ab.getXmlFields().getXmlField().get(2);
+        assertEquals("tns:abb", abb.getName());
+        XmlField abc = ab.getXmlFields().getXmlField().get(3);
+        assertEquals("abc", abc.getName());
+        XmlField abd = ab.getXmlFields().getXmlField().get(0);
+        assertEquals("abd", abd.getName());
+        XmlComplexType ac = (XmlComplexType) a.getXmlFields().getXmlField().get(5);
+        assertEquals("ac", ac.getName());
+        XmlField aca = ac.getXmlFields().getXmlField().get(1);
+        assertEquals("aca", aca.getName());
+        XmlField acb = ac.getXmlFields().getXmlField().get(2);
+        assertEquals("tns:acb", acb.getName());
+        XmlField acc = ac.getXmlFields().getXmlField().get(3);
+        assertEquals("acc", acc.getName());
+        XmlField acd = ac.getXmlFields().getXmlField().get(0);
+        assertEquals("acd", acd.getName());
+        XmlField ad = a.getXmlFields().getXmlField().get(0);
+        assertEquals("ad", ad.getName());
+        XmlField ae = a.getXmlFields().getXmlField().get(1);
+        assertEquals("tns:ae", ae.getName());
+        XmlField af = a.getXmlFields().getXmlField().get(2);
+        assertEquals("af", af.getName());
+    }
+
+    @Test
+    public void testInspectSchemaFileFormDefaultQualified() throws Exception {
+        File schemaFile = Paths.get("src/test/resources/inspect/form-default-qualified-schema.xsd").toFile();
+        XmlInspectionService service = new XmlInspectionService();
+        XmlDocument xmlDocument = service.inspectSchema(schemaFile);
+        assertNotNull(xmlDocument);
+        assertNotNull(xmlDocument.getFields());
+        assertEquals(1, xmlDocument.getFields().getField().size());
+        XmlComplexType a = (XmlComplexType) xmlDocument.getFields().getField().get(0);
+        assertNotNull(a);
+        assertEquals("tns:a", a.getName());
+        assertEquals(6, a.getXmlFields().getXmlField().size());
+        XmlComplexType aa = (XmlComplexType) a.getXmlFields().getXmlField().get(3);
+        assertEquals("tns:aa", aa.getName());
+        assertEquals(4, aa.getXmlFields().getXmlField().size());
+        XmlField aaa = aa.getXmlFields().getXmlField().get(1);
+        assertEquals("tns:aaa", aaa.getName());
+        XmlField aab = aa.getXmlFields().getXmlField().get(2);
+        assertEquals("tns:aab", aab.getName());
+        XmlField aac = aa.getXmlFields().getXmlField().get(3);
+        assertEquals("aac", aac.getName());
+        XmlField aad = aa.getXmlFields().getXmlField().get(0);
+        assertEquals("tns:aad", aad.getName());
+        XmlComplexType ab = (XmlComplexType) a.getXmlFields().getXmlField().get(4);
+        assertEquals("tns:ab", ab.getName());
+        XmlField aba = ab.getXmlFields().getXmlField().get(1);
+        assertEquals("tns:aba", aba.getName());
+        XmlField abb = ab.getXmlFields().getXmlField().get(2);
+        assertEquals("tns:abb", abb.getName());
+        XmlField abc = ab.getXmlFields().getXmlField().get(3);
+        assertEquals("abc", abc.getName());
+        XmlField abd = ab.getXmlFields().getXmlField().get(0);
+        assertEquals("tns:abd", abd.getName());
+        XmlComplexType ac = (XmlComplexType) a.getXmlFields().getXmlField().get(5);
+        assertEquals("ac", ac.getName());
+        XmlField aca = ac.getXmlFields().getXmlField().get(1);
+        assertEquals("tns:aca", aca.getName());
+        XmlField acb = ac.getXmlFields().getXmlField().get(2);
+        assertEquals("tns:acb", acb.getName());
+        XmlField acc = ac.getXmlFields().getXmlField().get(3);
+        assertEquals("acc", acc.getName());
+        XmlField acd = ac.getXmlFields().getXmlField().get(0);
+        assertEquals("tns:acd", acd.getName());
+        XmlField ad = a.getXmlFields().getXmlField().get(0);
+        assertEquals("tns:ad", ad.getName());
+        XmlField ae = a.getXmlFields().getXmlField().get(1);
+        assertEquals("tns:ae", ae.getName());
+        XmlField af = a.getXmlFields().getXmlField().get(2);
+        assertEquals("af", af.getName());
+    }
+
+}

--- a/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/XmlSchemaInspectionMultipleNamespacesTest.java
+++ b/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/XmlSchemaInspectionMultipleNamespacesTest.java
@@ -64,13 +64,13 @@ public class XmlSchemaInspectionMultipleNamespacesTest extends BaseXmlInspection
         Assert.assertEquals(4, rootFields.size());
         for (XmlField xmlField : rootFields) {
             switch (xmlField.getName()) {
-            case "tns:Name":
+            case "Name":
                 Assert.assertEquals(FieldType.STRING, xmlField.getFieldType());
-                Assert.assertEquals("/tns:RootDocument/tns:Name", xmlField.getPath());
+                Assert.assertEquals("/tns:RootDocument/Name", xmlField.getPath());
                 break;
-            case "tns:Value":
+            case "Value":
                 Assert.assertEquals(FieldType.STRING, xmlField.getFieldType());
-                Assert.assertEquals("/tns:RootDocument/tns:Value", xmlField.getPath());
+                Assert.assertEquals("/tns:RootDocument/Value", xmlField.getPath());
                 break;
             case "first:FirstElement":
                 Assert.assertEquals(FieldType.COMPLEX, xmlField.getFieldType());
@@ -79,13 +79,13 @@ public class XmlSchemaInspectionMultipleNamespacesTest extends BaseXmlInspection
                 Assert.assertEquals(2, firstFields.size());
                 for (XmlField firstField : firstFields) {
                     switch (firstField.getName()) {
-                    case "first:Name":
+                    case "Name":
                         Assert.assertEquals(FieldType.STRING, firstField.getFieldType());
-                        Assert.assertEquals("/tns:RootDocument/first:FirstElement/first:Name", firstField.getPath());
+                        Assert.assertEquals("/tns:RootDocument/first:FirstElement/Name", firstField.getPath());
                         break;
-                    case "first:Value":
+                    case "Value":
                         Assert.assertEquals(FieldType.STRING, firstField.getFieldType());
-                        Assert.assertEquals("/tns:RootDocument/first:FirstElement/first:Value", firstField.getPath());
+                        Assert.assertEquals("/tns:RootDocument/first:FirstElement/Value", firstField.getPath());
                         break;
                     default:
                         Assert.fail(String.format("Unknown field '%s'", firstField.getPath()));
@@ -99,13 +99,13 @@ public class XmlSchemaInspectionMultipleNamespacesTest extends BaseXmlInspection
                 Assert.assertEquals(2, secondFields.size());
                 for (XmlField secondField : secondFields) {
                     switch (secondField.getName()) {
-                    case "second:Name":
+                    case "Name":
                         Assert.assertEquals(FieldType.STRING, secondField.getFieldType());
-                        Assert.assertEquals("/tns:RootDocument/second:SecondElement/second:Name", secondField.getPath());
+                        Assert.assertEquals("/tns:RootDocument/second:SecondElement/Name", secondField.getPath());
                         break;
-                    case "second:Value":
+                    case "Value":
                         Assert.assertEquals(FieldType.STRING, secondField.getFieldType());
-                        Assert.assertEquals("/tns:RootDocument/second:SecondElement/second:Value", secondField.getPath());
+                        Assert.assertEquals("/tns:RootDocument/second:SecondElement/Value", secondField.getPath());
                         break;
                     default:
                         Assert.fail(String.format("Unknown field '%s'", secondField.getPath()));
@@ -195,9 +195,9 @@ public class XmlSchemaInspectionMultipleNamespacesTest extends BaseXmlInspection
                 List<XmlField> secondFields = XmlComplexType.class.cast(field).getXmlFields().getXmlField();
                 Assert.assertEquals(1, secondFields.size());
                 XmlField secondField = secondFields.get(0);
-                Assert.assertEquals("second:SecondValue", secondField.getName());
+                Assert.assertEquals("SecondValue", secondField.getName());
                 Assert.assertEquals(FieldType.STRING, secondField.getFieldType());
-                Assert.assertEquals("/RootDocument/second:SecondElement/second:SecondValue", secondField.getPath());
+                Assert.assertEquals("/RootDocument/second:SecondElement/SecondValue", secondField.getPath());
                 break;
             default:
                 Assert.fail(String.format("Unknown field '%s'", field.getPath()));

--- a/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/XmlSchemaInspectionTest.java
+++ b/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/XmlSchemaInspectionTest.java
@@ -208,66 +208,66 @@ public class XmlSchemaInspectionTest extends BaseXmlInspectionServiceTest {
         // orderDate
         XmlField orderDateAttr = purchaseOrder.getXmlFields().getXmlField().get(0);
         assertNotNull(orderDateAttr);
-        assertEquals("tns:orderDate", orderDateAttr.getName());
+        assertEquals("orderDate", orderDateAttr.getName());
         assertNull(orderDateAttr.getValue());
-        assertEquals("/tns:purchaseOrder/@tns:orderDate", orderDateAttr.getPath());
+        assertEquals("/tns:purchaseOrder/@orderDate", orderDateAttr.getPath());
         assertEquals(FieldType.DATE, orderDateAttr.getFieldType());
         assertEquals(true, orderDateAttr.isAttribute());
 
         // shipTo
         XmlField shipTo = purchaseOrder.getXmlFields().getXmlField().get(1);
         assertNotNull(shipTo);
-        assertEquals("tns:shipTo", shipTo.getName());
+        assertEquals("shipTo", shipTo.getName());
         assertNull(shipTo.getValue());
-        assertEquals("/tns:purchaseOrder/tns:shipTo", shipTo.getPath());
+        assertEquals("/tns:purchaseOrder/shipTo", shipTo.getPath());
         assertEquals(FieldType.COMPLEX, shipTo.getFieldType());
         assertEquals(6, ((XmlComplexType) shipTo).getXmlFields().getXmlField().size());
         // shipTo/@country
         XmlField shipToCountry = ((XmlComplexType) shipTo).getXmlFields().getXmlField().get(0);
         assertNotNull(shipTo);
-        assertEquals("tns:country", shipToCountry.getName());
+        assertEquals("country", shipToCountry.getName());
         assertEquals("US", shipToCountry.getValue());
-        assertEquals("/tns:purchaseOrder/tns:shipTo/@tns:country", shipToCountry.getPath());
+        assertEquals("/tns:purchaseOrder/shipTo/@country", shipToCountry.getPath());
         assertEquals(FieldType.STRING, shipToCountry.getFieldType());
         assertEquals(true, shipToCountry.isAttribute());
 
         XmlField shipToName = ((XmlComplexType) shipTo).getXmlFields().getXmlField().get(1);
         assertNotNull(shipToName);
-        assertEquals("tns:name", shipToName.getName());
+        assertEquals("name", shipToName.getName());
         assertNull(shipToName.getValue());
-        assertEquals("/tns:purchaseOrder/tns:shipTo/tns:name", shipToName.getPath());
+        assertEquals("/tns:purchaseOrder/shipTo/name", shipToName.getPath());
         assertEquals(FieldType.STRING, shipToName.getFieldType());
         assertEquals(false, shipToName.isAttribute());
 
         XmlField shipToStreet = ((XmlComplexType) shipTo).getXmlFields().getXmlField().get(2);
         assertNotNull(shipToStreet);
-        assertEquals("tns:street", shipToStreet.getName());
+        assertEquals("street", shipToStreet.getName());
         assertNull(shipToStreet.getValue());
-        assertEquals("/tns:purchaseOrder/tns:shipTo/tns:street", shipToStreet.getPath());
+        assertEquals("/tns:purchaseOrder/shipTo/street", shipToStreet.getPath());
         assertEquals(FieldType.STRING, shipToStreet.getFieldType());
         assertEquals(false, shipToStreet.isAttribute());
 
         XmlField shipToCity = ((XmlComplexType) shipTo).getXmlFields().getXmlField().get(3);
         assertNotNull(shipToCity);
-        assertEquals("tns:city", shipToCity.getName());
+        assertEquals("city", shipToCity.getName());
         assertNull(shipToCity.getValue());
-        assertEquals("/tns:purchaseOrder/tns:shipTo/tns:city", shipToCity.getPath());
+        assertEquals("/tns:purchaseOrder/shipTo/city", shipToCity.getPath());
         assertEquals(FieldType.STRING, shipToCity.getFieldType());
         assertEquals(false, shipToCity.isAttribute());
 
         XmlField shipToState = ((XmlComplexType) shipTo).getXmlFields().getXmlField().get(4);
         assertNotNull(shipToState);
-        assertEquals("tns:state", shipToState.getName());
+        assertEquals("state", shipToState.getName());
         assertNull(shipToState.getValue());
-        assertEquals("/tns:purchaseOrder/tns:shipTo/tns:state", shipToState.getPath());
+        assertEquals("/tns:purchaseOrder/shipTo/state", shipToState.getPath());
         assertEquals(FieldType.STRING, shipToState.getFieldType());
         assertEquals(false, shipToState.isAttribute());
 
         XmlField shipToZip = ((XmlComplexType) shipTo).getXmlFields().getXmlField().get(5);
         assertNotNull(shipToZip);
-        assertEquals("tns:zip", shipToZip.getName());
+        assertEquals("zip", shipToZip.getName());
         assertNull(shipToZip.getValue());
-        assertEquals("/tns:purchaseOrder/tns:shipTo/tns:zip", shipToZip.getPath());
+        assertEquals("/tns:purchaseOrder/shipTo/zip", shipToZip.getPath());
         assertEquals(FieldType.DECIMAL, shipToZip.getFieldType());
         assertEquals(false, shipToZip.isAttribute());
 
@@ -283,9 +283,9 @@ public class XmlSchemaInspectionTest extends BaseXmlInspectionServiceTest {
         // items
         XmlField items = purchaseOrder.getXmlFields().getXmlField().get(4);
         assertNotNull(items);
-        assertEquals("tns:items", items.getName());
+        assertEquals("items", items.getName());
         assertNull(items.getValue());
-        assertEquals("/tns:purchaseOrder/tns:items", items.getPath());
+        assertEquals("/tns:purchaseOrder/items", items.getPath());
         assertEquals(FieldType.COMPLEX, items.getFieldType());
         assertEquals(false, items.isAttribute());
 
@@ -294,9 +294,9 @@ public class XmlSchemaInspectionTest extends BaseXmlInspectionServiceTest {
         // items/item
         XmlComplexType item = (XmlComplexType) ((XmlComplexType) items).getXmlFields().getXmlField().get(0);
         assertNotNull(item);
-        assertEquals("tns:item", item.getName());
+        assertEquals("item", item.getName());
         assertNull(item.getValue());
-        assertEquals("/tns:purchaseOrder/tns:items/tns:item", item.getPath());
+        assertEquals("/tns:purchaseOrder/items/item", item.getPath());
         assertEquals(FieldType.COMPLEX, item.getFieldType());
         assertEquals(false, item.isAttribute());
         assertEquals(CollectionType.LIST, item.getCollectionType());
@@ -305,9 +305,9 @@ public class XmlSchemaInspectionTest extends BaseXmlInspectionServiceTest {
         // partNum
         XmlField partNum = item.getXmlFields().getXmlField().get(0);
         assertNotNull(partNum);
-        assertEquals("tns:partNum", partNum.getName());
+        assertEquals("partNum", partNum.getName());
         assertNull(partNum.getValue());
-        assertEquals("/tns:purchaseOrder/tns:items/tns:item/@tns:partNum", partNum.getPath());
+        assertEquals("/tns:purchaseOrder/items/item/@partNum", partNum.getPath());
         assertEquals(FieldType.STRING, partNum.getFieldType());
         assertEquals("SKU", partNum.getTypeName());
         assertEquals(true, partNum.isAttribute());
@@ -315,18 +315,18 @@ public class XmlSchemaInspectionTest extends BaseXmlInspectionServiceTest {
         // productName
         XmlField productName = item.getXmlFields().getXmlField().get(1);
         assertNotNull(productName);
-        assertEquals("tns:productName", productName.getName());
+        assertEquals("productName", productName.getName());
         assertNull(productName.getValue());
-        assertEquals("/tns:purchaseOrder/tns:items/tns:item/tns:productName", productName.getPath());
+        assertEquals("/tns:purchaseOrder/items/item/productName", productName.getPath());
         assertEquals(FieldType.STRING, productName.getFieldType());
         assertEquals(false, productName.isAttribute());
 
         // quantity
         XmlField quantity = item.getXmlFields().getXmlField().get(2);
         assertNotNull(quantity);
-        assertEquals("tns:quantity", quantity.getName());
+        assertEquals("quantity", quantity.getName());
         assertNull(quantity.getValue());
-        assertEquals("/tns:purchaseOrder/tns:items/tns:item/tns:quantity", quantity.getPath());
+        assertEquals("/tns:purchaseOrder/items/item/quantity", quantity.getPath());
         assertEquals(FieldType.BIG_INTEGER, quantity.getFieldType());
         assertEquals(false, quantity.isAttribute());
         assertNotNull(quantity.getRestrictions().getRestriction());
@@ -341,9 +341,9 @@ public class XmlSchemaInspectionTest extends BaseXmlInspectionServiceTest {
         // USPrice
         XmlField usPrice = item.getXmlFields().getXmlField().get(3);
         assertNotNull(usPrice);
-        assertEquals("tns:USPrice", usPrice.getName());
+        assertEquals("USPrice", usPrice.getName());
         assertNull(usPrice.getValue());
-        assertEquals("/tns:purchaseOrder/tns:items/tns:item/tns:USPrice", usPrice.getPath());
+        assertEquals("/tns:purchaseOrder/items/item/USPrice", usPrice.getPath());
         assertEquals(FieldType.DECIMAL, usPrice.getFieldType());
         assertEquals(false, usPrice.isAttribute());
 
@@ -352,16 +352,16 @@ public class XmlSchemaInspectionTest extends BaseXmlInspectionServiceTest {
         Assert.assertNotNull(itemComment);
         assertEquals("tns:comment", itemComment.getName());
         assertNull(itemComment.getValue());
-        assertEquals("/tns:purchaseOrder/tns:items/tns:item/tns:comment", itemComment.getPath());
+        assertEquals("/tns:purchaseOrder/items/item/tns:comment", itemComment.getPath());
         assertEquals(FieldType.STRING, itemComment.getFieldType());
         assertEquals(false, itemComment.isAttribute());
 
         // shipDate
         XmlField shipDate = item.getXmlFields().getXmlField().get(5);
         assertNotNull(shipDate);
-        assertEquals("tns:shipDate", shipDate.getName());
+        assertEquals("shipDate", shipDate.getName());
         assertNull(shipDate.getValue());
-        assertEquals("/tns:purchaseOrder/tns:items/tns:item/tns:shipDate", shipDate.getPath());
+        assertEquals("/tns:purchaseOrder/items/item/shipDate", shipDate.getPath());
         assertEquals(FieldType.DATE, shipDate.getFieldType());
         assertEquals(false, shipDate.isAttribute());
 

--- a/lib/modules/xml/core/src/test/resources/inspect/form-default-qualified-schema.xsd
+++ b/lib/modules/xml/core/src/test/resources/inspect/form-default-qualified-schema.xsd
@@ -1,0 +1,42 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="http://atlasmap.io/xml/test/" elementFormDefault="qualified" attributeFormDefault="qualified">
+  <xs:element name="a">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="aa">
+          <xs:complexType>
+            <xs:sequence>
+                <xs:element name="aaa" type="xs:string" />
+                <xs:element name="aab" type="xs:string" form="qualified" />
+                <xs:element name="aac" type="xs:string" form="unqualified" />
+            </xs:sequence>
+            <xs:attribute name="aad" type="xs:string" />
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="ab" form="qualified">
+          <xs:complexType>
+            <xs:sequence>
+                <xs:element name="aba" type="xs:string" />
+                <xs:element name="abb" type="xs:string" form="qualified" />
+                <xs:element name="abc" type="xs:string" form="unqualified" />
+            </xs:sequence>
+            <xs:attribute name="abd" type="xs:string" />
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="ac" form="unqualified">
+          <xs:complexType>
+            <xs:sequence>
+                <xs:element name="aca" type="xs:string" />
+                <xs:element name="acb" type="xs:string" form="qualified" />
+                <xs:element name="acc" type="xs:string" form="unqualified" />
+            </xs:sequence>
+            <xs:attribute name="acd" type="xs:string" />
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:attribute name="ad" type="xs:string" />
+      <xs:attribute name="ae" type="xs:string" form="qualified" />
+      <xs:attribute name="af" type="xs:string" form="unqualified" />
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/lib/modules/xml/core/src/test/resources/inspect/form-default-unqualified-schema.xsd
+++ b/lib/modules/xml/core/src/test/resources/inspect/form-default-unqualified-schema.xsd
@@ -1,0 +1,42 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="http://atlasmap.io/xml/test/" elementFormDefault="unqualified" attributeFormDefault="unqualified" >
+  <xs:element name="a">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="aa">
+          <xs:complexType>
+            <xs:sequence>
+                <xs:element name="aaa" type="xs:string" />
+                <xs:element name="aab" type="xs:string" form="qualified" />
+                <xs:element name="aac" type="xs:string" form="unqualified" />
+            </xs:sequence>
+            <xs:attribute name="aad" type="xs:string" />
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="ab" form="qualified">
+          <xs:complexType>
+            <xs:sequence>
+                <xs:element name="aba" type="xs:string" />
+                <xs:element name="abb" type="xs:string" form="qualified" />
+                <xs:element name="abc" type="xs:string" form="unqualified" />
+            </xs:sequence>
+            <xs:attribute name="abd" type="xs:string" />
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="ac" form="unqualified">
+          <xs:complexType>
+            <xs:sequence>
+                <xs:element name="aca" type="xs:string" />
+                <xs:element name="acb" type="xs:string" form="qualified" />
+                <xs:element name="acc" type="xs:string" form="unqualified" />
+            </xs:sequence>
+            <xs:attribute name="acd" type="xs:string" />
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:attribute name="ad" type="xs:string" />
+      <xs:attribute name="ae" type="xs:string" form="qualified" />
+      <xs:attribute name="af" type="xs:string" form="unqualified" />
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/lib/modules/xml/core/src/test/resources/inspect/form-no-default-schema.xsd
+++ b/lib/modules/xml/core/src/test/resources/inspect/form-no-default-schema.xsd
@@ -1,0 +1,41 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://atlasmap.io/xml/test/">
+  <xs:element name="a">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="aa">
+          <xs:complexType>
+            <xs:sequence>
+                <xs:element name="aaa" type="xs:string" />
+                <xs:element name="aab" type="xs:string" form="qualified" />
+                <xs:element name="aac" type="xs:string" form="unqualified" />
+            </xs:sequence>
+            <xs:attribute name="aad" type="xs:string" />
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="ab" form="qualified">
+          <xs:complexType>
+            <xs:sequence>
+                <xs:element name="aba" type="xs:string" />
+                <xs:element name="abb" type="xs:string" form="qualified" />
+                <xs:element name="abc" type="xs:string" form="unqualified" />
+            </xs:sequence>
+            <xs:attribute name="abd" type="xs:string" />
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="ac" form="unqualified">
+          <xs:complexType>
+            <xs:sequence>
+                <xs:element name="aca" type="xs:string" />
+                <xs:element name="acb" type="xs:string" form="qualified" />
+                <xs:element name="acc" type="xs:string" form="unqualified" />
+            </xs:sequence>
+            <xs:attribute name="acd" type="xs:string" />
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:attribute name="ad" type="xs:string" />
+      <xs:attribute name="ae" type="xs:string" form="qualified" />
+      <xs:attribute name="af" type="xs:string" form="unqualified" />
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
Fixes: #2655

This fix changes the default behavior for XML Schema inspection. It used to ignore form/elementFormDefault/attributeFormDefault and always apply targetNamespace, while XML Schema defines `elementFormDefault=unqualified` and `attributeFormDefault=unqualified` by default. After this fix, subsequent children are no longer qualified with namespace unless `elementFormDefault=qualified`, `attributeFormDefault=qualified` or `form=qualified` is explicitly specified. Also note that the global element, i.e. defined at the top of the schema is always qualified.