### PR TITLE
feat: PoC for Java DSL runtime support

### DIFF
--- a/lib/api/src/main/java/io/atlasmap/api/AtlasMappingBuilder.java
+++ b/lib/api/src/main/java/io/atlasmap/api/AtlasMappingBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2017 Red Hat, Inc.
+ * Copyright (C) 2021 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,23 @@
  */
 package io.atlasmap.api;
 
-public class AtlasConstants {
-    public static final String DEFAULT_SOURCE_DOCUMENT_ID = "ATLAS_DEFAULT_SOURCE_DOC";
-    public static final String DEFAULT_TARGET_DOCUMENT_ID = "ATLAS_DEFAULT_TARGET_DOC";
-    public static final String CONSTANTS_DOCUMENT_ID = "ATLAS_CONSTANTS_DOC";
-    public static final String PROPERTIES_SOURCE_DOCUMENT_ID = "ATLAS_SOURCE_PROPERTIES_DOC";
-    public static final String PROPERTIES_TARGET_DOCUMENT_ID = "ATLAS_TARGET_PROPERTIES_DOC";
+/**
+ * An interface to define a custom mapping logic. User can implement this class and
+ * define custom mapping logic in {@code #processMapping()}.
+ *
+ */
+public interface AtlasMappingBuilder {
 
-    private AtlasConstants() {
-    }
+    /**
+     * Define custom mapping logic. User can extend this class and implement
+     * custom mapping logic in this method.
+     */
+    void processMapping();
+
+    /**
+     * Set {@code AtlasSession}.
+     * @param session {@code AtlasSession}
+     */
+    void setAtlasSession(AtlasSession session);
+
 }

--- a/lib/api/src/main/java/io/atlasmap/spi/ActionProcessor.java
+++ b/lib/api/src/main/java/io/atlasmap/spi/ActionProcessor.java
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atlasmap.api;
+package io.atlasmap.spi;
 
-public class AtlasConstants {
-    public static final String DEFAULT_SOURCE_DOCUMENT_ID = "ATLAS_DEFAULT_SOURCE_DOC";
-    public static final String DEFAULT_TARGET_DOCUMENT_ID = "ATLAS_DEFAULT_TARGET_DOC";
-    public static final String CONSTANTS_DOCUMENT_ID = "ATLAS_CONSTANTS_DOC";
-    public static final String PROPERTIES_SOURCE_DOCUMENT_ID = "ATLAS_SOURCE_PROPERTIES_DOC";
-    public static final String PROPERTIES_TARGET_DOCUMENT_ID = "ATLAS_TARGET_PROPERTIES_DOC";
+import io.atlasmap.api.AtlasException;
+import io.atlasmap.v2.Action;
+import io.atlasmap.v2.ActionDetail;
 
-    private AtlasConstants() {
-    }
+public interface ActionProcessor {
+
+    ActionDetail getActionDetail();
+    Class<? extends Action> getActionClass();
+    Object process(Action action, Object sourceObject) throws AtlasException;
+
 }

--- a/lib/api/src/main/java/io/atlasmap/spi/AtlasFieldActionService.java
+++ b/lib/api/src/main/java/io/atlasmap/spi/AtlasFieldActionService.java
@@ -28,5 +28,6 @@ public interface AtlasFieldActionService {
     List<ActionDetail> listActionDetails();
     ActionDetail findActionDetail(Action action, FieldType type) throws AtlasException;
     Field processActions(AtlasInternalSession session, Field field) throws AtlasException;
+    ActionProcessor findActionProcessor(Action action, FieldType sourceType) throws AtlasException;
 
 }

--- a/lib/api/src/main/java/io/atlasmap/spi/AtlasModule.java
+++ b/lib/api/src/main/java/io/atlasmap/spi/AtlasModule.java
@@ -117,4 +117,6 @@ public interface AtlasModule {
 
     DataSourceMetadata getDataSourceMetadata();
 
+    Field createField();
+
 }

--- a/lib/core/src/main/java/io/atlasmap/builder/AtlasField.java
+++ b/lib/core/src/main/java/io/atlasmap/builder/AtlasField.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atlasmap.builder;
+
+import java.util.List;
+
+import io.atlasmap.api.AtlasException;
+import io.atlasmap.core.ConstantModule;
+import io.atlasmap.core.DefaultAtlasConversionService;
+import io.atlasmap.core.DefaultAtlasFieldActionService;
+import io.atlasmap.core.DefaultAtlasSession;
+import io.atlasmap.core.PropertyModule;
+import io.atlasmap.spi.ActionProcessor;
+import io.atlasmap.spi.AtlasModule;
+import io.atlasmap.spi.AtlasModuleMode;
+import io.atlasmap.v2.Constant;
+import io.atlasmap.v2.Field;
+import io.atlasmap.v2.PropertyField;
+
+/**
+ * A part of custom mapping builder API to implement custom mapping logic in Java code.
+ * This class wraps raw {@link Field} and provide some utility methods to introspect
+ * underlying field tree. {@link DefaultAtlasMappingBuilder#read(String, String)}
+ * reads from source document and creates AtlasField.
+ * @see DefaultAtlasMappingBuilder
+ */
+public class AtlasField {
+
+    private DefaultAtlasSession session;
+    private DefaultAtlasConversionService conversionService;
+    private DefaultAtlasFieldActionService fieldActionService;
+    private Field rawField;
+
+    public AtlasField(DefaultAtlasSession session) {
+        this.session = session;
+        this.conversionService = session.getAtlasContext().getContextFactory().getConversionService();
+        this.fieldActionService = session.getAtlasContext().getContextFactory().getFieldActionService();
+    }
+
+    public AtlasField read(String docId, String path) throws AtlasException {
+        AtlasModule module = session.resolveModule(docId);
+        if (module == null) {
+            throw new AtlasException(String.format("Source document '%s' doesn't exist", docId));
+        }
+        if (module.getMode() != AtlasModuleMode.SOURCE) {
+            throw new AtlasException(String.format(
+                    "Unable to read from %s Document '%s'", module.getMode(), docId));
+        }
+        Field sourceField = module.createField();
+        sourceField.setDocId(docId);
+        sourceField.setPath(path);
+        session.head().setSourceField(sourceField);
+        module.readSourceValue(session);
+        setRawField(sourceField);
+        return this;
+    }
+
+    public AtlasField readConstant(String name) throws AtlasException {
+        ConstantModule module = session.getConstantModule();
+        List<Constant> constants = session.getMapping().getConstants().getConstant();
+        for (Constant constant : constants) {
+            if (constant.getName() != null && constant.getName().equals(name)) {
+                Field sourceField = module.createField();
+                sourceField.setName(constant.getName());
+                sourceField.setFieldType(constant.getFieldType());
+                sourceField.setValue(constant.getValue());
+                session.head().setSourceField(sourceField);
+                module.readSourceValue(session);
+                setRawField(sourceField);
+                return this;
+            }
+        }
+        throw new AtlasException(String.format("Constant '%s' not found", name));
+    }
+
+    public AtlasField readProperty(String scope, String name) throws AtlasException {
+        PropertyModule module = session.getSourcePropertyModule();
+        PropertyField sourceField = module.createField();
+        sourceField.setScope(scope);
+        sourceField.setName(name);
+        session.head().setSourceField(sourceField);
+        module.readSourceValue(session);
+        setRawField(sourceField);
+        return this;
+    }
+
+    public void write(String docId, String path) throws AtlasException {
+        AtlasModule module = session.resolveModule(docId);
+        if (module == null) {
+            throw new AtlasException(String.format("Target document '%s' doesn't exist", docId));
+        }
+        if (module.getMode() != AtlasModuleMode.TARGET) {
+            throw new AtlasException(String.format(
+                    "Unable to write to %s Document '%s'", module.getMode(), docId));
+        }
+        Field f = module.createField();
+        f.setDocId(docId);
+        f.setPath(path);
+        session.head().setSourceField(getRawField());
+        session.head().setTargetField(f);
+        module.populateTargetField(session);
+        module.writeTargetValue(session);
+    }
+
+    public void writeProperty(String scope, String name) throws AtlasException {
+        PropertyModule module = session.getTargetPropertyModule();
+        PropertyField f = module.createField();
+        f.setScope(scope);
+        f.setName(name);
+        session.head().setSourceField(getRawField());
+        session.head().setTargetField(f);
+        module.populateTargetField(session);
+        module.writeTargetValue(session);
+    }
+
+    public AtlasField action(String actionName, List<Object> parameters) {
+        Object value = parameters != null && parameters.size() > 1 ? parameters.get(parameters.size()-1) : null;
+        ActionProcessor ap = this.fieldActionService.findActionProcessor(actionName, value);
+        
+        return this;
+    }
+
+    private Field getRawField() {
+        return this.rawField;
+    }
+
+    private AtlasField setRawField(Field f) {
+        this.rawField = f;
+        return this;
+    }
+}

--- a/lib/core/src/main/java/io/atlasmap/builder/DefaultAtlasMappingBuilder.java
+++ b/lib/core/src/main/java/io/atlasmap/builder/DefaultAtlasMappingBuilder.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atlasmap.builder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.atlasmap.api.AtlasException;
+import io.atlasmap.api.AtlasMappingBuilder;
+import io.atlasmap.api.AtlasSession;
+import io.atlasmap.core.AtlasUtil;
+import io.atlasmap.core.DefaultAtlasSession;
+import io.atlasmap.v2.AuditStatus;
+
+/**
+ * A base {@code AtlasMappingBuilder} with some common utility methods.
+ * In most cases user can extend this class and just implement {@link #processMapping()}.
+ * @see AtlasField
+ */
+public abstract class DefaultAtlasMappingBuilder implements AtlasMappingBuilder {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultAtlasMappingBuilder.class);
+    private DefaultAtlasSession session;
+
+    public AtlasField read(String docId, String path) throws AtlasException {
+        return new AtlasField(session).read(docId, path);
+    }
+
+    public AtlasField readConstant(String name) throws AtlasException {
+        return new AtlasField(session).readConstant(name);
+    }
+
+    public AtlasField readProperty(String scope, String name) throws AtlasException {
+        return new AtlasField(session).readProperty(scope, name);
+    }
+
+    @Override
+    public void setAtlasSession(AtlasSession session) {
+        if (!(session instanceof DefaultAtlasSession)) {
+            throw new IllegalArgumentException(String.format(
+                    "This version of MappingBuilder doesn't support %s",
+                    session.getClass().getName()));
+        }
+        this.session = (DefaultAtlasSession) session;
+    };
+
+    /**
+     * Get {@code DefaultAtlasSession}.
+     * @return {@code AtlasSession}.
+     */
+    public AtlasSession getAtlasSession() {
+        return this.session;
+    };
+
+    public void addAudit(Exception e) {
+        AtlasUtil.addAudit(this.session, this.getClass().getName(),
+                e.getMessage(), AuditStatus.ERROR, null);
+        if (LOG.isDebugEnabled()) {
+            LOG.error("", e);
+        }
+    }
+
+}

--- a/lib/core/src/main/java/io/atlasmap/core/BaseAtlasModule.java
+++ b/lib/core/src/main/java/io/atlasmap/core/BaseAtlasModule.java
@@ -93,7 +93,8 @@ public abstract class BaseAtlasModule implements AtlasModule, AtlasModuleMXBean 
         Field sourceField = session.head().getSourceField();
         Field targetField = session.head().getTargetField();
         Object targetValue = null;
-        if (sourceField.getFieldType() != null && sourceField.getFieldType().equals(targetField.getFieldType())) {
+        if (targetField.getFieldType() == null
+                || (sourceField.getFieldType() != null && sourceField.getFieldType().equals(targetField.getFieldType()))) {
             targetValue = sourceField.getValue();
         } else if (sourceField.getValue() != null) {
             try {

--- a/lib/core/src/main/java/io/atlasmap/core/ConstantModule.java
+++ b/lib/core/src/main/java/io/atlasmap/core/ConstantModule.java
@@ -230,4 +230,9 @@ public class ConstantModule implements AtlasModule {
         return "Constants";
     }
 
+    @Override
+    public ConstantField createField() {
+        return new ConstantField();
+    }
+
 }

--- a/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasContextFactory.java
+++ b/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasContextFactory.java
@@ -44,8 +44,6 @@ import io.atlasmap.api.AtlasException;
 import io.atlasmap.api.AtlasValidationService;
 import io.atlasmap.mxbean.AtlasContextFactoryMXBean;
 import io.atlasmap.spi.AtlasCombineStrategy;
-import io.atlasmap.spi.AtlasConversionService;
-import io.atlasmap.spi.AtlasFieldActionService;
 import io.atlasmap.spi.AtlasModule;
 import io.atlasmap.spi.AtlasModuleDetail;
 import io.atlasmap.spi.AtlasModuleInfo;
@@ -245,12 +243,12 @@ public class DefaultAtlasContextFactory implements AtlasContextFactory, AtlasCon
     }
 
     @Override
-    public AtlasConversionService getConversionService() {
+    public DefaultAtlasConversionService getConversionService() {
         return this.atlasConversionService;
     }
 
     @Override
-    public AtlasFieldActionService getFieldActionService() {
+    public DefaultAtlasFieldActionService getFieldActionService() {
         return this.atlasFieldActionService;
     }
 

--- a/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasCustomMappingProcessor.java
+++ b/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasCustomMappingProcessor.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atlasmap.core;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.atlasmap.api.AtlasMappingBuilder;
+import io.atlasmap.v2.AuditStatus;
+import io.atlasmap.v2.CustomMapping;
+
+public class DefaultAtlasCustomMappingProcessor {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultAtlasCustomMappingProcessor.class);
+    private static DefaultAtlasCustomMappingProcessor instance;
+
+    public static DefaultAtlasCustomMappingProcessor getInstance() {
+        if (instance == null) {
+            instance = new DefaultAtlasCustomMappingProcessor();
+        }
+        return instance;
+    }
+
+    public void process(DefaultAtlasSession session, CustomMapping customMapping) {
+        String className = customMapping.getClassName();
+        if (className == null || className.isEmpty()) {
+            AtlasUtil.addAudit(session, className,
+                    "Custom mapping class must be specified", AuditStatus.ERROR, className);
+            return;
+        }
+        DefaultAtlasContextFactory factory = session.getAtlasContext().getContextFactory();
+        AtlasMappingBuilder builder;
+        try {
+            Class<?> clazz = factory.getClassLoader().loadClass(className);
+            builder = AtlasMappingBuilder.class.cast(clazz.newInstance());
+        } catch (Exception e) {
+            AtlasUtil.addAudit(session, className, String.format(
+                    "Custom mapping class '%s' could not be loaded: %s",
+                    className, e.getMessage()), AuditStatus.ERROR, className);
+            if (LOG.isDebugEnabled()) {
+                LOG.error("", e);
+            }
+            return;
+        }
+
+        builder.setAtlasSession(session);
+        builder.processMapping();
+    }
+
+}

--- a/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasExpressionProcessor.java
+++ b/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasExpressionProcessor.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.atlasmap.api.AtlasConstants;
 import io.atlasmap.expression.Expression;
 import io.atlasmap.expression.ExpressionException;
 import io.atlasmap.spi.AtlasModule;
@@ -69,9 +70,9 @@ public class DefaultAtlasExpressionProcessor {
                     AtlasModule sourceModule;
                     Map<String, AtlasModule> sourceModules = session.getAtlasContext().getSourceModules();
                     if (f instanceof ConstantField) {
-                        sourceModule = sourceModules.get(DefaultAtlasContext.CONSTANTS_DOCUMENT_ID);
+                        sourceModule = sourceModules.get(AtlasConstants.CONSTANTS_DOCUMENT_ID);
                     } else if (f instanceof PropertyField) {
-                        sourceModule = sourceModules.get(DefaultAtlasContext.PROPERTIES_DOCUMENT_ID);
+                        sourceModule = sourceModules.get(AtlasConstants.PROPERTIES_SOURCE_DOCUMENT_ID);
                     } else {
                         String[] splitted = path.split(":", 2);
                         sourceModule = sourceModules.get(splitted[0]);

--- a/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasFieldActionService.java
+++ b/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasFieldActionService.java
@@ -43,6 +43,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import io.atlasmap.api.AtlasConversionException;
 import io.atlasmap.api.AtlasException;
+import io.atlasmap.spi.ActionProcessor;
 import io.atlasmap.spi.AtlasActionProcessor;
 import io.atlasmap.spi.AtlasConversionService;
 import io.atlasmap.spi.AtlasFieldAction;
@@ -121,12 +122,6 @@ public class DefaultAtlasFieldActionService implements AtlasFieldActionService {
 
     public List<ActionProcessor> loadFieldActions() {
         return loadFieldActions(this.getClass().getClassLoader());
-    }
-
-    interface ActionProcessor {
-        ActionDetail getActionDetail();
-        Class<? extends Action> getActionClass();
-        Object process(Action action, Object sourceObject) throws AtlasException;
     }
 
     public List<ActionProcessor> loadFieldActions(ClassLoader classLoader) {
@@ -573,6 +568,7 @@ public class DefaultAtlasFieldActionService implements AtlasFieldActionService {
         return processor.getActionDetail();
     }
 
+    @Override
     public ActionProcessor findActionProcessor(Action action, FieldType sourceType) throws AtlasException {
         CustomAction customAction = null;
         if (action instanceof CustomAction) {

--- a/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasFunctionResolver.java
+++ b/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasFunctionResolver.java
@@ -24,6 +24,7 @@ import java.util.ServiceLoader;
 import io.atlasmap.expression.Expression;
 import io.atlasmap.expression.FunctionResolver;
 import io.atlasmap.expression.parser.ParseException;
+import io.atlasmap.spi.ActionProcessor;
 import io.atlasmap.spi.FunctionFactory;
 import io.atlasmap.v2.ActionParameter;
 import io.atlasmap.v2.ActionParameters;
@@ -77,7 +78,7 @@ public class DefaultAtlasFunctionResolver implements FunctionResolver {
                     valueForTypeEvaluation = arguments.get(arguments.size() - 1);
                 }
 
-                DefaultAtlasFieldActionService.ActionProcessor actionProcessor = fieldActionService.findActionProcessor(name, valueForTypeEvaluation);
+                ActionProcessor actionProcessor = fieldActionService.findActionProcessor(name, valueForTypeEvaluation);
                 if (actionProcessor != null) {
                     Map<String, Object> actionParameters = new HashMap<>();
                     ActionParameters actionDetailParameters = actionProcessor.getActionDetail().getParameters();

--- a/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasPreviewContext.java
+++ b/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasPreviewContext.java
@@ -37,6 +37,7 @@ import io.atlasmap.v2.Field;
 import io.atlasmap.v2.FieldGroup;
 import io.atlasmap.v2.Mapping;
 import io.atlasmap.v2.MappingType;
+import io.atlasmap.v2.SimpleField;
 
 /**
  * Limited version of AtlasMap context dedicated for preview processing.
@@ -360,6 +361,11 @@ class DefaultAtlasPreviewContext extends DefaultAtlasContext implements AtlasPre
         @Override
         public String getDocId() {
             return "Preview";
+        }
+
+        @Override
+        public SimpleField createField() {
+            return new SimpleField();
         }
 
     };

--- a/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasSession.java
+++ b/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasSession.java
@@ -361,6 +361,18 @@ public class DefaultAtlasSession implements AtlasInternalSession {
         return answer;
     }
 
+    public ConstantModule getConstantModule() {
+        return (ConstantModule) this.getAtlasContext().getSourceModules().get(AtlasConstants.CONSTANTS_DOCUMENT_ID);
+    }
+
+    public PropertyModule getSourcePropertyModule() {
+        return (PropertyModule) this.getAtlasContext().getSourceModules().get(AtlasConstants.PROPERTIES_SOURCE_DOCUMENT_ID);
+    }
+
+    public PropertyModule getTargetPropertyModule() {
+        return (PropertyModule) this.getAtlasContext().getTargetModules().get(AtlasConstants.PROPERTIES_TARGET_DOCUMENT_ID);
+    }
+
     private class HeadImpl implements Head {
         private DefaultAtlasSession session;
         private Mapping mapping;

--- a/lib/core/src/main/java/io/atlasmap/core/PropertyModule.java
+++ b/lib/core/src/main/java/io/atlasmap/core/PropertyModule.java
@@ -122,4 +122,9 @@ public class PropertyModule extends BaseAtlasModule {
         return "Properties";
     }
 
+    @Override
+    public PropertyField createField() {
+        return new PropertyField();
+    }
+
 }

--- a/lib/core/src/main/java/io/atlasmap/core/validate/BaseModuleValidationService.java
+++ b/lib/core/src/main/java/io/atlasmap/core/validate/BaseModuleValidationService.java
@@ -29,6 +29,7 @@ import io.atlasmap.spi.AtlasModuleMode;
 import io.atlasmap.spi.FieldDirection;
 import io.atlasmap.v2.AtlasMapping;
 import io.atlasmap.v2.BaseMapping;
+import io.atlasmap.v2.CustomMapping;
 import io.atlasmap.v2.DataSource;
 import io.atlasmap.v2.Field;
 import io.atlasmap.v2.FieldGroup;
@@ -120,7 +121,9 @@ public abstract class BaseModuleValidationService<T extends Field> implements At
 
     protected void validateMappingEntries(List<BaseMapping> mappings, List<Validation> validations) {
         for (BaseMapping fieldMapping : mappings) {
-            if (fieldMapping.getClass().isAssignableFrom(Mapping.class)
+            if (fieldMapping.getClass().isAssignableFrom(CustomMapping.class)) {
+                validateCustomMapping((CustomMapping)fieldMapping, validations);
+            } else if (fieldMapping.getClass().isAssignableFrom(Mapping.class)
                     && MappingType.SEPARATE.equals(((Mapping) fieldMapping).getMappingType())) {
                 validateSeparateMapping((Mapping) fieldMapping, validations);
             } else if (fieldMapping.getClass().isAssignableFrom(Mapping.class)
@@ -175,6 +178,16 @@ public abstract class BaseModuleValidationService<T extends Field> implements At
 
         if (getMode() == AtlasModuleMode.SOURCE) {
             validateFieldCombinations(mapping, validations);
+        }
+    }
+
+    protected void validateCustomMapping(CustomMapping mapping, List<Validation> validations) {
+        if (mapping.getClassName() == null || mapping.getClassName().isEmpty()) {
+            Validation v = new Validation();
+            v.setScope(ValidationScope.MAPPING);
+            v.setMessage("Class name must be specified for custom mapping");
+            v.setStatus(ValidationStatus.ERROR);
+            validations.add(v);
         }
     }
 

--- a/lib/core/src/test/java/io/atlasmap/builder/DefaultAtlasMappingBuilderTest.java
+++ b/lib/core/src/test/java/io/atlasmap/builder/DefaultAtlasMappingBuilderTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atlasmap.builder;
+
+import static io.atlasmap.api.AtlasConstants.DEFAULT_SOURCE_DOCUMENT_ID;
+import static io.atlasmap.api.AtlasConstants.DEFAULT_TARGET_DOCUMENT_ID;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import io.atlasmap.api.AtlasException;
+import io.atlasmap.core.BaseDefaultAtlasContextTest;
+import io.atlasmap.v2.AtlasMapping;
+import io.atlasmap.v2.FieldType;
+
+public class DefaultAtlasMappingBuilderTest extends BaseDefaultAtlasContextTest {
+
+    @Test
+    public void test() throws Exception {
+        DefaultAtlasMappingBuilder builder = new DefaultAtlasMappingBuilder() {
+            @Override
+            public void processMapping() {
+                try {
+                    read(DEFAULT_SOURCE_DOCUMENT_ID, "/f1")
+                        .write(DEFAULT_TARGET_DOCUMENT_ID, "/f2");
+                    readConstant("c3").writeProperty(DEFAULT_TARGET_DOCUMENT_ID, "p4");
+                    readProperty(DEFAULT_SOURCE_DOCUMENT_ID, "p5").write(DEFAULT_TARGET_DOCUMENT_ID, "/f6");
+                } catch (AtlasException e) {
+                    addAudit(e);
+                }
+            }
+        };
+        AtlasMapping m = session.getMapping();
+        populateConstant("c3", "c3value");
+        populateSourceField(DEFAULT_SOURCE_DOCUMENT_ID, FieldType.STRING, "f1", "f1value");
+        populateProperty(DEFAULT_SOURCE_DOCUMENT_ID, "p5", "p5value");
+        builder.setAtlasSession(session);
+        builder.processMapping();
+        assertEquals(printAudit(session), 0, session.getAudits().getAudit().size());
+        assertEquals("f1value", getTargetFieldValue("/f2"));
+        assertEquals("c3value", session.getTargetProperties().get("p4"));
+        assertEquals("p5value", getTargetFieldValue("/f6"));
+    }
+}

--- a/lib/core/src/test/java/io/atlasmap/core/AtlasTestData.java
+++ b/lib/core/src/test/java/io/atlasmap/core/AtlasTestData.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import io.atlasmap.api.AtlasSession;
 import io.atlasmap.v2.AtlasMapping;
 import io.atlasmap.v2.AtlasModelFactory;
+import io.atlasmap.v2.Constants;
 import io.atlasmap.v2.FieldType;
 import io.atlasmap.v2.Property;
 
@@ -83,6 +84,7 @@ public class AtlasTestData {
         AtlasMapping mapping = AtlasModelFactory.createAtlasMapping();
         mapping.setName("generated.mapping." + UUID.randomUUID().toString().replace('-', '.'));
         mapping.getProperties().getProperty().addAll(generateAtlasProperties());
+        mapping.setConstants(new Constants());
         return mapping;
     }
 

--- a/lib/core/src/test/java/io/atlasmap/core/DefaultAtlasContextFactoryTest.java
+++ b/lib/core/src/test/java/io/atlasmap/core/DefaultAtlasContextFactoryTest.java
@@ -47,6 +47,7 @@ import io.atlasmap.spi.AtlasModuleMode;
 import io.atlasmap.v2.AtlasMapping;
 import io.atlasmap.v2.DataSourceMetadata;
 import io.atlasmap.v2.Field;
+import io.atlasmap.v2.SimpleField;
 
 public class DefaultAtlasContextFactoryTest {
 
@@ -467,5 +468,9 @@ public class DefaultAtlasContextFactoryTest {
             return null;
         }
 
+        @Override
+        public Field createField() {
+            return new SimpleField();
+        }
     }
 }

--- a/lib/core/src/test/java/io/atlasmap/core/DefaultAtlasContextTest.java
+++ b/lib/core/src/test/java/io/atlasmap/core/DefaultAtlasContextTest.java
@@ -418,7 +418,7 @@ public class DefaultAtlasContextTest extends BaseDefaultAtlasContextTest {
         when(mockOutputField.getPath()).thenReturn("output[1]");
         when(mappingElement2.getOutputField()).thenReturn(mockOutputFieldList);
 
-        context.getSourceModules().put(DefaultAtlasContext.CONSTANTS_DOCUMENT_ID, mockConstantModule);
+        context.getSourceModules().put(AtlasConstants.CONSTANTS_DOCUMENT_ID, mockConstantModule);
         context.getTargetModules().put(AtlasConstants.DEFAULT_TARGET_DOCUMENT_ID, mockConstantModule);
         context.process(session);
     }

--- a/lib/core/src/test/java/io/atlasmap/core/DefaultAtlasExpressionProcessorTest.java
+++ b/lib/core/src/test/java/io/atlasmap/core/DefaultAtlasExpressionProcessorTest.java
@@ -180,7 +180,7 @@ public class DefaultAtlasExpressionProcessorTest extends BaseDefaultAtlasContext
         String expression = "${DOC.Properties.85731:/Doc1/testprop} + ${DOC.Properties.85731:/Doc2/testprop}"
                 + " + ${DOC.Properties.85731:/testprop}";
         recreateSession();
-        context.getSourceModules().put(DefaultAtlasContext.PROPERTIES_DOCUMENT_ID, new PropertyModule(new DefaultAtlasPropertyStrategy()));
+        context.getSourceModules().put(AtlasConstants.PROPERTIES_SOURCE_DOCUMENT_ID, new PropertyModule(new DefaultAtlasPropertyStrategy()));
         session.head().setSourceField(source);
         DefaultAtlasExpressionProcessor.processExpression(session, expression);
         assertFalse(printAudit(session), session.hasErrors());

--- a/lib/core/src/test/java/io/atlasmap/core/DefaultAtlasFieldActionsServiceTest.java
+++ b/lib/core/src/test/java/io/atlasmap/core/DefaultAtlasFieldActionsServiceTest.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.atlasmap.api.AtlasConversionException;
 import io.atlasmap.api.AtlasException;
+import io.atlasmap.spi.ActionProcessor;
 import io.atlasmap.spi.AtlasInternalSession;
 import io.atlasmap.v2.AbsoluteValue;
 import io.atlasmap.v2.Action;
@@ -158,7 +159,7 @@ public class DefaultAtlasFieldActionsServiceTest {
 
     @Test
     public void testProcessActionWithActionActionDetailObject() throws AtlasException {
-        DefaultAtlasFieldActionService.ActionProcessor processor = null;
+        ActionProcessor processor = null;
         Object sourceObject = "String";
         Action action = new Trim();
         processor = fieldActionsService.findActionProcessor(action, FieldType.STRING);
@@ -173,7 +174,7 @@ public class DefaultAtlasFieldActionsServiceTest {
     public void testProcessActionWithActionActionDetailObjectAssignableType() throws AtlasException {
         Action action = new AbsoluteValue();
         Object sourceObject = new Integer("1");
-        DefaultAtlasFieldActionService.ActionProcessor processor = fieldActionsService.findActionProcessor(action, FieldType.STRING);
+        ActionProcessor processor = fieldActionsService.findActionProcessor(action, FieldType.STRING);
         assertEquals(1L, processor.process(action, sourceObject));
     }
 

--- a/lib/core/src/test/java/io/atlasmap/core/DefaultAtlasPreviewContextTest.java
+++ b/lib/core/src/test/java/io/atlasmap/core/DefaultAtlasPreviewContextTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 
 import org.junit.Test;
 
+import io.atlasmap.api.AtlasConstants;
 import io.atlasmap.api.AtlasException;
 import io.atlasmap.v2.Action;
 import io.atlasmap.v2.Audits;
@@ -349,7 +350,7 @@ public class DefaultAtlasPreviewContextTest extends BaseDefaultAtlasContextTest 
         fgc.getField().add(source);
         fg.getField().add(fgc);
         Field source2 = new ConstantField();
-        source2.setDocId(DefaultAtlasContext.CONSTANTS_DOCUMENT_ID);
+        source2.setDocId(AtlasConstants.CONSTANTS_DOCUMENT_ID);
         source2.setFieldType(FieldType.STRING);
         source2.setPath("/test");
         source2.setName("test");
@@ -357,7 +358,7 @@ public class DefaultAtlasPreviewContextTest extends BaseDefaultAtlasContextTest 
         fg.getField().add(source2);
         m.setExpression(String.format(
                 "REPEAT(COUNT(${source:/addressList<>/city}), ${%s:/test})",
-                DefaultAtlasContext.CONSTANTS_DOCUMENT_ID));
+                AtlasConstants.CONSTANTS_DOCUMENT_ID));
         Field target = new SimpleField();
         target.setFieldType(FieldType.STRING);
         target.setDocId("target");

--- a/lib/itests/core/src/test/java/io/atlasmap/itests/core/MappingBuilderTest.java
+++ b/lib/itests/core/src/test/java/io/atlasmap/itests/core/MappingBuilderTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atlasmap.itests.core;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+
+import org.junit.Test;
+import org.xmlunit.assertj.XmlAssert;
+
+import io.atlasmap.api.AtlasContext;
+import io.atlasmap.api.AtlasSession;
+import io.atlasmap.builder.DefaultAtlasMappingBuilder;
+import io.atlasmap.core.DefaultAtlasContextFactory;
+
+public class MappingBuilderTest {
+
+    @Test
+    public void test() throws Exception {
+        URL url = Thread.currentThread().getContextClassLoader().getResource("mappings/atlasmapping-builder.json");
+        AtlasContext context = DefaultAtlasContextFactory.getInstance().createContext(url.toURI());
+        AtlasSession session = context.createSession();
+        String sourceJson = new String(Files.readAllBytes(Paths.get(
+                Thread.currentThread().getContextClassLoader().getResource("data/json-source-builder.json").toURI())));
+            session.setSourceDocument("SourceJson", sourceJson);
+            context.process(session);
+            assertFalse(TestHelper.printAudit(session), session.hasErrors());
+            String targetXml = (String) session.getTargetDocument("TargetXml");
+            assertNotNull("target XML is null", targetXml);
+            HashMap<String, String> namespaces = new HashMap<>();
+            namespaces.put("tns", "http://atlasmap.io/itests/builder");
+            XmlAssert.assertThat(targetXml).withNamespaceContext(namespaces)
+                .valueByXPath("//foo/bar/test").isEqualTo("4123562");
+    }
+
+    public static class JsonXmlBuilder extends DefaultAtlasMappingBuilder {
+
+        @Override
+        public void processMapping() {
+            try {
+                read("SourceJson", "/sourceOrderList/orderBatchNumber")
+                    .write("TargetXml", "/foo/bar/test");
+            } catch (Exception e) {
+                addAudit(e);
+            }
+        }
+    }
+
+}

--- a/lib/itests/core/src/test/resources/data/json-source-builder.json
+++ b/lib/itests/core/src/test/resources/data/json-source-builder.json
@@ -1,0 +1,88 @@
+{
+  "sourceOrderList": {
+    "orders": [
+      {
+        "address": {
+          "addressLine1": "123 Main St",
+          "addressLine2": "Suite 42b",
+          "city": "Anytown",
+          "state": "NY",
+          "zipCode": "90210"
+        },
+        "contact": {
+          "firstName": "Ozzie",
+          "lastName": "Smith",
+          "phoneNumber": "5551212",
+          "zipCode": "81111"
+        },
+        "orderId": 0
+      },
+      {
+        "address": {
+          "addressLine1": "123 Main St",
+          "addressLine2": "Suite 42b",
+          "city": "Anytown",
+          "state": "NY",
+          "zipCode": "90210"
+        },
+        "contact": {
+          "firstName": "Ozzie",
+          "lastName": "Smith",
+          "phoneNumber": "5551212",
+          "zipCode": "81111"
+        },
+        "orderId": 1
+      },
+      {
+        "address": {
+          "addressLine1": "123 Main St",
+          "addressLine2": "Suite 42b",
+          "city": "Anytown",
+          "state": "NY",
+          "zipCode": "90210"
+        },
+        "contact": {
+          "firstName": "Ozzie",
+          "lastName": "Smith",
+          "phoneNumber": "5551212",
+          "zipCode": "81111"
+        },
+        "orderId": 2
+      },
+      {
+        "address": {
+          "addressLine1": "123 Main St",
+          "addressLine2": "Suite 42b",
+          "city": "Anytown",
+          "state": "NY",
+          "zipCode": "90210"
+        },
+        "contact": {
+          "firstName": "Ozzie",
+          "lastName": "Smith",
+          "phoneNumber": "5551212",
+          "zipCode": "81111"
+        },
+        "orderId": 3
+      },
+      {
+        "address": {
+          "addressLine1": "123 Main St",
+          "addressLine2": "Suite 42b",
+          "city": "Anytown",
+          "state": "NY",
+          "zipCode": "90210"
+        },
+        "contact": {
+          "firstName": "Ozzie",
+          "lastName": "Smith",
+          "phoneNumber": "5551212",
+          "zipCode": "81111"
+        },
+        "orderId": 4
+      }
+    ],
+    "orderBatchNumber": 4123562,
+    "numberOrders": 5
+  }
+}

--- a/lib/itests/core/src/test/resources/mappings/atlasmapping-builder.json
+++ b/lib/itests/core/src/test/resources/mappings/atlasmapping-builder.json
@@ -1,0 +1,42 @@
+{
+  "AtlasMapping" : {
+    "jsonType": "io.atlasmap.v2.AtlasMapping",
+    "dataSource": [
+      {
+        "jsonType": "io.atlasmap.json.v2.JsonDataSource",
+        "id": "SourceJson",
+        "uri": "atlas:json:SourceJson",
+        "dataSourceType": "SOURCE"
+      },
+      {
+        "jsonType" : "io.atlasmap.xml.v2.XmlDataSource",
+        "id" : "TargetXml",
+        "name" : "TargetXml",
+        "description" : "Target XML document",
+        "uri" : "atlas:xml:TargetXml",
+        "dataSourceType" : "TARGET",
+        "xmlNamespaces" : {
+          "xmlNamespace" : [ {
+            "alias" : "tns",
+             "uri" : "http://atlasmap.io/itests/builder"
+          }]
+        }
+      } ],
+    "mappings" : {
+      "mapping" : [ {
+        "jsonType" : "io.atlasmap.v2.CustomMapping",
+        "className" : "io.atlasmap.itests.core.MappingBuilderTest$JsonXmlBuilder"
+      } ]
+    },
+    "lookupTables" : {
+      "lookupTable" : [ ]
+    },
+    "constants" : {
+      "constant" : [ ]
+    },
+    "properties" : {
+      "property" : [ ]
+    },
+    "name" : "core.unit.test"
+  }
+}

--- a/lib/model/src/main/java/io/atlasmap/v2/BaseMapping.java
+++ b/lib/model/src/main/java/io/atlasmap/v2/BaseMapping.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.atlasmap.v2;
 
 import java.io.Serializable;

--- a/lib/model/src/main/java/io/atlasmap/v2/CustomMapping.java
+++ b/lib/model/src/main/java/io/atlasmap/v2/CustomMapping.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2017 Red Hat, Inc.
+ * Copyright (C) 2021 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atlasmap.api;
+package io.atlasmap.v2;
 
-public class AtlasConstants {
-    public static final String DEFAULT_SOURCE_DOCUMENT_ID = "ATLAS_DEFAULT_SOURCE_DOC";
-    public static final String DEFAULT_TARGET_DOCUMENT_ID = "ATLAS_DEFAULT_TARGET_DOC";
-    public static final String CONSTANTS_DOCUMENT_ID = "ATLAS_CONSTANTS_DOC";
-    public static final String PROPERTIES_SOURCE_DOCUMENT_ID = "ATLAS_SOURCE_PROPERTIES_DOC";
-    public static final String PROPERTIES_TARGET_DOCUMENT_ID = "ATLAS_TARGET_PROPERTIES_DOC";
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-    private AtlasConstants() {
+@JsonTypeInfo(include = JsonTypeInfo.As.PROPERTY, use = JsonTypeInfo.Id.CLASS, property = "jsonType")
+public class CustomMapping extends BaseMapping {
+
+    private static final long serialVersionUID = 1L;
+
+    private String className;
+
+    public String getClassName() {
+        return className;
     }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
 }

--- a/lib/modules/csv/module/src/main/java/io/atlasmap/csv/module/CsvModule.java
+++ b/lib/modules/csv/module/src/main/java/io/atlasmap/csv/module/CsvModule.java
@@ -143,4 +143,10 @@ public class CsvModule extends BaseAtlasModule {
     public Boolean isSupportedField(Field field) {
         return field instanceof CsvField || field instanceof FieldGroup;
     }
+
+    @Override
+    public CsvField createField() {
+        return new CsvField();
+    }
+
 }

--- a/lib/modules/java/module/src/main/java/io/atlasmap/java/module/JavaModule.java
+++ b/lib/modules/java/module/src/main/java/io/atlasmap/java/module/JavaModule.java
@@ -300,4 +300,9 @@ public class JavaModule extends BaseAtlasModule {
         return AtlasJavaModelFactory.cloneJavaField(field, true);
     }
 
+    @Override
+    public JavaField createField() {
+        return AtlasJavaModelFactory.createJavaField();
+    }
+
 }

--- a/lib/modules/json/module/src/main/java/io/atlasmap/json/module/JsonModule.java
+++ b/lib/modules/json/module/src/main/java/io/atlasmap/json/module/JsonModule.java
@@ -249,4 +249,10 @@ public class JsonModule extends BaseAtlasModule {
     public Field cloneField(Field field) throws AtlasException {
         return AtlasJsonModelFactory.cloneField((JsonField)field, true);
     }
+
+    @Override
+    public JsonField createField() {
+        return AtlasJsonModelFactory.createJsonField();
+    }
+
 }

--- a/lib/modules/xml/module/src/main/java/io/atlasmap/xml/module/XmlModule.java
+++ b/lib/modules/xml/module/src/main/java/io/atlasmap/xml/module/XmlModule.java
@@ -349,6 +349,11 @@ public class XmlModule extends BaseAtlasModule {
         return AtlasXmlModelFactory.cloneField((XmlField)field, true);
     }
 
+    @Override
+    public XmlField createField() {
+        return AtlasXmlModelFactory.createXmlField();
+    }
+
     protected XmlIOHelper getXmlIOHelper() {
         return this.ioHelper;
     }


### PR DESCRIPTION
Fixes: #2650
This introduces most basic support of AtlasMappingBuilder and AtlasField which allows user to write mapping logic in Java code. This changeset only enables simple read/write for non-collection field to bring the foundation in earlier. We can build a set of convenient API on top of this like an iterator for collection field, writing COMPLEX object in one invocation by comparing field name, apply transformations and etc.