### PR TITLE
fix: E2ETest failure

### DIFF
--- a/standalone/src/test/java/io/atlasmap/standalone/E2ETest.java
+++ b/standalone/src/test/java/io/atlasmap/standalone/E2ETest.java
@@ -130,7 +130,7 @@ public class E2ETest {
             "user-field-action-io.atlasmap.service.my.MyFieldActionsModel-transformation-0"));
         assertEquals("testparam", customActionParamInput.getAttribute("value"));
         // Check custom source class mapping
-        WebElement customClassDoc = driver.findElement(By.xpath("//article[@aria-label='io.atlasmap.service.my.MyFieldActionsModel']"));
+        WebElement customClassDoc = driver.findElement(By.xpath("//article[@aria-label='MyFieldActionsModel']"));
         WebElement paramDiv = customClassDoc.findElement(By.xpath(".//button[@data-testid='grip-param-button']/../../../.."));
         action = new Actions(driver);
         action.moveToElement(paramDiv).perform();

--- a/ui/packages/atlasmap-core/src/services/document-management.service.ts
+++ b/ui/packages/atlasmap-core/src/services/document-management.service.ts
@@ -372,7 +372,7 @@ export class DocumentManagementService {
     parameters?: { [key: string]: string }
   ): Promise<boolean> {
     if (docType === DocumentType.JAVA) {
-      return this.addJavaDocument(docName, isSource);
+      return this.addJavaDocument(docId, isSource);
     }
     return this.addNonJavaDocument(
       docBody,

--- a/ui/packages/atlasmap-core/src/utils/document-inspection-util.ts
+++ b/ui/packages/atlasmap-core/src/utils/document-inspection-util.ts
@@ -88,6 +88,8 @@ export class DocumentInspectionUtil {
     const model: DocumentInitializationModel =
       new DocumentInitializationModel();
     model.id = className;
+    const simpleName = className.split('.').pop();
+    model.name = simpleName ? simpleName : '';
     model.type = DocumentType.JAVA;
     model.inspectionType = InspectionType.JAVA_CLASS;
     model.inspectionSource = className;


### PR DESCRIPTION
Fixes: #2925
It turned out the FQDN was used as a Document label for Java Document, and somehow changed to simple name after refactoring. Using simple name as a Document display name is right (#2919), but it might be better to use Document ID for data-testid to be unique (#2928).