### PR TITLE
chore: Update UI dependencies

### DIFF
--- a/ui/packages/atlasmap-core/package.json
+++ b/ui/packages/atlasmap-core/package.json
@@ -21,11 +21,48 @@
     "lint": "tsdx lint src test",
     "format": "yarn lint --fix"
   },
-  "peerDependencies": {
-    "ky": "^0.17.0",
+
+  "dependencies": {
+    "@patternfly/react-core": "^4.115.2",
+    "@patternfly/react-icons": "^4.10.2",
+    "@patternfly/react-styles": "^4.10.2",
+    "@patternfly/react-topology": "^4.8.37",
+    "@types/file-saver": "^2.0.2",
+    "@types/pako": "^1.0.1",
+    "@types/react": "^17.0.5",
+    "@types/react-dom": "^17.0.5",
+    "@types/text-encoding": "^0.0.35",
+    "file-saver": "^2.0.5",
+    "ky": "~0.17.0",
+    "loglevel": "^1.7.1",
+    "pako": "^2.0.3",
     "react": "^17.0.2",
-    "rxjs": "^6.2.2"
+    "react-dom": "^17.0.2",
+    "rxjs": "^6.6.7",
+    "text-encoding": "^0.7.0"
   },
+  "devDependencies": {
+    "@babel/core": "^7.12.10",
+    "@testing-library/jest-dom": "^5.7.0",
+    "@testing-library/react": "^11.2.7",
+    "@types/jest": "^24.9.1",
+    "babel-jest": "^24.9.0",
+    "husky": "^6.0.0",
+    "ts-jest": "^24.3.0",
+    "ts-loader": "^6.2.2",
+    "tsdx": "^0.13.1",
+    "typescript": "~3.9.9"
+  },
+  "peerDependencies": {
+    "react": "^17.0.2",
+    "rxjs": "^6.6.7"
+  },
+  "resolutions": {
+    "jest": "24.9.0",
+    "prettier": "^2.3.0",
+    "webpack": "4.42.0"
+  },
+
   "husky": {
     "hooks": {
       "pre-commit": "tsdx lint"
@@ -38,42 +75,11 @@
     "trailingComma": "es5",
     "endOfLine": "auto"
   },
-  "devDependencies": {
-    "@babel/core": "^7.12.10",
-    "@patternfly/react-core": "^4.115.2",
-    "@patternfly/react-icons": "^4.10.2",
-    "@patternfly/react-styles": "^4.10.2",
-    "@patternfly/react-topology": "^4.8.37",
-    "@testing-library/jest-dom": "^5.7.0",
-    "@testing-library/react": "^11.2.7",
-    "@types/file-saver": "2.0.1",
-    "@types/jest": "^24.9.1",
-    "@types/pako": "1.0.1",
-    "@types/react": "^17.0.5",
-    "@types/react-dom": "^17.0.5",
-    "@types/text-encoding": "0.0.35",
-    "babel-jest": "^24.9.0",
-    "husky": "^4.2.3",
-    "ky": "^0.17.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "rxjs": "^6.5.4",
-    "text-encoding": "^0.7.0",
-    "ts-jest": "^24.3.0",
-    "ts-loader": "^6.2.2",
-    "tsdx": "^0.13.1",
-    "tslib": "^1.11.1",
-    "typescript": "~3.9.9"
-  },
-  "resolutions": {
-    "jest": "24.9.0",
-    "prettier": "^2.3.0",
-    "webpack": "4.42.0"
-  },
   "jest": {
     "moduleNameMapper": {
       "\\.(css|less)$": "<rootDir>/test/__mocks__/styleMock.js",
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/test/__mocks__/fileMock.js",
+      "ky": "ky/umd",
       "@src": "<rootDir>/src/index.ts",
       "@src/(.*)": "<rootDir>/src/$1",
       "@test/(.*)": "<rootDir>/test/$1"
@@ -112,10 +118,5 @@
       "react-hooks/exhaustive-deps": "warn",
       "sort-imports": "error"
     }
-  },
-  "dependencies": {
-    "file-saver": "2.0.2",
-    "loglevel": "^1.6.7",
-    "pako": "^1.0.11"
   }
 }

--- a/ui/packages/atlasmap-core/src/services/file-management.service.spec.ts
+++ b/ui/packages/atlasmap-core/src/services/file-management.service.spec.ts
@@ -27,7 +27,6 @@ import { ErrorLevel } from '../models/error.model';
 import { FileManagementService } from './file-management.service';
 import FileSaver from 'file-saver';
 import { InitializationService } from './initialization.service';
-import { ResponsePromise } from 'ky';
 import fs from 'fs';
 import ky from 'ky/umd';
 import log from 'loglevel';
@@ -54,15 +53,13 @@ describe('FileManagementService', () => {
     mockedKy.get = jest.fn().mockReturnValue(
       new (class {
         json(): Promise<any> {
-          return new Promise<any>((resolve) => {
-            resolve({
-              StringMap: {
-                stringMapEntry: [
-                  { name: 'dummyMappingFile1' },
-                  { name: 'dummyMappingFile2' },
-                ],
-              },
-            });
+          return Promise.resolve({
+            StringMap: {
+              stringMapEntry: [
+                { name: 'dummyMappingFile1' },
+                { name: 'dummyMappingFile2' },
+              ],
+            },
           });
         }
       })()
@@ -79,9 +76,7 @@ describe('FileManagementService', () => {
     mockedKy.get = jest.fn().mockReturnValue(
       new (class {
         json(): Promise<any> {
-          return new Promise<any>((_resolve, reject) => {
-            reject('expected error');
-          });
+          return Promise.reject('expected error');
         }
       })()
     );
@@ -100,11 +95,9 @@ describe('FileManagementService', () => {
     mockedKy.get = jest.fn().mockReturnValue(
       new (class {
         arrayBuffer(): Promise<ArrayBuffer> {
-          return new Promise<ArrayBuffer>((resolve) => {
-            resolve(new TextEncoder().encode('test text'));
-          });
+          return Promise.resolve(new TextEncoder().encode('test text'));
         }
-      })() as ResponsePromise
+      })()
     );
     service.getCurrentMappingDigest().subscribe((value) => {
       expect(new TextDecoder().decode(value)).toMatch('test text');
@@ -116,11 +109,9 @@ describe('FileManagementService', () => {
     mockedKy.get = jest.fn().mockReturnValue(
       new (class {
         arrayBuffer(): Promise<ArrayBuffer> {
-          return new Promise<ArrayBuffer>((_resolve, reject) => {
-            reject('expected error');
-          });
+          return Promise.reject('expected error');
         }
-      })() as ResponsePromise
+      })()
     );
     service.getCurrentMappingDigest().subscribe({
       error: (error) => {
@@ -137,11 +128,9 @@ describe('FileManagementService', () => {
     mockedKy.get = jest.fn().mockReturnValue(
       new (class {
         arrayBuffer(): Promise<ArrayBuffer> {
-          return new Promise<ArrayBuffer>((resolve) => {
-            resolve(new TextEncoder().encode('test text'));
-          });
+          return Promise.resolve(new TextEncoder().encode('test text'));
         }
-      })() as ResponsePromise
+      })()
     );
     service.getCurrentADMArchive().subscribe((value) => {
       expect(new TextDecoder().decode(value)).toMatch('test text');
@@ -153,11 +142,9 @@ describe('FileManagementService', () => {
     mockedKy.get = jest.fn().mockReturnValue(
       new (class {
         arrayBuffer(): Promise<ArrayBuffer> {
-          return new Promise<ArrayBuffer>((_resolve, reject) => {
-            reject('expected error');
-          });
+          return Promise.reject('expected error');
         }
-      })() as ResponsePromise
+      })()
     );
     service.getCurrentADMArchive().subscribe({
       error: (error) => {
@@ -174,11 +161,9 @@ describe('FileManagementService', () => {
     mockedKy.delete = jest.fn().mockReturnValue(
       new (class {
         arrayBuffer(): Promise<ArrayBuffer> {
-          return new Promise<ArrayBuffer>((resolve) => {
-            resolve(new ArrayBuffer(0));
-          });
+          return Promise.resolve(new ArrayBuffer(0));
         }
-      })() as ResponsePromise
+      })()
     );
     service.resetMappings().subscribe((value) => {
       expect(value).toBeTruthy();
@@ -190,9 +175,7 @@ describe('FileManagementService', () => {
     mockedKy.delete = jest.fn().mockReturnValue(
       new (class {
         arrayBuffer(): Promise<ArrayBuffer> {
-          return new Promise<ArrayBuffer>((_resolve, reject) => {
-            reject('expected error');
-          });
+          return Promise.reject('expected error');
         }
       })()
     );
@@ -213,11 +196,9 @@ describe('FileManagementService', () => {
     mockedKy.delete = jest.fn().mockReturnValue(
       new (class {
         arrayBuffer(): Promise<ArrayBuffer> {
-          return new Promise<ArrayBuffer>((resolve) => {
-            resolve(new ArrayBuffer(0));
-          });
+          return Promise.resolve(new ArrayBuffer(0));
         }
-      })() as ResponsePromise
+      })()
     );
     service.resetLibs().subscribe((value) => {
       expect(value).toBeTruthy();
@@ -229,9 +210,7 @@ describe('FileManagementService', () => {
     mockedKy.delete = jest.fn().mockReturnValue(
       new (class {
         arrayBuffer(): Promise<ArrayBuffer> {
-          return new Promise<ArrayBuffer>((_resolve, reject) => {
-            reject('expected error');
-          });
+          return Promise.reject('expected error');
         }
       })()
     );
@@ -252,11 +231,9 @@ describe('FileManagementService', () => {
     mockedKy.put = jest.fn().mockReturnValue(
       new (class {
         arrayBuffer(): Promise<ArrayBuffer> {
-          return new Promise<ArrayBuffer>((resolve) => {
-            resolve(new ArrayBuffer(0));
-          });
+          return Promise.resolve(new ArrayBuffer(0));
         }
-      })() as ResponsePromise
+      })()
     );
     const mappingJson = '{"AtlasMapping": {}}';
     service.setMappingToService(mappingJson).subscribe((value) => {
@@ -269,9 +246,7 @@ describe('FileManagementService', () => {
     mockedKy.put = jest.fn().mockReturnValue(
       new (class {
         arrayBuffer(): Promise<ArrayBuffer> {
-          return new Promise<ArrayBuffer>((_resolve, reject) => {
-            reject('expected error');
-          });
+          return Promise.reject('expected error');
         }
       })()
     );
@@ -291,11 +266,9 @@ describe('FileManagementService', () => {
     mockedKy.put = jest.fn().mockReturnValue(
       new (class {
         arrayBuffer(): Promise<ArrayBuffer> {
-          return new Promise<ArrayBuffer>((resolve) => {
-            resolve(new ArrayBuffer(0));
-          });
+          return Promise.resolve(new ArrayBuffer(0));
         }
-      })() as ResponsePromise
+      })()
     );
     const binary = new TextEncoder().encode('dummy binary');
     const url = service.cfg.initCfg.baseMappingServiceUrl + 'mapping/ZIP/';
@@ -309,9 +282,7 @@ describe('FileManagementService', () => {
     mockedKy.put = jest.fn().mockReturnValue(
       new (class {
         arrayBuffer(): Promise<ArrayBuffer> {
-          return new Promise<ArrayBuffer>((_resolve, reject) => {
-            reject('expected error');
-          });
+          return Promise.reject('expected error');
         }
       })()
     );
@@ -333,30 +304,24 @@ describe('FileManagementService', () => {
     mockedKy.put = jest.fn().mockReturnValue(
       new (class {
         arrayBuffer(): Promise<ArrayBuffer> {
-          return new Promise<ArrayBuffer>((resolve) => {
-            resolve(new ArrayBuffer(0));
-          });
+          return Promise.resolve(new ArrayBuffer(0));
         }
-      })() as ResponsePromise
+      })()
     );
     // get ADM archive file
     mockedKy.get = jest.fn().mockReturnValue(
       new (class {
         arrayBuffer(): Promise<ArrayBuffer> {
-          return new Promise<ArrayBuffer>((resolve) => {
-            const buf = fs.readFileSync(
+          return Promise.resolve(
+            fs.readFileSync(
               `${__dirname}/../../../../test-resources/adm/mockdoc.adm`
-            );
-            resolve(buf);
-          });
+            )
+          );
         }
         json(): Promise<any> {
-          return new Promise<any>((resolve) => {
-            const json = { AtlasMapping: {} };
-            resolve(json);
-          });
+          return Promise.resolve({ AtlasMapping: {} });
         }
-      })() as ResponsePromise
+      })()
     );
     mockedFileSaver.saveAs = jest.fn().mockImplementation((_data) => {});
     service.cfg.mappings = new MappingDefinition();
@@ -404,11 +369,9 @@ describe('FileManagementService', () => {
     mockedKy.put = jest.fn().mockReturnValue(
       new (class {
         arrayBuffer(): Promise<ArrayBuffer> {
-          return new Promise<ArrayBuffer>((resolve) => {
-            resolve(new ArrayBuffer(0));
-          });
+          return Promise.resolve(new ArrayBuffer(0));
         }
-      })() as ResponsePromise
+      })()
     );
     mockedInitService.prototype.initialize = jest
       .fn()

--- a/ui/packages/atlasmap-core/src/services/mapping-management.service.spec.ts
+++ b/ui/packages/atlasmap-core/src/services/mapping-management.service.spec.ts
@@ -19,7 +19,7 @@ import { Field } from '../models/field.model';
 import { MappingDefinition } from '../models/mapping-definition.model';
 import { MappingManagementService } from '../services/mapping-management.service';
 import { MappingModel } from '../models/mapping.model';
-import ky from 'ky/umd';
+import ky from 'ky';
 import log from 'loglevel';
 
 describe('MappingManagementService', () => {

--- a/ui/packages/atlasmap-core/src/services/mapping-management.service.ts
+++ b/ui/packages/atlasmap-core/src/services/mapping-management.service.ts
@@ -29,7 +29,6 @@ import { LookupTableData, LookupTableUtil } from '../utils/lookup-table-util';
 import { MappedField, MappingModel } from '../models/mapping.model';
 import { Observable, Subject, Subscription, forkJoin, from } from 'rxjs';
 import { TransitionMode, TransitionModel } from '../models/transition.model';
-import ky, { Options } from 'ky';
 
 import { ConfigModel } from '../models/config.model';
 import { DataMapperUtil } from '../common/data-mapper-util';
@@ -39,6 +38,7 @@ import { Field } from '../models/field.model';
 import { MappingDefinition } from '../models/mapping-definition.model';
 import { MappingSerializer } from '../utils/mapping-serializer';
 import { PaddingField } from '../models/document-definition.model';
+import ky from 'ky';
 import log from 'loglevel';
 import { timeout } from 'rxjs/operators';
 
@@ -777,7 +777,7 @@ export class MappingManagementService {
    * Invoke the runtime service to save the current active mapping.
    * No validation will occur.
    */
-  async updateMappings(payload: Options['json']): Promise<boolean> {
+  async updateMappings(payload: any): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
       if (
         this.cfg.initCfg.baseMappingServiceUrl === null ||
@@ -821,7 +821,7 @@ export class MappingManagementService {
   /**
    * Invoke the runtime service to validate the current active mapping.
    */
-  private async validateMappings(payload: Options['json']): Promise<boolean> {
+  private async validateMappings(payload: any): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
       if (
         this.cfg.initCfg.baseMappingServiceUrl === null ||

--- a/ui/packages/atlasmap-core/src/utils/mapping-serializer.spec.ts
+++ b/ui/packages/atlasmap-core/src/utils/mapping-serializer.spec.ts
@@ -23,7 +23,7 @@ import atlasMappingExprPropJson from '../../../../test-resources/mapping/atlasma
 import atlasMappingTestJson from '../../../../test-resources/mapping/atlasmapping-test.json';
 import atlasmapFieldActionJson from '../../../../test-resources/fieldActions/atlasmap-field-action.json';
 
-import ky from 'ky/umd';
+import ky from 'ky';
 import log from 'loglevel';
 
 describe('MappingSerializer', () => {

--- a/ui/packages/atlasmap-standalone/package.json
+++ b/ui/packages/atlasmap-standalone/package.json
@@ -21,14 +21,13 @@
     "@patternfly/react-topology": "^4.8.37",
     "@types/d3-scale": "^2.1.1",
     "@types/d3-shape": "^1.3.2",
-    "@types/jest": "24.9.1",
     "@types/node": "13.7.1",
     "@types/react": "^17.0.5",
     "@types/react-dom": "^17.0.5",
     "d3-scale": "^3.2.0",
     "d3-shape": "^1.3.5",
     "http-proxy-middleware": "^0.20.0",
-    "ky": "^0.17.0",
+    "ky": "~0.17.0",
     "lodash.clamp": "^4.0.3",
     "react": "^17.0.2",
     "react-dnd": "^14.0.2",
@@ -38,9 +37,13 @@
     "react-file-picker": "^0.0.6",
     "react-scripts": "^3.4.4",
     "react-use-gesture": "^9.1.3",
-    "rxjs": "^6.2.2",
-    "typescript": "3.9.9"
+    "rxjs": "^6.6.7"
   },
+  "devDependencies": {
+    "@types/jest": "24.9.1",
+    "typescript": "~3.9.9"
+  },
+  "peerDependencies": {},
   "resolutions": {
     "jest": "24.9.0",
     "babel-loader": "8.1.0",

--- a/ui/packages/atlasmap/package.json
+++ b/ui/packages/atlasmap/package.json
@@ -25,46 +25,36 @@
     "format": "yarn lint --fix",
     "storybook": "start-storybook -p 6006"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "tsdx lint"
-    }
-  },
-  "prettier": {
-    "trailingComma": "all",
-    "endOfLine": "auto"
-  },
+
   "dependencies": {
     "@atlasmap/core": "^2.3.0-SNAPSHOT",
-    "react-sage": "^0.2.3",
-    "use-debounce": "^3.4.2"
-  },
-  "peerDependencies": {
     "@patternfly/react-core": "^4.115.2",
     "@patternfly/react-icons": "^4.10.2",
     "@patternfly/react-styles": "^4.10.2",
     "@patternfly/react-table": "^4.26.7",
     "@patternfly/react-topology": "^4.8.37",
-    "@storybook/addon-actions": "^6.2.9",
-    "d3-scale": "^3.2.0",
-    "d3-shape": "^1.3.5",
-    "ky": "^0.17.0",
-    "lodash.clamp": "^4.0.3",
+    "@types/d3-scale": "2.1.1",
+    "@types/d3-shape": "1.3.2",
+    "@types/he": "^1.1.1",
+    "@types/react": "^17.0.5",
+    "@types/react-dom": "^17.0.5",
+    "d3-scale": "^3.2.1",
+    "d3-shape": "^1.3.7",
+    "he": "^1.2.0",
+    "ky": "~0.17.0",
     "react": "^17.0.2",
     "react-dnd": "^14.0.2",
     "react-dnd-html5-backend": "^14.0.0",
     "react-dnd-touch-backend": "^14.0.0",
     "react-dom": "^17.0.2",
+    "react-sage": "^0.2.3",
+    "react-spring": "^9.1.2",
     "react-use-gesture": "^9.1.3",
-    "rxjs": "^6.2.2"
+    "rxjs": "^6.6.7",
+    "use-debounce": "^6.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
-    "@patternfly/react-core": "^4.115.2",
-    "@patternfly/react-icons": "^4.10.2",
-    "@patternfly/react-styles": "^4.10.2",
-    "@patternfly/react-table": "^4.26.7",
-    "@patternfly/react-topology": "^4.8.37",
     "@storybook/addon-actions": "^6.2.9",
     "@storybook/addon-docs": "^6.2.9",
     "@storybook/addon-knobs": "^6.2.9",
@@ -75,44 +65,26 @@
     "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^10.3.1",
-    "@types/d3-scale": "2.1.1",
-    "@types/d3-shape": "1.3.2",
-    "@types/he": "^1.1.1",
     "@types/hoist-non-react-statics": "^3.3.1",
     "@types/jest": "24.9.1",
-    "@types/lodash.clamp": "^4.0.6",
-    "@types/react": "^17.0.5",
-    "@types/react-dom": "^17.0.5",
     "@typescript-eslint/eslint-plugin": "^4.23.0",
     "autoprefixer": "^10.2.5",
     "babel-loader": "8.1.0",
     "css-loader": "^5.2.4",
     "cssnano": "^5.0.2",
-    "d3-scale": "^3.2.1",
-    "d3-shape": "^1.3.7",
     "eslint-config-react-app": "^6.0.0",
     "eslint-plugin-mdx": "^1.13.0",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "fork-ts-checker-webpack-plugin": "^4.1.3",
-    "he": "^1.2.0",
     "husky": "^4.2.3",
     "jest-css-modules-transform": "^4.2.1",
     "jest-environment-jsdom-sixteen": "^1.0.3",
-    "ky": "^0.17.0",
     "lodash.clamp": "^4.0.3",
     "postcss": "^8.2.15",
     "postcss-loader": "^4.2.0",
     "postcss-url": "^10.1.3",
-    "react": "^17.0.2",
-    "react-dnd": "^14.0.2",
-    "react-dnd-html5-backend": "^14.0.0",
-    "react-dnd-touch-backend": "^14.0.0",
-    "react-dom": "^17.0.2",
-    "react-spring": "^9.1.2",
-    "react-use-gesture": "^9.1.3",
     "rollup-plugin-postcss": "^4.0.0",
-    "rxjs": "^6.2.2",
     "source-map-loader": "volune/source-map-loader#fixes",
     "style-loader": "^2.0.0",
     "ts-loader": "^6.2.2",
@@ -123,10 +95,22 @@
     "typescript": "~3.9.9",
     "typescript-plugin-css-modules": "^3.2.0"
   },
+  "peerDependencies": {
+  },
   "resolutions": {
     "jest": "24.9.0",
     "prettier": "^2.3.0",
     "webpack": "4.42.0"
+  },
+
+  "husky": {
+    "hooks": {
+      "pre-commit": "tsdx lint"
+    }
+  },
+  "prettier": {
+    "trailingComma": "all",
+    "endOfLine": "auto"
   },
   "jest": {
     "setupFilesAfterEnv": [

--- a/ui/packages/atlasmap/src/UI/DocumentFieldPreview.tsx
+++ b/ui/packages/atlasmap/src/UI/DocumentFieldPreview.tsx
@@ -27,7 +27,7 @@ export interface IDocumentFieldPreviewProps {
 
 export const DocumentFieldPreview: FunctionComponent<IDocumentFieldPreviewProps> =
   ({ id, value, onChange }) => {
-    const [debouncedOnChange] = useDebouncedCallback(onChange, 200);
+    const debouncedOnChange = useDebouncedCallback(onChange, 200);
     return (
       <Form
         className={styles.form}

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3959,10 +3959,10 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
-"@types/file-saver@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@types/file-saver/-/file-saver-2.0.1.tgz#e18eb8b069e442f7b956d313f4fadd3ef887354e"
-  integrity sha512-g1QUuhYVVAamfCifK7oB7G3aIl4BbOyzDOqVyUfEr4tfBKrXfeH+M+Tg7HKCXSrbzxYdhyCP7z9WbKo0R2hBCw==
+"@types/file-saver@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/file-saver/-/file-saver-2.0.2.tgz#bd593ccfaee42ff94a5c1c83bf69ae9be83493b9"
+  integrity sha512-xbqnZmGrCEqi/KUzOkeUSe77p7APvLuyellGaAoeww3CHJ1AbjQWjPSCFtKIzZn8L7LpEax4NXnC+gfa6nM7IA==
 
 "@types/geojson@*":
   version "7946.0.7"
@@ -4071,18 +4071,6 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/lodash.clamp@^4.0.6":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.clamp/-/lodash.clamp-4.0.6.tgz#ca51ac61e11c6c6109638f44179abb97031619cb"
-  integrity sha512-+Rn39PbxYSbFFVXGEpw5t7EM8clP4P3d5rtbBFJYZUsgyWO1S0EYiNf+vKc2dRUy5eSI+oAVVlpgMF0vJcMUtA==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.14.169"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.169.tgz#83c217688f07a4d9ef8f28a3ebd1d318f6ff4cbb"
-  integrity sha512-DvmZHoHTFJ8zhVYwCLWbQ7uAbYQEk52Ev2/ZiQ7Y7gQGeV9pjBqjnQpECMHfKS1rCYAhMI7LHVxwyZLZinJgdw==
-
 "@types/markdown-to-jsx@^6.11.3":
   version "6.11.3"
   resolved "https://registry.yarnpkg.com/@types/markdown-to-jsx/-/markdown-to-jsx-6.11.3.tgz#cdd1619308fecbc8be7e6a26f3751260249b020e"
@@ -4152,7 +4140,7 @@
   resolved "https://registry.yarnpkg.com/@types/overlayscrollbars/-/overlayscrollbars-1.12.0.tgz#98456caceca8ad73bd5bb572632a585074e70764"
   integrity sha512-h/pScHNKi4mb+TrJGDon8Yb06ujFG0mSg12wIO0sWMUF3dQIe2ExRRdNRviaNt9IjxIiOfnRr7FsQAdHwK4sMg==
 
-"@types/pako@1.0.1":
+"@types/pako@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/pako/-/pako-1.0.1.tgz#33b237f3c9aff44d0f82fe63acffa4a365ef4a61"
   integrity sha512-GdZbRSJ3Cv5fiwT6I0SQ3ckeN2PWNqxd26W9Z2fCK1tGrrasGy4puvNFtnddqH9UJFMQYXxEuuB7B8UK+LLwSg==
@@ -4258,7 +4246,7 @@
   dependencies:
     "@types/jest" "*"
 
-"@types/text-encoding@0.0.35":
+"@types/text-encoding@^0.0.35":
   version "0.0.35"
   resolved "https://registry.yarnpkg.com/@types/text-encoding/-/text-encoding-0.0.35.tgz#6f14474e0b232bc70c59677aadc65dcc5a99c3a9"
   integrity sha512-jfo/A88XIiAweUa8np+1mPbm3h2w0s425YrI8t3wk5QxhH6UI7w517MboNVnGDeMSuoFwA8Rwmklno+FicvV4g==
@@ -4439,44 +4427,20 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.8.5"
     "@webassemblyjs/wast-parser" "1.8.5"
 
-"@webassemblyjs/ast@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
-  integrity sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==
-  dependencies:
-    "@webassemblyjs/helper-module-context" "1.9.0"
-    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
-    "@webassemblyjs/wast-parser" "1.9.0"
-
 "@webassemblyjs/floating-point-hex-parser@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz#1ba926a2923613edce496fd5b02e8ce8a5f49721"
   integrity sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==
-
-"@webassemblyjs/floating-point-hex-parser@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz#3c3d3b271bddfc84deb00f71344438311d52ffb4"
-  integrity sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==
 
 "@webassemblyjs/helper-api-error@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz#c49dad22f645227c5edb610bdb9697f1aab721f7"
   integrity sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==
 
-"@webassemblyjs/helper-api-error@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz#203f676e333b96c9da2eeab3ccef33c45928b6a2"
-  integrity sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==
-
 "@webassemblyjs/helper-buffer@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz#fea93e429863dd5e4338555f42292385a653f204"
   integrity sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==
-
-"@webassemblyjs/helper-buffer@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz#a1442d269c5feb23fcbc9ef759dac3547f29de00"
-  integrity sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==
 
 "@webassemblyjs/helper-code-frame@1.8.5":
   version "1.8.5"
@@ -4485,22 +4449,10 @@
   dependencies:
     "@webassemblyjs/wast-printer" "1.8.5"
 
-"@webassemblyjs/helper-code-frame@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz#647f8892cd2043a82ac0c8c5e75c36f1d9159f27"
-  integrity sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==
-  dependencies:
-    "@webassemblyjs/wast-printer" "1.9.0"
-
 "@webassemblyjs/helper-fsm@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz#ba0b7d3b3f7e4733da6059c9332275d860702452"
   integrity sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==
-
-"@webassemblyjs/helper-fsm@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz#c05256b71244214671f4b08ec108ad63b70eddb8"
-  integrity sha512-OPRowhGbshCb5PxJ8LocpdX9Kl0uB4XsAjl6jH/dWKlk/mzsANvhwbiULsaiqT5GZGT9qinTICdj6PLuM5gslw==
 
 "@webassemblyjs/helper-module-context@1.8.5":
   version "1.8.5"
@@ -4510,22 +4462,10 @@
     "@webassemblyjs/ast" "1.8.5"
     mamacro "^0.0.3"
 
-"@webassemblyjs/helper-module-context@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz#25d8884b76839871a08a6c6f806c3979ef712f07"
-  integrity sha512-MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-
 "@webassemblyjs/helper-wasm-bytecode@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz#537a750eddf5c1e932f3744206551c91c1b93e61"
   integrity sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==
-
-"@webassemblyjs/helper-wasm-bytecode@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz#4fed8beac9b8c14f8c58b70d124d549dd1fe5790"
-  integrity sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==
 
 "@webassemblyjs/helper-wasm-section@1.8.5":
   version "1.8.5"
@@ -4537,27 +4477,10 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.8.5"
     "@webassemblyjs/wasm-gen" "1.8.5"
 
-"@webassemblyjs/helper-wasm-section@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz#5a4138d5a6292ba18b04c5ae49717e4167965346"
-  integrity sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/helper-buffer" "1.9.0"
-    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
-    "@webassemblyjs/wasm-gen" "1.9.0"
-
 "@webassemblyjs/ieee754@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz#712329dbef240f36bf57bd2f7b8fb9bf4154421e"
   integrity sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==
-  dependencies:
-    "@xtuc/ieee754" "^1.2.0"
-
-"@webassemblyjs/ieee754@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz#15c7a0fbaae83fb26143bbacf6d6df1702ad39e4"
-  integrity sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==
   dependencies:
     "@xtuc/ieee754" "^1.2.0"
 
@@ -4568,22 +4491,10 @@
   dependencies:
     "@xtuc/long" "4.2.2"
 
-"@webassemblyjs/leb128@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.9.0.tgz#f19ca0b76a6dc55623a09cffa769e838fa1e1c95"
-  integrity sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==
-  dependencies:
-    "@xtuc/long" "4.2.2"
-
 "@webassemblyjs/utf8@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.8.5.tgz#a8bf3b5d8ffe986c7c1e373ccbdc2a0915f0cedc"
   integrity sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==
-
-"@webassemblyjs/utf8@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.9.0.tgz#04d33b636f78e6a6813227e82402f7637b6229ab"
-  integrity sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==
 
 "@webassemblyjs/wasm-edit@1.8.5":
   version "1.8.5"
@@ -4599,20 +4510,6 @@
     "@webassemblyjs/wasm-parser" "1.8.5"
     "@webassemblyjs/wast-printer" "1.8.5"
 
-"@webassemblyjs/wasm-edit@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz#3fe6d79d3f0f922183aa86002c42dd256cfee9cf"
-  integrity sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/helper-buffer" "1.9.0"
-    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
-    "@webassemblyjs/helper-wasm-section" "1.9.0"
-    "@webassemblyjs/wasm-gen" "1.9.0"
-    "@webassemblyjs/wasm-opt" "1.9.0"
-    "@webassemblyjs/wasm-parser" "1.9.0"
-    "@webassemblyjs/wast-printer" "1.9.0"
-
 "@webassemblyjs/wasm-gen@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz#54840766c2c1002eb64ed1abe720aded714f98bc"
@@ -4624,17 +4521,6 @@
     "@webassemblyjs/leb128" "1.8.5"
     "@webassemblyjs/utf8" "1.8.5"
 
-"@webassemblyjs/wasm-gen@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz#50bc70ec68ded8e2763b01a1418bf43491a7a49c"
-  integrity sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
-    "@webassemblyjs/ieee754" "1.9.0"
-    "@webassemblyjs/leb128" "1.9.0"
-    "@webassemblyjs/utf8" "1.9.0"
-
 "@webassemblyjs/wasm-opt@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz#b24d9f6ba50394af1349f510afa8ffcb8a63d264"
@@ -4644,16 +4530,6 @@
     "@webassemblyjs/helper-buffer" "1.8.5"
     "@webassemblyjs/wasm-gen" "1.8.5"
     "@webassemblyjs/wasm-parser" "1.8.5"
-
-"@webassemblyjs/wasm-opt@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz#2211181e5b31326443cc8112eb9f0b9028721a61"
-  integrity sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/helper-buffer" "1.9.0"
-    "@webassemblyjs/wasm-gen" "1.9.0"
-    "@webassemblyjs/wasm-parser" "1.9.0"
 
 "@webassemblyjs/wasm-parser@1.8.5":
   version "1.8.5"
@@ -4667,18 +4543,6 @@
     "@webassemblyjs/leb128" "1.8.5"
     "@webassemblyjs/utf8" "1.8.5"
 
-"@webassemblyjs/wasm-parser@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz#9d48e44826df4a6598294aa6c87469d642fff65e"
-  integrity sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/helper-api-error" "1.9.0"
-    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
-    "@webassemblyjs/ieee754" "1.9.0"
-    "@webassemblyjs/leb128" "1.9.0"
-    "@webassemblyjs/utf8" "1.9.0"
-
 "@webassemblyjs/wast-parser@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz#e10eecd542d0e7bd394f6827c49f3df6d4eefb8c"
@@ -4691,18 +4555,6 @@
     "@webassemblyjs/helper-fsm" "1.8.5"
     "@xtuc/long" "4.2.2"
 
-"@webassemblyjs/wast-parser@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz#3031115d79ac5bd261556cecc3fa90a3ef451914"
-  integrity sha512-qsqSAP3QQ3LyZjNC/0jBJ/ToSxfYJ8kYyuiGvtn/8MK89VrNEfwj7BPQzJVHi0jGTRK2dGdJ5PRqhtjzoww+bw==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/floating-point-hex-parser" "1.9.0"
-    "@webassemblyjs/helper-api-error" "1.9.0"
-    "@webassemblyjs/helper-code-frame" "1.9.0"
-    "@webassemblyjs/helper-fsm" "1.9.0"
-    "@xtuc/long" "4.2.2"
-
 "@webassemblyjs/wast-printer@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz#114bbc481fd10ca0e23b3560fa812748b0bae5bc"
@@ -4710,15 +4562,6 @@
   dependencies:
     "@webassemblyjs/ast" "1.8.5"
     "@webassemblyjs/wast-parser" "1.8.5"
-    "@xtuc/long" "4.2.2"
-
-"@webassemblyjs/wast-printer@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz#4935d54c85fef637b00ce9f52377451d00d47899"
-  integrity sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
 "@xtuc/ieee754@^1.2.0":
@@ -4793,7 +4636,7 @@ acorn@^5.5.3:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
   integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
 
-acorn@^6.0.1, acorn@^6.0.4, acorn@^6.2.1, acorn@^6.4.1:
+acorn@^6.0.1, acorn@^6.0.4, acorn@^6.2.1:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
@@ -8428,7 +8271,7 @@ endent@^2.0.1:
     fast-json-parse "^1.0.3"
     objectorarray "^1.0.4"
 
-enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0, enhanced-resolve@^4.5.0:
+enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz#2f3cfd84dbe3b487f18f2db2ef1e064a571ca5ec"
   integrity sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==
@@ -9328,10 +9171,10 @@ file-loader@^6.2.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-file-saver@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.2.tgz#06d6e728a9ea2df2cce2f8d9e84dfcdc338ec17a"
-  integrity sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw==
+file-saver@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.5.tgz#d61cfe2ce059f414d899e9dd6d4107ee25670c38"
+  integrity sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==
 
 file-selector@^0.1.8:
   version "0.1.19"
@@ -10667,6 +10510,11 @@ husky@^4.2.3:
     please-upgrade-node "^3.2.0"
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
+
+husky@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-6.0.0.tgz#810f11869adf51604c32ea577edbc377d7f9319e"
+  integrity sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==
 
 iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
@@ -12430,7 +12278,7 @@ klona@^2.0.4:
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.4.tgz#7bb1e3affb0cb8624547ef7e8f6708ea2e39dfc0"
   integrity sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==
 
-ky@^0.17.0:
+ky@~0.17.0:
   version "0.17.0"
   resolved "https://registry.yarnpkg.com/ky/-/ky-0.17.0.tgz#c1c464bd5e88217fb75ccadcee146497a8ea2f13"
   integrity sha512-WSDBoSr9IWJOJOIGdsVbngyFrbAkCE3Nvwa4KLF77jWiKVm2zpMUQKSqaq6bZ/4V3ez8F2ggKDMaKXnteZY+ag==
@@ -12769,7 +12617,7 @@ log-update@^2.3.0:
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
 
-loglevel@^1.6.7, loglevel@^1.6.8:
+loglevel@^1.6.8, loglevel@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
   integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
@@ -14309,7 +14157,12 @@ pacote@^11.2.6:
     ssri "^8.0.1"
     tar "^6.1.0"
 
-pako@^1.0.11, pako@~1.0.5:
+pako@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.0.3.tgz#cdf475e31b678565251406de9e759196a0ea7a43"
+  integrity sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw==
+
+pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
@@ -17349,7 +17202,7 @@ rw@1:
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
   integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
 
-rxjs@^6.2.2, rxjs@^6.5.3, rxjs@^6.5.4, rxjs@^6.6.0:
+rxjs@^6.5.3, rxjs@^6.6.0, rxjs@^6.6.7:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -19163,7 +19016,7 @@ typescript-plugin-css-modules@^3.2.0:
     stylus "^0.54.7"
     tsconfig-paths "^3.9.0"
 
-typescript@3.9.9, typescript@^3.7.3, typescript@~3.9.9:
+typescript@^3.7.3, typescript@~3.9.9:
   version "3.9.9"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
   integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
@@ -19496,10 +19349,10 @@ use-composed-ref@^1.0.0:
   dependencies:
     ts-essentials "^2.0.3"
 
-use-debounce@^3.4.2:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-3.4.3.tgz#5df9322322b3f1b1c263d46413f9facf6d8b56ab"
-  integrity sha512-nxy+opOxDccWfhMl36J5BSCTpvcj89iaQk2OZWLAtBJQj7ISCtx1gh+rFbdjGfMl6vtCZf6gke/kYvrkVfHMoA==
+use-debounce@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-6.0.1.tgz#ed1eb2b30189408fb9792ea2887f4c6c3cb401a3"
+  integrity sha512-kpvIxpa0vOLz/2I2sfNJ72mUeaT2CMNCu5BT1f2HkV9qZK27UVSOFf1sSSu+wjJE4TcR2VTXS2SM569+m3TN7Q==
 
 use-isomorphic-layout-effect@^1.0.0:
   version "1.1.1"
@@ -19740,7 +19593,7 @@ watchpack-chokidar2@^2.0.1:
   dependencies:
     chokidar "^2.1.8"
 
-watchpack@^1.6.0, watchpack@^1.7.4:
+watchpack@^1.6.0:
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
@@ -19893,36 +19746,7 @@ webpack-virtual-modules@^0.2.2:
   dependencies:
     debug "^3.0.0"
 
-webpack@4:
-  version "4.46.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.46.0.tgz#bf9b4404ea20a073605e0a011d188d77cb6ad542"
-  integrity sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/helper-module-context" "1.9.0"
-    "@webassemblyjs/wasm-edit" "1.9.0"
-    "@webassemblyjs/wasm-parser" "1.9.0"
-    acorn "^6.4.1"
-    ajv "^6.10.2"
-    ajv-keywords "^3.4.1"
-    chrome-trace-event "^1.0.2"
-    enhanced-resolve "^4.5.0"
-    eslint-scope "^4.0.3"
-    json-parse-better-errors "^1.0.2"
-    loader-runner "^2.4.0"
-    loader-utils "^1.2.3"
-    memory-fs "^0.4.1"
-    micromatch "^3.1.10"
-    mkdirp "^0.5.3"
-    neo-async "^2.6.1"
-    node-libs-browser "^2.2.1"
-    schema-utils "^1.0.0"
-    tapable "^1.1.3"
-    terser-webpack-plugin "^1.4.3"
-    watchpack "^1.7.4"
-    webpack-sources "^1.4.1"
-
-webpack@4.42.0:
+webpack@4, webpack@4.42.0:
   version "4.42.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.42.0.tgz#b901635dd6179391d90740a63c93f76f39883eb8"
   integrity sha512-EzJRHvwQyBiYrYqhyjW9AqM90dE4+s1/XtCfn7uWg6cS72zH+2VPFAlsnW0+W0cDi0XRjNKUMoJtpSi50+Ph6w==


### PR DESCRIPTION
Fixes: #2739

Wrapping up this round with updating some small libraries and cleaning up dependency related sections in each package.json
ky couldn't be updated as it caused errors with Jest, even with ky 0.25
Unexpectedly webpack 4.46.0 was still in the yarn.lock, removed manually.