### PR TITLE
chore: Add TargetTestClass for an UI test resource

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -188,6 +188,12 @@
               <className>twitter4j.Status</className>
             </inspection>
             <inspection>
+              <artifacts>
+		      <artifact>io.atlasmap:atlas-java-test-model:${project.version}</artifact>
+              </artifacts>
+              <className>io.atlasmap.java.test.TargetTestClass</className>
+            </inspection>
+            <inspection>
                 <fileName>${project.basedir}/test-resources/json/schema</fileName>
                 <inspectionType>SCHEMA</inspectionType>
             </inspection>


### PR DESCRIPTION
@pleacu #3141 seems to be rather Java side issue, Java inspection doesn't have collection suffix on the field path as expected. This PR will add TargetTestClass to be inspected and generate `ui/test-resources/inspected/atlasmap-inspection-io.atlasmap.java.test.TargetTestClass.json`