### PR TITLE
fix: Add jandex index for atlasmap model beans discovery

### DIFF
--- a/lib/model/pom.xml
+++ b/lib/model/pom.xml
@@ -30,6 +30,10 @@
 
   <properties>
     <osgi.export.pkg>io.atlasmap.v2</osgi.export.pkg>
+    <!-- override include resource to include the jandex resource -->
+    <osgi.include.resource.atlasmap>${osgi.include.resource},META-INF/jandex.idx=target/classes/META-INF/jandex.idx</osgi.include.resource.atlasmap>
+    <!-- override skipping jandex maven plugin -->
+    <jandex.skip>false</jandex.skip>
   </properties>
 
   <dependencies>

--- a/lib/modules/csv/model/pom.xml
+++ b/lib/modules/csv/model/pom.xml
@@ -30,6 +30,10 @@
 
   <properties>
     <osgi.export.pkg>io.atlasmap.csv.v2</osgi.export.pkg>
+    <!-- override include resource to include the jandex resource -->
+    <osgi.include.resource.atlasmap>${osgi.include.resource},META-INF/jandex.idx=target/classes/META-INF/jandex.idx</osgi.include.resource.atlasmap>
+    <!-- override skipping jandex maven plugin -->
+    <jandex.skip>false</jandex.skip>
   </properties>
 
   <dependencies>

--- a/lib/modules/dfdl/model/pom.xml
+++ b/lib/modules/dfdl/model/pom.xml
@@ -32,6 +32,10 @@
 
   <properties>
     <osgi.export.pkg>io.atlasmap.dfdl.v2</osgi.export.pkg>
+    <!-- override include resource to include the jandex resource -->
+    <osgi.include.resource.atlasmap>${osgi.include.resource},META-INF/jandex.idx=target/classes/META-INF/jandex.idx</osgi.include.resource.atlasmap>
+    <!-- override skipping jandex maven plugin -->
+    <jandex.skip>false</jandex.skip>
   </properties>
 
   <dependencies>

--- a/lib/modules/java/model/pom.xml
+++ b/lib/modules/java/model/pom.xml
@@ -30,6 +30,10 @@
 
   <properties>
     <osgi.export.pkg>io.atlasmap.java.v2</osgi.export.pkg>
+    <!-- override include resource to include the jandex resource -->
+    <osgi.include.resource.atlasmap>${osgi.include.resource},META-INF/jandex.idx=target/classes/META-INF/jandex.idx</osgi.include.resource.atlasmap>
+    <!-- override skipping jandex maven plugin -->
+    <jandex.skip>false</jandex.skip>
   </properties>
 
   <dependencies>

--- a/lib/modules/json/model/pom.xml
+++ b/lib/modules/json/model/pom.xml
@@ -32,6 +32,10 @@
 
   <properties>
     <osgi.export.pkg>io.atlasmap.json.v2</osgi.export.pkg>
+    <!-- override include resource to include the jandex resource -->
+    <osgi.include.resource.atlasmap>${osgi.include.resource},META-INF/jandex.idx=target/classes/META-INF/jandex.idx</osgi.include.resource.atlasmap>
+    <!-- override skipping jandex maven plugin -->
+    <jandex.skip>false</jandex.skip>
   </properties>
 
   <dependencies>

--- a/lib/modules/xml/model/pom.xml
+++ b/lib/modules/xml/model/pom.xml
@@ -32,6 +32,10 @@
 
   <properties>
     <osgi.export.pkg>io.atlasmap.xml.v2</osgi.export.pkg>
+    <!-- override include resource to include the jandex resource -->
+    <osgi.include.resource.atlasmap>${osgi.include.resource},META-INF/jandex.idx=target/classes/META-INF/jandex.idx</osgi.include.resource.atlasmap>
+    <!-- override skipping jandex maven plugin -->
+    <jandex.skip>false</jandex.skip>
   </properties>
 
   <dependencies>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -45,7 +45,9 @@
     <jackson.databind.version>2.12.3</jackson.databind.version>
     <jackson.version.range>[2.6,3)</jackson.version.range>
     <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+    <jandex.skip>true</jandex.skip>
     <java.version>1.8</java.version>
+    <jandex-maven-plugin.version>1.1.0</jandex-maven-plugin.version>
     <javacc-maven-plugin.version>2.6</javacc-maven-plugin.version>
     <javax.activation.version>1.1.1</javax.activation.version>
     <javax.ws.rs.version>2.1.1</javax.ws.rs.version>
@@ -72,6 +74,7 @@
     <mockito.version>3.11.1</mockito.version>
     <okhttp.version>4.9.1</okhttp.version>
     <openapi-generator-maven-plugin.version>5.1.1</openapi-generator-maven-plugin.version>
+    <osgi.include.resource.atlasmap>${osgi.include.resource}</osgi.include.resource.atlasmap>
     <osgi.symbolic.name>${project.artifactId}</osgi.symbolic.name>
     <osgi.import.pkg>*</osgi.import.pkg>
     <resteasy-spring-boot-starter.version>4.8.0.Final</resteasy-spring-boot-starter.version>
@@ -797,7 +800,7 @@
             <Implementation-Version>${project.version}</Implementation-Version>
             <Embed-Dependency>${osgi.embed.dependency}</Embed-Dependency>
             <Embed-Transitive>${osgi.embed.transitive}</Embed-Transitive>
-            <Include-Resource>${osgi.include.resource}</Include-Resource>
+            <Include-Resource>${osgi.include.resource.atlasmap}</Include-Resource>
           </instructions>
         </configuration>
       </plugin>
@@ -809,6 +812,22 @@
           <!-- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925 -->
           <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jboss.jandex</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+        <version>${jandex-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>make-index</id>
+            <goals>
+              <goal>jandex</goal>
+            </goals>
+            <configuration>
+              <skip>${jandex.skip}</skip>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Fixes: #2721

FYI, if I put this configuration in `parent/pom.xml`:  
`<Include-Resource>${osgi.include.resource},META-INF/jandex.idx=target/classes/META-INF/jandex.idx</Include-Resource>`

The build doesn't work for modules that don't have the jandex.idx. This is the reason why I've overwrote this maven plugin section everywhere, I've created the jandex.
If you have an idea of how I can improve this, let me know.