### PR TITLE
chore: Enable canceling previous GitHub workflow

### DIFF
--- a/.github/workflows/cancel-previous.yml
+++ b/.github/workflows/cancel-previous.yml
@@ -1,0 +1,15 @@
+name: Cancel Previous
+on:
+  workflow_run:
+    workflows: ["Chromatic", "__Experimental", "Master", "Checked"]
+    types:
+      - requested
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: styfle/cancel-workflow-action@0.9.0
+      with:
+        workflow_id: ${{ github.event.workflow.id }}
+      continue-on-error: true
+


### PR DESCRIPTION
Fixes: #3167