### PR TITLE
Fixed issue where a source Java Enum that is null generates an Audit ERROR due to underlying JavaWriter exception

### DIFF
--- a/lib/modules/java/core/src/main/java/io/atlasmap/java/core/JavaFieldWriter.java
+++ b/lib/modules/java/core/src/main/java/io/atlasmap/java/core/JavaFieldWriter.java
@@ -163,7 +163,8 @@ public class JavaFieldWriter implements AtlasFieldWriter {
                 }
 
                 if (lastSegment.getCollectionType() == CollectionType.NONE) {
-                    if (targetField.getFieldType() == FieldType.COMPLEX && targetField.getValue() == null) {
+                    // Don't handle null for JavaEnumField complex type using complex child object
+                    if (targetField.getFieldType() == FieldType.COMPLEX && !(targetField instanceof JavaEnumField) && targetField.getValue() == null) {
                         if (targetClassName != null && !targetClassName.isEmpty()) {
                             writerUtil.createComplexChildObject(parentObject, lastSegment, writerUtil.loadClass(targetClassName));
                         } else {

--- a/lib/modules/java/core/src/test/java/io/atlasmap/java/core/BaseJavaFieldWriterTest.java
+++ b/lib/modules/java/core/src/test/java/io/atlasmap/java/core/BaseJavaFieldWriterTest.java
@@ -114,9 +114,9 @@ public abstract class BaseJavaFieldWriterTest {
     public JavaEnumField createEnumField(String path, Enum<?> value) {
         JavaEnumField f = new JavaEnumField();
         f.setPath(path);
-        f.setName(value.name());
-        f.setOrdinal(value.ordinal());
-        f.setFieldType(FieldType.NONE);
+        f.setName(null == value ? null : value.name());
+        f.setOrdinal(null == value ? null : value.ordinal());
+        f.setFieldType(FieldType.COMPLEX);
         f.setValue(value);
         return f;
     }

--- a/lib/modules/java/core/src/test/java/io/atlasmap/java/core/JavaFieldWriterTest.java
+++ b/lib/modules/java/core/src/test/java/io/atlasmap/java/core/JavaFieldWriterTest.java
@@ -411,6 +411,10 @@ public class JavaFieldWriterTest extends BaseJavaFieldWriterTest {
         ensureNotNullAndClass(o.getPrimitives().getBoxedStringArrayField()[10], String.class);
         assertEquals("boxedString", o.getPrimitives().getBoxedStringArrayField()[10]);
 
+        // test writing null enum values
+        write("/statesLong", (StateEnumClassLong)null);
+        assertNull(o.getStatesLong());
+
         // test writing enum values
         write("/statesLong", StateEnumClassLong.Massachusetts);
         assertNotNull(o.getStatesLong());


### PR DESCRIPTION
<!-- Please follow the guildeline - https://github.com/atlasmap/atlasmap/wiki/AtlasMap-Developer-Memo -->
Fixes: #3239

The issue occurs when the enum in the source Java Object is null and is required to be mapped to an enum in a destination Java Object.
This generates a mapping error as it tries to create enum using the writerUtil.createComplexChildObject which tries to call a constructor on the Java Enum class.

The exception is:
io.atlasmap.api.AtlasException: Unable to create value for segment: statesLong parentObject: io.atlasmap.java.test.TargetTestClass


The fix does not write the complex value if its null and rather uses the writerUtil.setChildObject which sets the destination as null.

Sample code for the issue can be found at
https://github.com/johnathani/AtlasMap-Enum-Error.git

There README.md explains the issue.
