### PR TITLE
fix: Hidden Java Field is shwon duplicated

### DIFF
--- a/lib/modules/java/core/src/main/java/io/atlasmap/java/inspect/ClassInspectionService.java
+++ b/lib/modules/java/core/src/main/java/io/atlasmap/java/inspect/ClassInspectionService.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -597,11 +598,17 @@ public class ClassInspectionService {
 
     private void inspectClassFields(ClassLoader classLoader, Class<?> clazz, JavaClass javaClass,
             Set<String> cachedClasses, String pathPrefix) {
+        Set<String> existing = javaClass.getJavaFields().getJavaField().stream()
+            .map(JavaField::getName).collect(Collectors.toSet());
         Field[] fields = clazz.getDeclaredFields();
         if (fields != null && !javaClass.isEnumeration()) {
             for (Field f : fields) {
                 JavaField s = inspectField(classLoader, f, cachedClasses, pathPrefix);
 
+                if (existing.contains(f.getName())) {
+                    LOG.warn("Ignoring hidden Java field: " + s.getName());
+                    continue;
+                }
                 if (getFieldExclusions().contains(f.getName())) {
                     s.setStatus(FieldStatus.EXCLUDED);
                 }

--- a/lib/modules/java/core/src/test/java/io/atlasmap/java/inspect/ClassInspectionServiceTest.java
+++ b/lib/modules/java/core/src/test/java/io/atlasmap/java/inspect/ClassInspectionServiceTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import io.atlasmap.core.DefaultAtlasConversionService;
 import io.atlasmap.java.test.TargetTestClass;
+import io.atlasmap.java.test.TargetTestClassExtended;
 import io.atlasmap.java.v2.JavaClass;
 import io.atlasmap.java.v2.JavaField;
 import io.atlasmap.java.v2.Modifier;
@@ -416,5 +417,17 @@ public class ClassInspectionServiceTest {
         JavaField contactArray = javaClass.getJavaFields().getJavaField().get(13);
         assertEquals(CollectionType.ARRAY, contactArray.getCollectionType());
         assertEquals("/contactArray[]", contactArray.getPath());
+    }
+
+    @Test
+    public void testDuplicatedField() {
+        JavaClass parent = classInspectionService.inspectClass(TargetTestClass.class, CollectionType.NONE, null);
+        JavaClass extended = classInspectionService.inspectClass(TargetTestClassExtended.class, CollectionType.NONE, null);
+        assertEquals(TargetTestClass.class.getName(), parent.getClassName());
+        assertEquals(TargetTestClassExtended.class.getName(), extended.getClassName());
+        assertEquals(
+            parent.getJavaFields().getJavaField().size(),
+            extended.getJavaFields().getJavaField().size()
+        );
     }
 }

--- a/lib/modules/java/core/src/test/java/io/atlasmap/java/inspect/ComplexClassInspectTest.java
+++ b/lib/modules/java/core/src/test/java/io/atlasmap/java/inspect/ComplexClassInspectTest.java
@@ -111,8 +111,7 @@ public class ComplexClassInspectTest {
         assertNotNull(c.getUri());
         assertNull(c.getValue());
 
-        // Two serialVersionUID fields due to inheritance
-        assertEquals(new Integer(7), new Integer(c.getJavaFields().getJavaField().size()));
+        assertEquals(Integer.valueOf(6), Integer.valueOf(c.getJavaFields().getJavaField().size()));
 
         Integer validated = 0;
         for (JavaField f : c.getJavaFields().getJavaField()) {
@@ -149,7 +148,7 @@ public class ComplexClassInspectTest {
             }
         }
 
-        assertEquals(validated, new Integer(c.getJavaFields().getJavaField().size()));
+        assertEquals(validated, Integer.valueOf(c.getJavaFields().getJavaField().size()));
     }
 
 }

--- a/lib/modules/java/test-model/src/main/java/io/atlasmap/java/test/TargetTestClassExtended.java
+++ b/lib/modules/java/test-model/src/main/java/io/atlasmap/java/test/TargetTestClassExtended.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atlasmap.java.test;
+
+public class TargetTestClassExtended extends TargetTestClass {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}


### PR DESCRIPTION
Fixes: #3197
Since Java hidden field is generally a bad practice and doesn't work well together with AtlasMap path expression, we'll simply ignore it.