### PR TITLE
fix: Add support for editing CSV processing parameters.

### DIFF
--- a/ui/packages/atlasmap-core/src/contracts/common.ts
+++ b/ui/packages/atlasmap-core/src/contracts/common.ts
@@ -158,3 +158,18 @@ export interface IFieldAction {
 export interface IStringList {
   string: string[];
 }
+
+export interface IParameterOption {
+  label: string;
+  value: string;
+}
+
+export interface IParameter {
+  name: string;
+  label: string;
+  value: string;
+  boolean?: boolean;
+  options?: IParameterOption[];
+  enabled?: boolean;
+  required?: boolean;
+}

--- a/ui/packages/atlasmap-core/src/contracts/documents/csv.ts
+++ b/ui/packages/atlasmap-core/src/contracts/documents/csv.ts
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-import { IDocument, IField } from '../common';
+import { IDocument, IField, IParameter } from '../common';
 
 /**
  * The CSV inspection data model contracts between frontend and backend.
@@ -65,4 +65,101 @@ export interface ICsvField extends IField {
  */
 export interface ICsvFields {
   csvField: ICsvField[];
+}
+
+export class ICsvParameterOptions {
+  // TODO: Retrieve from the backend CSV module
+  static getCsvParameterOptions(): IParameter[] {
+    return [
+      {
+        name: 'format',
+        label: 'CSV File Format',
+        value: 'Default',
+        options: [
+          { label: 'Default', value: 'Default' },
+          { label: 'Excel', value: 'Excel' },
+          { label: 'InformixUnload', value: 'InformixUnload' },
+          { label: 'InformixUnloadCsv', value: 'InformixUnloadCsv' },
+          { label: 'MongoDBCsv', value: 'MongoDBCsv' },
+          { label: 'MongoDBTsv', value: 'MongoDBTsv' },
+          { label: 'MySQL', value: 'MySQL' },
+          { label: 'Oracle', value: 'Oracle' },
+          { label: 'PostgreSQLCsv', value: 'PostgreSQLCsv' },
+          { label: 'PostgreSQLText', value: 'PostgreSQLText' },
+          { label: 'RFC4180', value: 'RFC4180' },
+          { label: 'TDF', value: 'TDF' },
+        ],
+        required: true,
+      },
+      {
+        name: 'allowDuplicateHeaderNames',
+        label: 'Allow Duplicate Header Names',
+        value: 'true',
+        boolean: true,
+        required: false,
+      },
+      {
+        name: 'allowMissingColumnNames',
+        label: 'Allow Missing Column Names',
+        value: 'true',
+        boolean: true,
+        required: false,
+      },
+      {
+        name: 'commentMarker',
+        label: 'Comment Marker',
+        value: '',
+        required: false,
+      },
+      {
+        name: 'delimiter',
+        label: 'Delimiter',
+        value: '',
+        required: false,
+      },
+      { name: 'escape', label: 'Escape', value: '', required: false },
+      {
+        name: 'firstRecordAsHeader',
+        label: 'First Record As Header',
+        value: 'true',
+        boolean: true,
+        required: false,
+      },
+      { name: 'headers', label: 'Headers', value: '', required: false },
+      {
+        name: 'ignoreEmptyLines',
+        label: 'Ignore Empty Lines',
+        value: 'true',
+        boolean: true,
+        required: false,
+      },
+      {
+        name: 'ignoreHeaderCase',
+        label: 'Ignore Header Case',
+        value: 'true',
+        boolean: true,
+        required: false,
+      },
+      {
+        name: 'ignoreSurroundingSpaces',
+        label: 'Ignore Surrounding Spaces',
+        value: 'true',
+        boolean: true,
+        required: false,
+      },
+      {
+        name: 'nullString',
+        label: 'Null String',
+        value: '',
+        required: false,
+      },
+      {
+        name: 'skipHeaderRecord',
+        label: 'Skip Header Record',
+        value: 'true',
+        boolean: true,
+        required: false,
+      },
+    ];
+  }
 }

--- a/ui/packages/atlasmap/src/Atlasmap/Atlasmap.tsx
+++ b/ui/packages/atlasmap/src/Atlasmap/Atlasmap.tsx
@@ -224,6 +224,9 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
       onFieldPreviewChange,
       canStartMapping: () => true, // TODO: check that there is at least one target field unmapped and compatible
       onStartMapping: (field) => onCreateMapping(field, undefined),
+      onEditCSVParams: (docId, isSource) => {
+        handlers.onEditCSVParams(docId, isSource);
+      },
     }),
     [
       selectMapping,
@@ -304,6 +307,9 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
       onFieldPreviewChange,
       canStartMapping: (field) => !field.isConnected,
       onStartMapping: (field) => onCreateMapping(undefined, field),
+      onEditCSVParams: (docId, isSource) => {
+        handlers.onEditCSVParams(docId, isSource);
+      },
     }),
     [
       selectMapping,

--- a/ui/packages/atlasmap/src/Atlasmap/dialogs/index.ts
+++ b/ui/packages/atlasmap/src/Atlasmap/dialogs/index.ts
@@ -26,6 +26,7 @@ export * from './useImportADMArchiveDialog';
 export * from './useExportADMArchiveDialog';
 export * from './useImportDocumentDialog';
 export * from './useNamespaceDialog';
+export * from './useParametersDialog';
 export * from './usePropertyDialog';
 export * from './useRemoveMappedFieldDialog';
 export * from './useResetAtlasmapDialog';

--- a/ui/packages/atlasmap/src/Atlasmap/dialogs/useImportDocumentDialog.tsx
+++ b/ui/packages/atlasmap/src/Atlasmap/dialogs/useImportDocumentDialog.tsx
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 import React, { ReactElement, useCallback, useState } from 'react';
-
+import { ICsvParameterOptions } from '@atlasmap/core';
 import { useAtlasmap } from '../AtlasmapProvider';
 import { useConfirmationDialog } from './useConfirmationDialog';
 import { useParametersDialog } from './useParametersDialog';
@@ -43,106 +43,19 @@ export function useImportDocumentDialog(): [
         const userFileSuffix: string =
           userFileSplit[userFileSplit.length - 1].toUpperCase();
         if (userFileSuffix === 'CSV') {
-          openParametersDialog(
-            (parameters) => {
-              const inspectionParameters: { [key: string]: string } = {};
-              for (let parameter of parameters) {
-                inspectionParameters[parameter.name] = parameter.value;
-              }
-              importInstanceSchema(selectedFile, configModel, isSource, false);
-            },
-            [
-              {
-                name: 'format',
-                label: 'CSV File Format',
-                value: 'Default',
-                options: [
-                  { label: 'Default', value: 'Default' },
-                  { label: 'Excel', value: 'Excel' },
-                  { label: 'InformixUnload', value: 'InformixUnload' },
-                  { label: 'InformixUnloadCsv', value: 'InformixUnloadCsv' },
-                  { label: 'MongoDBCsv', value: 'MongoDBCsv' },
-                  { label: 'MongoDBTsv', value: 'MongoDBTsv' },
-                  { label: 'MySQL', value: 'MySQL' },
-                  { label: 'Oracle', value: 'Oracle' },
-                  { label: 'PostgreSQLCsv', value: 'PostgreSQLCsv' },
-                  { label: 'PostgreSQLText', value: 'PostgreSQLText' },
-                  { label: 'RFC4180', value: 'RFC4180' },
-                  { label: 'TDF', value: 'TDF' },
-                ],
-                required: true,
-              },
-              {
-                name: 'allowDuplicateHeaderNames',
-                label: 'Allow Duplicate Header Names',
-                value: 'true',
-                boolean: true,
-                required: false,
-              },
-              {
-                name: 'allowMissingColumnNames',
-                label: 'Allow Missing Column Names',
-                value: 'true',
-                boolean: true,
-                required: false,
-              },
-              {
-                name: 'commentMarker',
-                label: 'Comment Marker',
-                value: '',
-                required: false,
-              },
-              {
-                name: 'delimiter',
-                label: 'Delimiter',
-                value: '',
-                required: false,
-              },
-              { name: 'escape', label: 'Escape', value: '', required: false },
-              {
-                name: 'firstRecordAsHeader',
-                label: 'First Record As Header',
-                value: 'true',
-                boolean: true,
-                required: false,
-              },
-              { name: 'headers', label: 'Headers', value: '', required: false },
-              {
-                name: 'ignoreEmptyLines',
-                label: 'Ignore Empty Lines',
-                value: 'true',
-                boolean: true,
-                required: false,
-              },
-              {
-                name: 'ignoreHeaderCase',
-                label: 'Ignore Header Case',
-                value: 'true',
-                boolean: true,
-                required: false,
-              },
-              {
-                name: 'ignoreSurroundingSpaces',
-                label: 'Ignore Surrounding Spaces',
-                value: 'true',
-                boolean: true,
-                required: false,
-              },
-              {
-                name: 'nullString',
-                label: 'Null String',
-                value: '',
-                required: false,
-              },
-              {
-                name: 'skipHeaderRecord',
-                label: 'Skip Header Record',
-                value: 'true',
-                boolean: true,
-                required: false,
-              },
-            ],
-          );
+          openParametersDialog((parameters) => {
+            const inspectionParameters: { [key: string]: string } = {};
+            for (let parameter of parameters) {
+              inspectionParameters[parameter.name] = parameter.value;
+            }
+            importInstanceSchema(
+              selectedFile,
+              configModel,
+              isSource,
+              false,
+              inspectionParameters,
+            );
+          }, ICsvParameterOptions.getCsvParameterOptions());
           return;
         }
 

--- a/ui/packages/atlasmap/src/Atlasmap/dialogs/useParametersDialog.tsx
+++ b/ui/packages/atlasmap/src/Atlasmap/dialogs/useParametersDialog.tsx
@@ -13,8 +13,9 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-import { IParameter, ParametersDialog } from '../../UI';
-import React, { ReactElement, useCallback, useState } from 'react';
+import React, { ReactElement, useCallback, useEffect, useState } from 'react';
+import { IParameter } from '@atlasmap/core';
+import { ParametersDialog } from '../../UI';
 
 import { useToggle } from '../../Atlasmap/utils';
 
@@ -27,6 +28,9 @@ export function useParametersDialog(
     useState<ParametersCallback | null>(null);
   const [parameters, setParameters] = useState<IParameter[]>([]);
   const { state, toggleOn, toggleOff } = useToggle(false);
+  const reset = useCallback(() => {
+    setParameters([]);
+  }, []);
   const onConfirm = useCallback(
     (parameters: IParameter[]) => {
       if (onParametersCb) {
@@ -55,5 +59,6 @@ export function useParametersDialog(
     },
     [toggleOn],
   );
+  useEffect(reset, [reset]);
   return [dialog, onOpenParametersDialog];
 }

--- a/ui/packages/atlasmap/src/Atlasmap/utils/document.ts
+++ b/ui/packages/atlasmap/src/Atlasmap/utils/document.ts
@@ -182,8 +182,8 @@ export async function getCustomClassNameOptions(): Promise<string[]> {
 }
 
 /**
- * Import an instance or schema document into either the Source panel or Target
- * panel (JSON, XML, XSD).
+ * Import a CSV, instance or schema document into either the Source panel or Target
+ * panel (CSV, JSON, XML, XSD).
  *
  * @param selectedFile
  * @param cfg
@@ -282,4 +282,38 @@ export function getPropertyScopeOptions(isSource: boolean): {
     });
   }
   return scopeOptions;
+}
+
+/**
+ * Return CSV document inspection parameters.
+ *
+ * @param docId
+ * @param isSource
+ * @returns
+ */
+export function getDocCSVParams(
+  docId: string,
+  isSource: boolean,
+): { [key: string]: string } {
+  const doc = getDocDef(docId, ConfigModel.getConfig(), isSource);
+  return doc?.inspectionParameters;
+}
+
+/**
+ * Set CSV document inspection parameters.
+ *
+ * @param docId
+ * @param isSource
+ * @param parameters
+ */
+export async function setDocCSVParams(
+  docId: string,
+  isSource: boolean,
+  parameters: { [key: string]: string },
+) {
+  const cfg = ConfigModel.getConfig();
+  const docDef = getDocDef(docId, cfg, isSource);
+  docDef.inspectionParameters = parameters;
+  await cfg.mappingService.notifyMappingUpdated();
+  await cfg.fileService.updateDigestFile();
 }

--- a/ui/packages/atlasmap/src/UI/dialogs/ParametersDialog.stories.tsx
+++ b/ui/packages/atlasmap/src/UI/dialogs/ParametersDialog.stories.tsx
@@ -127,9 +127,24 @@ const parameters = [
   { name: 'quote', label: 'Quote', value: '', required: false, enabled: false },
 ];
 
-export const parametersDialog = () => (
+/**
+ * The 'Select' parameters dialog doesn't specify predefined parameters, the
+ * 'Edit' dialog does.
+ *
+ * @returns
+ */
+export const parametersSelectDialog = () => (
   <ParametersDialog
     title={text('Title', 'Select CSV Processing Parameters')}
+    isOpen={boolean('Is open', true)}
+    onCancel={action('onCancel')}
+    onConfirm={action('onConfirm')}
+  />
+);
+
+export const parametersEditDialog = () => (
+  <ParametersDialog
+    title={text('Title', 'Edit CSV Processing Parameters')}
     isOpen={boolean('Is open', true)}
     onCancel={action('onCancel')}
     onConfirm={action('onConfirm')}

--- a/ui/packages/atlasmap/src/UI/dialogs/ParametersDialog.tsx
+++ b/ui/packages/atlasmap/src/UI/dialogs/ParametersDialog.tsx
@@ -34,25 +34,11 @@ import React, {
   useEffect,
   useState,
 } from 'react';
-
-export interface IParameter {
-  name: string;
-  label: string;
-  value: string;
-  boolean?: boolean;
-  options?: IParameterOption[];
-  enabled?: boolean;
-  required?: boolean;
-}
-
-export interface IParameterOption {
-  label: string;
-  value: string;
-}
+import { IParameter } from '@atlasmap/core';
 
 export interface IParametersDialogProps {
   title: string;
-  parameters?: IParameter[];
+  parameters: IParameter[];
   isOpen: IConfirmationDialogProps['isOpen'];
   onCancel: IConfirmationDialogProps['onCancel'];
   onConfirm: (parameters: IParameter[]) => void;
@@ -129,7 +115,7 @@ export const ParametersDialog: FunctionComponent<IParametersDialogProps> = ({
   const formLabelParamRequired = {
     '--pf-c-form__label--FontSize': 'large',
     '--pf-c-form--m-horizontal--md__group--GridTemplateColumns': '140px 1fr',
-    'margin-bottom': '1.0rem',
+    marginBottom: '1.0rem',
   } as React.CSSProperties;
   const formLabelTopPadding = {
     '--pf-c-form--m-horizontal__group-label--md--GridColumnWidth': '380px',

--- a/ui/packages/atlasmap/src/Views/ColumnMapperView/Actions/EditCSVParamsAction.tsx
+++ b/ui/packages/atlasmap/src/Views/ColumnMapperView/Actions/EditCSVParamsAction.tsx
@@ -1,0 +1,41 @@
+/*
+    Copyright (C) 2017 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+import { Button, Tooltip } from '@patternfly/react-core';
+import React, { FunctionComponent } from 'react';
+
+import { EditIcon } from '@patternfly/react-icons';
+
+export interface IEditCSVParamsActionProps {
+  id: string;
+  onClick: () => void;
+}
+export const EditCSVParamsAction: FunctionComponent<IEditCSVParamsActionProps> =
+  ({ id, onClick }) => (
+    <Tooltip
+      position={'auto'}
+      enableFlip={true}
+      content={<div>Modify CSV Parameters</div>}
+    >
+      <Button
+        variant="plain"
+        onClick={onClick}
+        aria-label="Modify CSV parameters"
+        data-testid={`modify-csv-params-${id}-button`}
+      >
+        <EditIcon />
+      </Button>
+    </Tooltip>
+  );

--- a/ui/packages/atlasmap/src/Views/ColumnMapperView/Actions/index.ts
+++ b/ui/packages/atlasmap/src/Views/ColumnMapperView/Actions/index.ts
@@ -17,6 +17,7 @@ export * from './CaptureDocumentNameAction';
 export * from './ChangeDocumentNameAction';
 export * from './DeleteDocumentAction';
 export * from './DeleteMappingAction';
+export * from './EditCSVParamsAction';
 export * from './EditMappingAction';
 export * from './EnableJavaClassAction';
 export * from './ImportAction';

--- a/ui/packages/atlasmap/src/Views/ColumnMapperView/Columns/SourcesColumn.tsx
+++ b/ui/packages/atlasmap/src/Views/ColumnMapperView/Columns/SourcesColumn.tsx
@@ -25,6 +25,7 @@ import {
   CaptureDocumentNameAction,
   ChangeDocumentNameAction,
   DeleteDocumentAction,
+  EditCSVParamsAction,
   EnableJavaClassAction,
   ImportAction,
 } from '../Actions';
@@ -50,6 +51,7 @@ import {
   SOURCES_WIDTH_BOUNDARY_ID,
 } from './constants';
 
+import { DocumentType } from '@atlasmap/core';
 import { PlusIcon } from '@patternfly/react-icons';
 import { TraverseFields } from './TraverseFields';
 import { commonActions } from './commonActions';
@@ -80,6 +82,7 @@ export interface ISourceColumnCallbacks
   shouldShowMappingPreviewForField: (field: IAtlasmapField) => boolean;
   onFieldPreviewChange: (field: IAtlasmapField, value: string) => void;
   canAddToSelectedMapping: (isSource: boolean) => boolean;
+  onEditCSVParams: (id: string, isSource: boolean) => void;
 }
 
 export interface ISourcesColumnData {
@@ -106,6 +109,7 @@ export const SourcesColumn: FunctionComponent<
   onDeleteDocument,
   onCaptureDocumentName,
   onChangeDocumentName,
+  onEditCSVParams,
   onSearch,
   canDrop,
   onDrop,
@@ -294,29 +298,57 @@ export const SourcesColumn: FunctionComponent<
                           </DocumentFooter>
                         ) : undefined
                       }
-                      actions={[
-                        onCaptureDocumentName && (
-                          <CaptureDocumentNameAction
-                            id={documentId}
-                            onClick={() => onCaptureDocumentName(s.id)}
-                            key={'capture-document-name'}
-                          />
-                        ),
-                        onChangeDocumentName && (
-                          <ChangeDocumentNameAction
-                            id={documentId}
-                            onClick={() => onChangeDocumentName(s.id, s.name)}
-                            key={'change-document-name'}
-                          />
-                        ),
-                        onDeleteDocument && (
-                          <DeleteDocumentAction
-                            id={documentId}
-                            onClick={() => onDeleteDocument(s.id)}
-                            key={'delete-document'}
-                          />
-                        ),
-                      ]}
+                      actions={
+                        s.type === DocumentType.CSV
+                          ? [
+                              onCaptureDocumentName && (
+                                <CaptureDocumentNameAction
+                                  id={documentId}
+                                  onClick={() => onCaptureDocumentName(s.id)}
+                                  key={'capture-document-name'}
+                                />
+                              ),
+                              onEditCSVParams && (
+                                <EditCSVParamsAction
+                                  id={documentId}
+                                  onClick={() => onEditCSVParams(s.id, true)}
+                                  key={'on-edit-csv-params'}
+                                />
+                              ),
+                              onDeleteDocument && (
+                                <DeleteDocumentAction
+                                  id={documentId}
+                                  onClick={() => onDeleteDocument(s.id)}
+                                  key={'delete-document'}
+                                />
+                              ),
+                            ]
+                          : [
+                              onCaptureDocumentName && (
+                                <CaptureDocumentNameAction
+                                  id={documentId}
+                                  onClick={() => onCaptureDocumentName(s.id)}
+                                  key={'capture-document-name'}
+                                />
+                              ),
+                              onChangeDocumentName && (
+                                <ChangeDocumentNameAction
+                                  id={documentId}
+                                  onClick={() =>
+                                    onChangeDocumentName(s.id, s.name)
+                                  }
+                                  key={'change-document-name'}
+                                />
+                              ),
+                              onDeleteDocument && (
+                                <DeleteDocumentAction
+                                  id={documentId}
+                                  onClick={() => onDeleteDocument(s.id)}
+                                  key={'delete-document'}
+                                />
+                              ),
+                            ]
+                      }
                       noPadding={true}
                     >
                       <Tree>

--- a/ui/packages/atlasmap/src/Views/ColumnMapperView/Columns/TargetsColumn.tsx
+++ b/ui/packages/atlasmap/src/Views/ColumnMapperView/Columns/TargetsColumn.tsx
@@ -25,6 +25,7 @@ import {
   CaptureDocumentNameAction,
   ChangeDocumentNameAction,
   DeleteDocumentAction,
+  EditCSVParamsAction,
   EnableJavaClassAction,
   ImportAction,
 } from '../Actions';
@@ -49,6 +50,7 @@ import {
   TARGETS_WIDTH_BOUNDARY_ID,
 } from './constants';
 
+import { DocumentType } from '@atlasmap/core';
 import { PlusIcon } from '@patternfly/react-icons';
 import { TraverseFields } from './TraverseFields';
 import { commonActions } from './commonActions';
@@ -76,6 +78,7 @@ export interface ITargetsColumnCallbacks extends IPropertiesTreeCallbacks {
   shouldShowMappingPreviewForField: (field: IAtlasmapField) => boolean;
   onFieldPreviewChange: (field: IAtlasmapField, value: string) => void;
   canAddToSelectedMapping: (isSource: boolean) => boolean;
+  onEditCSVParams: (id: string, isSource: boolean) => void;
 }
 
 export interface ITargetsColumnData {
@@ -98,6 +101,7 @@ export const TargetsColumn: FunctionComponent<
   onChangeDocumentName,
   onCustomClassSearch,
   onCreateProperty,
+  onEditCSVParams,
   onEditProperty,
   onDeleteProperty,
   onDrop,
@@ -231,29 +235,57 @@ export const TargetsColumn: FunctionComponent<
                           </DocumentFooter>
                         ) : undefined
                       }
-                      actions={[
-                        onCaptureDocumentName && (
-                          <CaptureDocumentNameAction
-                            id={documentId}
-                            onClick={() => onCaptureDocumentName(t.id)}
-                            key={'capture-document-name'}
-                          />
-                        ),
-                        onChangeDocumentName && (
-                          <ChangeDocumentNameAction
-                            id={documentId}
-                            onClick={() => onChangeDocumentName(t.id, t.name)}
-                            key={'change-document-name'}
-                          />
-                        ),
-                        onDeleteDocument && (
-                          <DeleteDocumentAction
-                            id={documentId}
-                            onClick={() => onDeleteDocument(t.id)}
-                            key={'delete-documents'}
-                          />
-                        ),
-                      ]}
+                      actions={
+                        t.type === DocumentType.CSV
+                          ? [
+                              onCaptureDocumentName && (
+                                <CaptureDocumentNameAction
+                                  id={documentId}
+                                  onClick={() => onCaptureDocumentName(t.id)}
+                                  key={'capture-tgt-csv-document-name'}
+                                />
+                              ),
+                              onEditCSVParams && (
+                                <EditCSVParamsAction
+                                  id={documentId}
+                                  onClick={() => onEditCSVParams(t.id, false)}
+                                  key={'on-edit-tgt-csv-params'}
+                                />
+                              ),
+                              onDeleteDocument && (
+                                <DeleteDocumentAction
+                                  id={documentId}
+                                  onClick={() => onDeleteDocument(t.id)}
+                                  key={'delete-tgt-csv-document'}
+                                />
+                              ),
+                            ]
+                          : [
+                              onCaptureDocumentName && (
+                                <CaptureDocumentNameAction
+                                  id={documentId}
+                                  onClick={() => onCaptureDocumentName(t.id)}
+                                  key={'capture-tgt-document-name'}
+                                />
+                              ),
+                              onChangeDocumentName && (
+                                <ChangeDocumentNameAction
+                                  id={documentId}
+                                  onClick={() =>
+                                    onChangeDocumentName(t.id, t.name)
+                                  }
+                                  key={'change-tgt-document-name'}
+                                />
+                              ),
+                              onDeleteDocument && (
+                                <DeleteDocumentAction
+                                  id={documentId}
+                                  onClick={() => onDeleteDocument(t.id)}
+                                  key={'delete-tgt-documents'}
+                                />
+                              ),
+                            ]
+                      }
                       noPadding={true}
                     >
                       <Tree>

--- a/ui/packages/atlasmap/src/Views/SourceTargetView.stories.tsx
+++ b/ui/packages/atlasmap/src/Views/SourceTargetView.stories.tsx
@@ -81,6 +81,7 @@ export const sourceTargetView = () =>
               isSource: true,
               acceptDropType: 'target',
               draggableType: 'source',
+              onEditCSVParams: action('onEditCSVParams'),
             }}
             targetEvents={{
               onCreateProperty: action('onCreateProperty'),
@@ -112,6 +113,7 @@ export const sourceTargetView = () =>
               isSource: false,
               acceptDropType: 'source',
               draggableType: 'target',
+              onEditCSVParams: action('onEditCSVParams'),
             }}
             showTypes={boolean('Show types', false)}
             showMappingPreview={boolean('Show mapping preview', false)}


### PR DESCRIPTION
Fixes: #2990

As stated in the issue - this adds full CSV parameter edit support and solves the Atlasmap cancel issue.  We can open a new issue or reopen this one if there are Syndesis integration problems.