### PR TITLE
chore: Add chromatic ignore for NodesArc story

### DIFF
--- a/ui/packages/atlasmap/src/UI/Canvas/NodesArc.stories.tsx
+++ b/ui/packages/atlasmap/src/UI/Canvas/NodesArc.stories.tsx
@@ -32,8 +32,11 @@ import { animated, useSpring } from 'react-spring';
 import PrintNodeRef from './PrintNodeRef';
 
 const obj = {
-  title: 'Canvas',
+  title: 'UI|Canvas/NodesArc',
   includeStories: [], // or don't load this file at all
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };
 export default obj;
 


### PR DESCRIPTION
It seems the animation causes snapshot check to emit false positive
https://www.chromatic.com/docs/ignoring-elements