### PR TITLE
fix: scope is missing in property field path

### DIFF
--- a/lib/service/src/test/java/io/atlasmap/service/AtlasServiceTest.java
+++ b/lib/service/src/test/java/io/atlasmap/service/AtlasServiceTest.java
@@ -44,6 +44,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
 import io.atlasmap.v2.AtlasMapping;
+import io.atlasmap.v2.Audit;
+import io.atlasmap.v2.Audits;
 import io.atlasmap.v2.BaseMapping;
 import io.atlasmap.v2.Field;
 import io.atlasmap.v2.FieldGroup;
@@ -209,6 +211,7 @@ public class AtlasServiceTest {
         Response res = service.processMappingRequest(this.getClass().getClassLoader().getResourceAsStream("mappings/process-mapping-request.json"),
                 generateTestUriInfo("http://localhost:8686/v2/atlas", "http://localhost:8686/v2/atlas/mapping/process"));
         ProcessMappingResponse resp = Json.mapper().readValue((byte[])res.getEntity(), ProcessMappingResponse.class);
+        assertEquals(printAudit(resp.getAudits()), 0, resp.getAudits().getAudit().size());
         FieldGroup group = (FieldGroup) resp.getMapping().getOutputField().get(0);
         assertEquals("/addressList<>/city", group.getPath());
         Field f = group.getField().get(0);
@@ -216,8 +219,31 @@ public class AtlasServiceTest {
         assertEquals("testZzz", f.getValue());
     }
 
+    @Test
+    public void testProcessMapping2977() throws Exception {
+        Response res = service.processMappingRequest(this.getClass().getClassLoader().getResourceAsStream("mappings/process-mapping-request-2977.json"),
+                generateTestUriInfo("http://localhost:8686/v2/atlas", "http://localhost:8686/v2/atlas/mapping/process"));
+        ProcessMappingResponse resp = Json.mapper().readValue((byte[])res.getEntity(), ProcessMappingResponse.class);
+        assertEquals(printAudit(resp.getAudits()), 0, resp.getAudits().getAudit().size());
+        Field field = resp.getMapping().getOutputField().get(0);
+        assertEquals("/ns:XmlOE/ns:Address/ns:addressLine1", field.getPath());
+        assertEquals("Boston", field.getValue());
+    }
+
     protected UriInfo generateTestUriInfo(String baseUri, String absoluteUri) throws Exception {
         return new TestUriInfo(new URI(baseUri), new URI(absoluteUri));
+    }
+
+    protected String printAudit(Audits audits) {
+        StringBuilder buf = new StringBuilder("Audits: ");
+        for (Audit a : audits.getAudit()) {
+            buf.append('[');
+            buf.append(a.getStatus());
+            buf.append(", message=");
+            buf.append(a.getMessage());
+            buf.append("], ");
+        }
+        return buf.toString();
     }
 
 }

--- a/lib/service/src/test/resources/mappings/process-mapping-request-2977.json
+++ b/lib/service/src/test/resources/mappings/process-mapping-request-2977.json
@@ -1,0 +1,76 @@
+{
+  "ProcessMappingRequest": {
+    "jsonType": "io.atlasmap.v2.ProcessMappingRequest",
+    "mapping": {
+      "jsonType": "io.atlasmap.v2.Mapping",
+      "expression": "if ( ${DOC.Properties.578580:/JSONSchemaSource/prop-city} == ${DOC.Constants.10788:/Boston}, ${JSONInstanceSource:/order/address/city}, ${JSONInstanceSource:/order/address/state})",
+      "inputFieldGroup": {
+        "jsonType": "io.atlasmap.v2.FieldGroup",
+        "actions": [],
+        "field": [
+          {
+            "jsonType": "io.atlasmap.v2.PropertyField",
+            "value": "Boston",
+            "docId": "DOC.Properties.578580",
+            "index": 0,
+            "path": "/JSONSchemaSource/prop-city",
+            "fieldType": "STRING",
+            "name": "prop-city",
+            "scope": "JSONSchemaSource"
+          },
+          {
+            "jsonType": "io.atlasmap.v2.ConstantField",
+            "value": "Boston",
+            "docId": "DOC.Constants.10788",
+            "index": 1,
+            "path": "/Boston",
+            "fieldType": "STRING",
+            "name": "Boston"
+          },
+          {
+            "jsonType": "io.atlasmap.json.v2.JsonField",
+            "value": "Boston",
+            "docId": "JSONInstanceSource",
+            "index": 2,
+            "path": "/order/address/city",
+            "fieldType": "STRING",
+            "name": "city"
+          },
+          {
+            "jsonType": "io.atlasmap.json.v2.JsonField",
+            "value": "Massachusetts",
+            "docId": "JSONInstanceSource",
+            "index": 3,
+            "path": "/order/address/state",
+            "fieldType": "STRING",
+            "name": "state"
+          }
+        ]
+      },
+      "inputField": [],
+      "outputField": [
+        {
+          "jsonType": "io.atlasmap.xml.v2.XmlField",
+          "actions": [
+            {
+              "string": "RESULT",
+              "@type": "Append"
+            },
+            {
+              "string": "",
+              "@type": "Append"
+            }
+          ],
+          "value": "",
+          "docId": "XMLInstanceSource",
+          "path": "/ns:XmlOE/ns:Address/ns:addressLine1",
+          "fieldType": "STRING",
+          "name": "addressLine1",
+          "userCreated": false,
+          "attribute": false
+        }
+      ],
+      "id": "preview"
+    }
+  }
+}

--- a/ui/packages/atlasmap-core/src/contracts/common.ts
+++ b/ui/packages/atlasmap-core/src/contracts/common.ts
@@ -14,8 +14,10 @@
     limitations under the License.
 */
 
-export const modelPackagePrefix = 'io.atlasmap.v2';
-export const dataSourceJsonType = modelPackagePrefix + '.DataSource';
+export const FIELD_PATH_SEPARATOR = '/';
+
+export const MODEL_PACKAGE_PREFIX = 'io.atlasmap.v2';
+export const DATA_SOURCE_JSON_TYPE = MODEL_PACKAGE_PREFIX + '.DataSource';
 
 /** SOURCE or TARGET. */
 export enum DataSourceType {

--- a/ui/packages/atlasmap-core/src/contracts/documents/java.ts
+++ b/ui/packages/atlasmap-core/src/contracts/documents/java.ts
@@ -18,11 +18,12 @@ import { CollectionType, IField, IStringList } from '../common';
 /**
  * The Java class inspection data model contracts between frontend and backend.
  */
-export const javaModelPackagePrefix = 'io.atlasmap.java.v2';
-export const javaInspectionRequestJsonType =
-  javaModelPackagePrefix + '.ClassInspectionRequest';
-export const javaClassJsonType = javaModelPackagePrefix + '.JavaClass';
-export const javaEnumFieldJsonType = javaModelPackagePrefix + '.JavaEnumField';
+export const JAVA_MODEL_PACKAGE_PREFIX = 'io.atlasmap.java.v2';
+export const JAVA_INSPECTION_REQUEST_JSON_TYPE =
+  JAVA_MODEL_PACKAGE_PREFIX + '.ClassInspectionRequest';
+export const JAVA_CLASS_JSON_TYPE = JAVA_MODEL_PACKAGE_PREFIX + '.JavaClass';
+export const JAVA_ENUM_FIELD_JSON_TYPE =
+  JAVA_MODEL_PACKAGE_PREFIX + '.JavaEnumField';
 
 /**
  * The root object that carries {@link IClassInspectionRequest}

--- a/ui/packages/atlasmap-core/src/contracts/documents/json.ts
+++ b/ui/packages/atlasmap-core/src/contracts/documents/json.ts
@@ -19,12 +19,13 @@ import { IDocument, IField, IStringList, InspectionType } from '../common';
 /**
  * The JSON inspection data model contracts between frontend and backend.
  */
-export const jsonModelPackagePrefix = 'io.atlasmap.json.v2';
-export const jsonDataSourceJsonType =
-  jsonModelPackagePrefix + '.JsonDataSource';
-export const jsonEnumFieldJsonType = jsonModelPackagePrefix + '.JsonEnumField';
-export const jsonInspectionRequestJsonType =
-  jsonModelPackagePrefix + '.JsonInspectionRequest';
+export const JSON_MODEL_PACKAGE_PREFIX = 'io.atlasmap.json.v2';
+export const JSON_DATA_SOURCE_JSON_TYPE =
+  JSON_MODEL_PACKAGE_PREFIX + '.JsonDataSource';
+export const JSON_ENUM_FIELD_JSON_TYPE =
+  JSON_MODEL_PACKAGE_PREFIX + '.JsonEnumField';
+export const JSON_INSPECTION_REQUEST_JSON_TYPE =
+  JSON_MODEL_PACKAGE_PREFIX + '.JsonInspectionRequest';
 
 /**
  * The root object that carries {@link IJsonInspectionRequest}

--- a/ui/packages/atlasmap-core/src/contracts/documents/xml.ts
+++ b/ui/packages/atlasmap-core/src/contracts/documents/xml.ts
@@ -20,11 +20,13 @@ import { IDataSource, IDocument, IField } from '../common';
  * The XML inspection data model contracts between frontend and backend.
  */
 
-export const xmlModelPackagePrefix = 'io.atlasmap.xml.v2';
-export const xmlDataSourceJsonType = xmlModelPackagePrefix + '.XmlDataSource';
-export const xmlEnumFieldJsonType = xmlModelPackagePrefix + '.XmlEnumField';
-export const xmlInspectionRequestJsonType =
-  xmlModelPackagePrefix + '.XmlInspectionRequest';
+export const XML_MODEL_PACKAGE_PREFIX = 'io.atlasmap.xml.v2';
+export const XML_DATA_SOURCE_JSON_TYPE =
+  XML_MODEL_PACKAGE_PREFIX + '.XmlDataSource';
+export const XML_ENUM_FIELD_JSON_TYPE =
+  XML_MODEL_PACKAGE_PREFIX + '.XmlEnumField';
+export const XML_INSPECTION_REQUEST_JSON_TYPE =
+  XML_MODEL_PACKAGE_PREFIX + '.XmlInspectionRequest';
 
 /**
  * The root object that carries {@link IXmlInspectionResponse}

--- a/ui/packages/atlasmap-core/src/contracts/mapping-preview.ts
+++ b/ui/packages/atlasmap-core/src/contracts/mapping-preview.ts
@@ -14,14 +14,14 @@
     limitations under the License.
 */
 import { IMapping } from './mapping';
-import { modelPackagePrefix } from './common';
+import { MODEL_PACKAGE_PREFIX } from './common';
 
 /**
  * The mapping Data model contracts between frontend and backend.
  */
 
-export const processMappingRequestJsonType =
-  modelPackagePrefix + '.ProcessMappingRequest';
+export const PROCESS_MAPPING_REQUEST_JSON_TYPE =
+  MODEL_PACKAGE_PREFIX + '.ProcessMappingRequest';
 
 /**
  * The root object that carries {@link IProcessMappingRequest}

--- a/ui/packages/atlasmap-core/src/contracts/mapping.ts
+++ b/ui/packages/atlasmap-core/src/contracts/mapping.ts
@@ -19,19 +19,19 @@ import {
   FieldType,
   IDataSource,
   IField,
-  modelPackagePrefix,
+  MODEL_PACKAGE_PREFIX,
 } from './common';
 
 /**
  * The mapping Data model contracts between frontend and backend.
  */
 
-export const atlasMappingJsonType = modelPackagePrefix + '.AtlasMapping';
-export const mappingJsonType = modelPackagePrefix + '.Mapping';
-export const collectionJsonType = modelPackagePrefix + '.Collection';
-export const fieldGroupJsonType = modelPackagePrefix + '.FieldGroup';
-export const propertyFieldJsonType = modelPackagePrefix + '.PropertyField';
-export const constantFieldJsonType = modelPackagePrefix + '.ConstantField';
+export const ATLAS_MAPPING_JSON_TYPE = MODEL_PACKAGE_PREFIX + '.AtlasMapping';
+export const MAPPING_JSON_TYPE = MODEL_PACKAGE_PREFIX + '.Mapping';
+export const COLLECTION_JSON_TYPE = MODEL_PACKAGE_PREFIX + '.Collection';
+export const FIELD_GROUP_JSON_TYPE = MODEL_PACKAGE_PREFIX + '.FieldGroup';
+export const PROPERTY_FIELD_JSON_TYPE = MODEL_PACKAGE_PREFIX + '.PropertyField';
+export const CONSTANT_FIELD_JSON_TYPE = MODEL_PACKAGE_PREFIX + '.ConstantField';
 
 /**
  * The root object that carries {@link IAtlasMapping}

--- a/ui/packages/atlasmap-core/src/models/config.model.ts
+++ b/ui/packages/atlasmap-core/src/models/config.model.ts
@@ -236,31 +236,7 @@ export class ConfigModel {
     const docs: DocumentDefinition[] = this.getDocsWithoutPropertyDoc(isSource);
     return isSource
       ? [this.sourcePropertyDoc, this.constantDoc].concat(docs)
-      : [this.targetPropertyDoc, this.constantDoc].concat(docs);
-  }
-
-  /**
-   * Return a uri:DocumentDefinition document map for either the sources or targets panel contents.
-   *
-   * @param cfg
-   * @param isSource
-   */
-  getDocUriMap(
-    cfg: ConfigModel,
-    isSource: boolean
-  ): { [key: string]: DocumentDefinition } | null {
-    const docMap: { [key: string]: DocumentDefinition } = {};
-    let docFound = false;
-    for (const doc of cfg.getDocs(isSource)) {
-      if (doc.uri) {
-        docMap[doc.uri] = doc;
-        docFound = true;
-      }
-    }
-    if (docFound) {
-      return docMap;
-    }
-    return null;
+      : [this.targetPropertyDoc].concat(docs);
   }
 
   /**

--- a/ui/packages/atlasmap-core/src/models/field.model.ts
+++ b/ui/packages/atlasmap-core/src/models/field.model.ts
@@ -13,7 +13,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-import { DocumentType, FieldType, IField } from '../contracts/common';
+import {
+  DocumentType,
+  FIELD_PATH_SEPARATOR,
+  FieldType,
+  IField,
+} from '../contracts/common';
 import { DocumentDefinition } from './document-definition.model';
 
 export class EnumValue {
@@ -88,19 +93,9 @@ export class Field {
     return paths;
   }
 
-  static getField(
-    fieldPath: string,
-    fields: Field[],
-    fieldScope?: string
-  ): Field {
+  static getField(fieldPath: string, fields: Field[]): Field {
     // TODO: check this non null operator
-    return fields.find(
-      (field) =>
-        fieldPath === field.path &&
-        (fieldScope
-          ? fieldScope.length > 0 && fieldScope === field.scope
-          : true)
-    )!;
+    return fields.find((field) => fieldPath === field.path)!;
   }
 
   static alphabetizeFields(fields: Field[]): void {
@@ -108,9 +103,6 @@ export class Field {
     const fieldPaths: string[] = [];
     for (const field of fields) {
       let fieldKey = field.path;
-      if (field.scope) {
-        fieldKey += '-' + field.scope;
-      }
       // Discard duplicate field keys, field names are repeatable.
       if (fieldsByPath[fieldKey] != null) {
         continue;
@@ -251,7 +243,7 @@ export class Field {
     if (includePath) {
       fieldPath = this.path;
     } else {
-      const pathComps = this.path.split(this.docDef.pathSeparator);
+      const pathComps = this.path.split(FIELD_PATH_SEPARATOR);
       // Check for a leaf path attribute field starting with '@'
       if (
         this.isAttribute &&

--- a/ui/packages/atlasmap-core/src/models/inspect/java-inspection.model.ts
+++ b/ui/packages/atlasmap-core/src/models/inspect/java-inspection.model.ts
@@ -27,7 +27,7 @@ import {
   IJavaClass,
   IJavaClassContainer,
   IJavaField,
-  javaInspectionRequestJsonType,
+  JAVA_INSPECTION_REQUEST_JSON_TYPE,
 } from '../../contracts/documents/java';
 
 import { ConfigModel } from '../config.model';
@@ -152,7 +152,7 @@ export class JavaInspectionRequestOptions extends DocumentInspectionRequestOptio
     super(cfg, doc);
     const request: IClassInspectionRequestContainer = {
       ClassInspectionRequest: {
-        jsonType: javaInspectionRequestJsonType,
+        jsonType: JAVA_INSPECTION_REQUEST_JSON_TYPE,
         className: this.doc.inspectionSource,
         disablePrivateOnlyFields: this.cfg.initCfg.disablePrivateOnlyFields,
         disableProtectedOnlyFields: this.cfg.initCfg.disableProtectedOnlyFields,

--- a/ui/packages/atlasmap-core/src/models/inspect/json-inspection.model.ts
+++ b/ui/packages/atlasmap-core/src/models/inspect/json-inspection.model.ts
@@ -27,7 +27,7 @@ import {
   IJsonField,
   IJsonInspectionResponse,
   IJsonInspectionResponseContainer,
-  jsonInspectionRequestJsonType,
+  JSON_INSPECTION_REQUEST_JSON_TYPE,
 } from '../../contracts/documents/json';
 import { FieldType } from '../../contracts/common';
 
@@ -136,7 +136,7 @@ export class JsonInspectionRequestModel extends DocumentInspectionRequestModel {
 export class JsonInspectionRequestOptions extends DocumentInspectionRequestOptions {
   json = {
     JsonInspectionRequest: {
-      jsonType: jsonInspectionRequestJsonType,
+      jsonType: JSON_INSPECTION_REQUEST_JSON_TYPE,
       type: this.doc.inspectionType,
       jsonData: this.doc.inspectionSource,
     },

--- a/ui/packages/atlasmap-core/src/models/inspect/xml-inspection.model.ts
+++ b/ui/packages/atlasmap-core/src/models/inspect/xml-inspection.model.ts
@@ -28,7 +28,7 @@ import {
   IXmlField,
   IXmlInspectionResponse,
   IXmlInspectionResponseContainer,
-  xmlInspectionRequestJsonType,
+  XML_INSPECTION_REQUEST_JSON_TYPE,
 } from '../../contracts/documents/xml';
 import { NamespaceModel } from '../document-definition.model';
 
@@ -161,7 +161,7 @@ export class XmlInspectionRequestModel extends DocumentInspectionRequestModel {
 export class XmlInspectionRequestOptions extends DocumentInspectionRequestOptions {
   json = {
     XmlInspectionRequest: {
-      jsonType: xmlInspectionRequestJsonType,
+      jsonType: XML_INSPECTION_REQUEST_JSON_TYPE,
       type: this.doc.inspectionType,
       xmlData: this.doc.inspectionSource,
     },

--- a/ui/packages/atlasmap-core/src/models/mapping.model.ts
+++ b/ui/packages/atlasmap-core/src/models/mapping.model.ts
@@ -203,21 +203,19 @@ export class MappingModel {
   }
 
   /**
-   * Return the MappedField associated with the specified field path and panel.  The
-   * document ID and field scope are optional identifier parameters used to distinguish
-   * duplicate field paths.
+   * Return the MappedField associated with the specified field path and panel. The
+   * document ID is optional identifier parameters used to distinguish the fields
+   * with the same path in a different document. The first match will be returned
+   * if not specified.
    *
    * @param fieldPath
    * @param isSource
    * @param identifier
    */
-  getMappedFieldByName(
+  getMappedFieldByPath(
     fieldPath: string,
     isSource: boolean,
-    identifier: {
-      docId?: string;
-      fieldScope?: string;
-    }
+    docId?: string
   ): MappedField | null {
     if (!fieldPath) {
       return null;
@@ -225,19 +223,10 @@ export class MappingModel {
     const mappedFields = this.getMappedFields(isSource);
     for (let i = 0; i < mappedFields.length; i++) {
       if (mappedFields[i].field?.path === fieldPath) {
-        if (!identifier.docId && !identifier.fieldScope) {
+        if (!docId) {
           return mappedFields[i];
         }
-        if (
-          identifier.docId &&
-          mappedFields[i].field?.docDef.id === identifier.docId
-        ) {
-          return mappedFields[i];
-        }
-        if (
-          identifier.fieldScope &&
-          mappedFields[i].field?.scope === identifier.fieldScope
-        ) {
+        if (docId && mappedFields[i].field?.docDef.id === docId) {
           return mappedFields[i];
         }
       }
@@ -289,6 +278,7 @@ export class MappingModel {
       return null;
     }
     if (
+      !field.documentField?.status ||
       field.documentField?.status === 'SUPPORTED' ||
       field.documentField?.status === 'CACHED'
     ) {

--- a/ui/packages/atlasmap-core/src/services/document-management.service.ts
+++ b/ui/packages/atlasmap-core/src/services/document-management.service.ts
@@ -16,6 +16,7 @@
 import {
   CollectionType,
   DocumentType,
+  FIELD_PATH_SEPARATOR,
   InspectionType,
 } from '../contracts/common';
 import {
@@ -512,6 +513,15 @@ export class DocumentManagementService {
       }
     }
     cfg.mappingService.notifyLineRefresh();
+  }
+
+  getPropertyPath(scope: string | undefined | null, name: string) {
+    let answer = FIELD_PATH_SEPARATOR;
+    if (scope && scope.length > 0) {
+      answer += scope + FIELD_PATH_SEPARATOR;
+    }
+    answer += name;
+    return answer;
   }
 
   private markChildrenVisible(field: Field): void {

--- a/ui/packages/atlasmap-core/src/services/file-management.service.spec.ts
+++ b/ui/packages/atlasmap-core/src/services/file-management.service.spec.ts
@@ -28,10 +28,10 @@ import { ErrorLevel } from '../models/error.model';
 import { FileManagementService } from './file-management.service';
 import FileSaver from 'file-saver';
 import { InitializationService } from './initialization.service';
+import { MAPPING_JSON_TYPE } from '../contracts/mapping';
 import fs from 'fs';
 import ky from 'ky/umd';
 import log from 'loglevel';
-import { mappingJsonType } from '../contracts/mapping';
 import { mocked } from 'ts-jest/utils';
 import pako from 'pako';
 
@@ -267,7 +267,7 @@ describe('FileManagementService', () => {
         }
       })()
     );
-    const mappingJson = { AtlasMapping: { jsonType: mappingJsonType } };
+    const mappingJson = { AtlasMapping: { jsonType: MAPPING_JSON_TYPE } };
     service
       .setMappingToService(mappingJson)
       .then((value) => {
@@ -287,7 +287,7 @@ describe('FileManagementService', () => {
         }
       })()
     );
-    const mappingJson = { AtlasMapping: { jsonType: mappingJsonType } };
+    const mappingJson = { AtlasMapping: { jsonType: MAPPING_JSON_TYPE } };
     service
       .setMappingToService(mappingJson)
       .then((value) => {

--- a/ui/packages/atlasmap-core/src/services/mapping-expression.service.ts
+++ b/ui/packages/atlasmap-core/src/services/mapping-expression.service.ts
@@ -129,20 +129,17 @@ export class MappingExpressionService {
 
   addField(
     mapping: MappingModel,
-    fieldName: string,
-    fieldScope: string,
+    fieldPath: string,
     newTextNode: IExpressionNode,
     atIndex: number,
     isTrailer: boolean
   ) {
-    let mappedField = mapping.getMappedFieldByName(fieldName, true, {
-      fieldScope: fieldScope,
-    });
+    let mappedField = mapping.getMappedFieldByPath(fieldPath, true);
 
     if (!mappedField) {
       // If the selected field was not part of the original mapping
       // and is complex then add it as a reference node.
-      mappedField = mapping.getReferenceField(fieldName);
+      mappedField = mapping.getReferenceField(fieldPath);
 
       if (mappedField) {
         mapping.transition!.expression!.addConditionalExpressionNode(
@@ -154,7 +151,7 @@ export class MappingExpressionService {
       // Try adding the selected field to the active mapping.
       let field: Field | null = null;
       for (const doc of this.cfg.getDocs(true)) {
-        field = Field.getField(fieldName, doc.getAllFields(), fieldScope);
+        field = Field.getField(fieldPath, doc.getAllFields());
         if (field) {
           break;
         }
@@ -231,11 +228,7 @@ export class MappingExpressionService {
         }
         displayName = CommonUtil.extractDisplayPath(field.path, 100);
         formattedField[0] = displayName;
-        if (field.isProperty() && field.scope) {
-          formattedField[1] = field.path + ' <' + field.scope + '>';
-        } else {
-          formattedField[1] = field.path;
-        }
+        formattedField[1] = field.path;
         fieldCount++;
         formattedFields.push(formattedField);
       }

--- a/ui/packages/atlasmap-core/src/services/mapping-preview.service.ts
+++ b/ui/packages/atlasmap-core/src/services/mapping-preview.service.ts
@@ -22,7 +22,7 @@ import {
 import {
   IProcessMappingRequestContainer,
   IProcessMappingResponseContainer,
-  processMappingRequestJsonType,
+  PROCESS_MAPPING_REQUEST_JSON_TYPE,
 } from '../contracts/mapping-preview';
 import { Subject, Subscription } from 'rxjs';
 import { ConfigModel } from '../models/config.model';
@@ -128,7 +128,7 @@ export class MappingPreviewService {
   ): IProcessMappingRequestContainer {
     return {
       ProcessMappingRequest: {
-        jsonType: processMappingRequestJsonType,
+        jsonType: PROCESS_MAPPING_REQUEST_JSON_TYPE,
         mapping: MappingSerializer.serializeFieldMapping(
           this.cfg,
           inputFieldMapping,
@@ -156,7 +156,7 @@ export class MappingPreviewService {
         ) {
           // TODO let field component subscribe mappingPreviewOutputSource instead of doing this
           // TODO: check this non null operator
-          toWrite.field!.value = toRead.field?.value!;
+          toWrite.field!.value = toRead.mappingField?.value!;
           const index = answer.targetFields.indexOf(toRead);
           if (index !== -1) {
             answer.targetFields.splice(index, 1);

--- a/ui/packages/atlasmap-core/src/utils/mapping-serializer.spec.ts
+++ b/ui/packages/atlasmap-core/src/utils/mapping-serializer.spec.ts
@@ -635,7 +635,7 @@ describe('MappingSerializer', () => {
         expect(
           TestUtils.isEqualJSON(
             atlasMappingCollExprMapping,
-            MappingSerializer.serializeMappings(cfg) // ignoreValue defaults to true
+            serialized // ignoreValue defaults to true
           )
         ).toBe(true);
 

--- a/ui/packages/atlasmap-core/src/utils/mapping-util.ts
+++ b/ui/packages/atlasmap-core/src/utils/mapping-util.ts
@@ -14,6 +14,11 @@
     limitations under the License.
 */
 import {
+  CONSTANT_FIELD_JSON_TYPE,
+  IPropertyField,
+  PROPERTY_FIELD_JSON_TYPE,
+} from '../contracts/mapping';
+import {
   DocumentDefinition,
   PaddingField,
 } from '../models/document-definition.model';
@@ -23,11 +28,6 @@ import {
   ErrorScope,
   ErrorType,
 } from '../models/error.model';
-import {
-  IPropertyField,
-  constantFieldJsonType,
-  propertyFieldJsonType,
-} from '../contracts/mapping';
 import { MappedField, MappingModel } from '../models/mapping.model';
 import { ConfigModel } from '../models/config.model';
 import { Field } from '../models/field.model';
@@ -152,19 +152,12 @@ with ID ${mappedField.mappingField.docId}`,
           mappedField.mappingField.path
         ) {
           const propMappingField = mappedField.mappingField as IPropertyField;
-          const parsedScope = propMappingField.scope
-            ? propMappingField.scope
-            : undefined;
-          let propertyField = doc.getField(propMappingField.path!, parsedScope);
+          let propertyField = doc.getField(propMappingField.path!);
 
           if (!propertyField) {
             propertyField = new Field();
           }
-          const lastSeparator: number = propMappingField.name!.lastIndexOf('/');
-          let fieldName =
-            lastSeparator === -1
-              ? propMappingField.name
-              : propMappingField.name!.substring(lastSeparator + 1);
+          let fieldName = propMappingField.name;
           propertyField.type = propMappingField.fieldType!;
           if (propMappingField.scope) {
             propertyField.scope = propMappingField.scope;
@@ -348,10 +341,10 @@ with ID ${mappedField.mappingField.docId}`,
   }
 
   static isPropertyField(field: IField) {
-    return field?.jsonType === propertyFieldJsonType;
+    return field?.jsonType === PROPERTY_FIELD_JSON_TYPE;
   }
 
   static isConstantField(field: IField) {
-    return field?.jsonType === constantFieldJsonType;
+    return field?.jsonType === CONSTANT_FIELD_JSON_TYPE;
   }
 }

--- a/ui/packages/atlasmap/src/Atlasmap/utils/field.ts
+++ b/ui/packages/atlasmap/src/Atlasmap/utils/field.ts
@@ -19,6 +19,7 @@ import {
   ErrorLevel,
   ErrorScope,
   ErrorType,
+  FIELD_PATH_SEPARATOR,
   Field,
   FieldType,
   MappedField,
@@ -60,9 +61,7 @@ export function createConstant(
 
 export function deleteConstant(constName: string): void {
   const cfg = ConfigModel.getConfig();
-  const field = cfg.constantDoc.getField(
-    cfg.sourcePropertyDoc.pathSeparator + constName,
-  );
+  const field = cfg.constantDoc.getField(FIELD_PATH_SEPARATOR + constName);
   if (!field) {
     return;
   }
@@ -84,9 +83,7 @@ export function editConstant(
 ): void {
   const cfg = ConfigModel.getConfig();
   let constFieldName = origName ? origName : constName;
-  let field = cfg.constantDoc.getField(
-    cfg.constantDoc.pathSeparator + constFieldName,
-  );
+  let field = cfg.constantDoc.getField(FIELD_PATH_SEPARATOR + constFieldName);
   if (!field) {
     return;
   }
@@ -98,19 +95,14 @@ export function editConstant(
   }
   if (origName && origName !== constName) {
     field.name = constName;
-    cfg.constantDoc.updateField(
-      field,
-      cfg.constantDoc.pathSeparator + constName,
-    );
+    cfg.constantDoc.updateField(field, FIELD_PATH_SEPARATOR + constName);
   }
   cfg.mappingService.notifyMappingUpdated();
 }
 
 export function getConstantType(constName: string): string {
   const cfg = ConfigModel.getConfig();
-  const field = cfg.constantDoc.getField(
-    cfg.sourcePropertyDoc.pathSeparator + constName,
-  );
+  const field = cfg.constantDoc.getField(FIELD_PATH_SEPARATOR + constName);
   if (!field) {
     return '';
   }
@@ -119,9 +111,7 @@ export function getConstantType(constName: string): string {
 
 export function getConstantTypeIndex(constName: string): number {
   const cfg = ConfigModel.getConfig();
-  const field = cfg.constantDoc.getField(
-    cfg.sourcePropertyDoc.pathSeparator + constName,
-  );
+  const field = cfg.constantDoc.getField(FIELD_PATH_SEPARATOR + constName);
   if (!field) {
     return 0;
   }
@@ -141,21 +131,17 @@ export function createProperty(
   addToActiveMapping?: boolean,
 ): void {
   const cfg = ConfigModel.getConfig();
+  const path = cfg.documentService.getPropertyPath(propScope, propName);
   let field = isSource
-    ? cfg.sourcePropertyDoc.getField(
-        cfg.sourcePropertyDoc.pathSeparator + propName,
-        propScope,
-      )
-    : cfg.targetPropertyDoc.getField(
-        cfg.sourcePropertyDoc.pathSeparator + propName,
-        propScope,
-      );
+    ? cfg.sourcePropertyDoc.getField(path)
+    : cfg.targetPropertyDoc.getField(path);
   if (!field) {
     field = new Field();
   }
   field.name = propName;
   field.type = FieldType[propType as keyof typeof FieldType];
   field.scope = propScope;
+  field.path = path;
   field.userCreated = true;
 
   if (isSource) {
@@ -177,15 +163,10 @@ export function deleteProperty(
   isSource: boolean,
 ): void {
   const cfg = ConfigModel.getConfig();
+  const path = cfg.documentService.getPropertyPath(propScope, propName);
   const field = isSource
-    ? cfg.sourcePropertyDoc.getField(
-        cfg.sourcePropertyDoc.pathSeparator + propName,
-        propScope,
-      )
-    : cfg.targetPropertyDoc.getField(
-        cfg.sourcePropertyDoc.pathSeparator + propName,
-        propScope,
-      );
+    ? cfg.sourcePropertyDoc.getField(path)
+    : cfg.targetPropertyDoc.getField(path);
   if (!field) {
     return;
   }
@@ -223,15 +204,10 @@ export function editProperty(
   newScope?: string,
 ): void {
   const cfg = ConfigModel.getConfig();
+  let oldPath = cfg.documentService.getPropertyPath(propScope, propName);
   let field = isSource
-    ? cfg.sourcePropertyDoc.getField(
-        cfg.sourcePropertyDoc.pathSeparator + propName,
-        propScope,
-      )
-    : cfg.targetPropertyDoc.getField(
-        cfg.targetPropertyDoc.pathSeparator + propName,
-        propScope,
-      );
+    ? cfg.sourcePropertyDoc.getField(oldPath)
+    : cfg.targetPropertyDoc.getField(oldPath);
   if (!field) {
     return;
   }
@@ -242,16 +218,12 @@ export function editProperty(
     field.scope = newScope;
   }
   field.type = FieldType[propType as keyof typeof FieldType];
-  let originalKey = '';
-  if (propScope.length > 0) {
-    originalKey =
-      cfg.targetPropertyDoc.pathSeparator + propName + '-' + propScope;
-  }
+  field.path = cfg.documentService.getPropertyPath(field.scope, field.name!);
 
   if (isSource) {
-    cfg.sourcePropertyDoc.updateField(field, originalKey);
+    cfg.sourcePropertyDoc.updateField(field, oldPath);
   } else {
-    cfg.targetPropertyDoc.updateField(field, originalKey);
+    cfg.targetPropertyDoc.updateField(field, oldPath);
   }
   cfg.mappingService.notifyMappingUpdated();
 }
@@ -264,12 +236,10 @@ export function getPropertyType(
   const cfg = ConfigModel.getConfig();
   const field = isSource
     ? cfg.sourcePropertyDoc.getField(
-        cfg.sourcePropertyDoc.pathSeparator + propName,
-        propScope,
+        cfg.documentService.getPropertyPath(propScope, propName),
       )
     : cfg.targetPropertyDoc.getField(
-        cfg.targetPropertyDoc.pathSeparator + propName,
-        propScope,
+        cfg.documentService.getPropertyPath(propScope, propName),
       );
   if (!field) {
     return '';
@@ -285,12 +255,10 @@ export function getPropertyTypeIndex(
   const cfg = ConfigModel.getConfig();
   const field = isSource
     ? cfg.sourcePropertyDoc.getField(
-        cfg.sourcePropertyDoc.pathSeparator + propName,
-        propScope,
+        cfg.documentService.getPropertyPath(propScope, propName),
       )
     : cfg.targetPropertyDoc.getField(
-        cfg.targetPropertyDoc.pathSeparator + propName,
-        propScope,
+        cfg.documentService.getPropertyPath(propScope, propName),
       );
   if (!field) {
     return 0;

--- a/ui/packages/atlasmap/src/Atlasmap/utils/ui.ts
+++ b/ui/packages/atlasmap/src/Atlasmap/utils/ui.ts
@@ -331,7 +331,6 @@ export function getField(fieldPath: string, isSource: boolean): Field | null {
 
 export function mappingExpressionAddField(
   selectedField: string,
-  selectedFieldScope: string,
   newTextNode: any,
   atIndex: number,
   isTrailer: boolean,
@@ -343,7 +342,6 @@ export function mappingExpressionAddField(
   configModel.expressionService.addField(
     mapping,
     selectedField,
-    selectedFieldScope,
     newTextNode,
     atIndex,
     isTrailer,

--- a/ui/packages/atlasmap/src/UI/ExpressionContent.tsx
+++ b/ui/packages/atlasmap/src/UI/ExpressionContent.tsx
@@ -63,7 +63,6 @@ export interface IExpressionContentProps {
   getFieldEnums: (nodeId: string) => EnumValue[];
   mappingExpressionAddField: (
     selectedField: string,
-    selectFieldScope: string,
     newTextNode: IExpressionNode,
     atIndex: number,
     isTrailer: boolean,
@@ -191,7 +190,6 @@ export const ExpressionContent: FunctionComponent<IExpressionContentProps> = ({
 
   let addFieldToExpression: (
     selectedField: string,
-    selectedScope: string,
     newTextNode: IExpressionNode,
     atIndex: number,
     isTrailer: boolean,
@@ -435,24 +433,7 @@ export const ExpressionContent: FunctionComponent<IExpressionContentProps> = ({
       return;
     }
     const isTrailer = getCaretPositionNodeId(atContainer) === trailerID;
-    const selectedFieldComps = selectedField.split(' ');
-    selectedField = selectedFieldComps[0];
-    let selectedFieldScope = '';
-
-    // Extract the scope if it exists.
-    if (selectedFieldComps[1]) {
-      selectedFieldScope = selectedFieldComps[1].substring(
-        1,
-        selectedFieldComps[1].length - 1,
-      );
-    }
-    addFieldToExpression(
-      selectedField,
-      selectedFieldScope,
-      newTextNode,
-      atIndex,
-      isTrailer,
-    );
+    addFieldToExpression(selectedField, newTextNode, atIndex, isTrailer);
     clearSearchMode(false);
     markup!.focus();
   }

--- a/ui/test-resources/mapping/atlasmapping-coll-expr-mapping.json
+++ b/ui/test-resources/mapping/atlasmapping-coll-expr-mapping.json
@@ -173,7 +173,7 @@
               } ],
               "docId" : "DOC.Properties",
               "index" : 0,
-              "path" : "/prop-city",
+              "path" : "/current/prop-city",
               "fieldType" : "STRING",
               "name" : "prop-city",
               "scope" : "current"

--- a/ui/test-resources/mapping/atlasmapping-coll-expr-preview.json
+++ b/ui/test-resources/mapping/atlasmapping-coll-expr-preview.json
@@ -173,7 +173,7 @@
                 } ],
                 "docId" : "DOC.Properties",
                 "index" : 0,
-                "path" : "/prop-city",
+                "path" : "/current/prop-city",
                 "fieldType" : "STRING",
                 "name" : "prop-city",
                 "scope" : "current"

--- a/ui/test-resources/mapping/atlasmapping-coll-ref-expr-preview.json
+++ b/ui/test-resources/mapping/atlasmapping-coll-ref-expr-preview.json
@@ -180,7 +180,7 @@
               } ],
               "docId" : "DOC.Properties",
               "index" : 0,
-              "path" : "/prop-city",
+              "path" : "/current/prop-city",
               "fieldType" : "STRING",
               "name" : "prop-city",
               "scope" : "current",

--- a/ui/test-resources/mapping/atlasmapping-expr-prop.json
+++ b/ui/test-resources/mapping/atlasmapping-expr-prop.json
@@ -165,7 +165,7 @@
             "value" : "boston",
             "docId" : "DOC.Properties",
             "index" : 0,
-            "path" : "/prop-city",
+            "path" : "/current/prop-city",
             "fieldType" : "STRING",
             "name" : "prop-city",
             "scope" : "current"
@@ -331,11 +331,7 @@
     },
     "properties" : {
       "property" : [ {
-        "name" : "boston",
-        "value" : "boston",
-        "fieldType" : "STRING",
-        "scope" : "current"
-      }, {
+        "dataSourceType": "SOURCE",
         "name" : "prop-city",
         "value" : "boston",
         "fieldType" : "STRING",


### PR DESCRIPTION
Fixes: #2977
Expression mapping needs corresponding field entry in `inputFieldGroup` or `inputField` where it's identified with Document ID and path. Same for property, path has to match. No need to handle property scope separately as it's supposed to be put in path.
![atlasmap](https://user-images.githubusercontent.com/265462/124189009-0f30ce00-da8e-11eb-977f-c5fc6ded6ff7.gif)
