### PR TITLE
Fixed issue where a source Java Enum that is null generates an Audit ERROR

### DIFF
--- a/lib/modules/java/core/src/main/java/io/atlasmap/java/core/JavaFieldWriter.java
+++ b/lib/modules/java/core/src/main/java/io/atlasmap/java/core/JavaFieldWriter.java
@@ -163,7 +163,8 @@ public class JavaFieldWriter implements AtlasFieldWriter {
                 }
 
                 if (lastSegment.getCollectionType() == CollectionType.NONE) {
-                    if (targetField.getFieldType() == FieldType.COMPLEX && targetField.getValue() == null) {
+                    // Don't handle null for JavaEnumField complex type using complex child object
+                    if (targetField.getFieldType() == FieldType.COMPLEX && !(targetField instanceof JavaEnumField) && targetField.getValue() == null) {
                         if (targetClassName != null && !targetClassName.isEmpty()) {
                             writerUtil.createComplexChildObject(parentObject, lastSegment, writerUtil.loadClass(targetClassName));
                         } else {


### PR DESCRIPTION
The issue occurs when the enum in the source Java Object is null and is required to be mapped to an enum in a destination Java Object.
This generates a mapping error as it tries to create enum using the writerUtil.createComplexChildObject which tries to call a constructor on the Java Enum class.

The fix ignores this branch of code if the value complex and not a JavaEnum Field and null.
The null enum now branches to use the writerUtil.setChildObject which sets the destination as null.

Sample code for the issue can be found at
https://github.com/johnathani/AtlasMap-Enum-Error.git

There README.md explains the issue.
