### PR TITLE
fix: Fixed mapping error for null complex type to null complex type i…

### DIFF
--- a/lib/itests/reference-mappings/src/test/java/io/atlasmap/itests/reference/java_to_java/JavaJavaComplexTest.java
+++ b/lib/itests/reference-mappings/src/test/java/io/atlasmap/itests/reference/java_to_java/JavaJavaComplexTest.java
@@ -89,8 +89,8 @@ public class JavaJavaComplexTest extends AtlasMappingBaseTest {
         assertFalse(session.hasErrors(), printAudit(session));
         TargetTestClass object = (TargetTestClass) session.getDefaultTargetDocument();
         assertEquals(TargetTestClass.class.getName(), object.getClass().getName());
-        assertEquals(TargetContact.class.getName(), object.getContact().getClass().getName());
-        assertNull(object.getContact().getFirstName());
+        // Lazy instantiation will not istantiate target class if source class is null (Java to Java)
+        assertNull(object.getContact());
     }
 
     @Test


### PR DESCRIPTION
Fixes: #3275

The issue occurs when a source complex type in a POJO has mappings targeting fields in the target POJO, but the source complex type is null.

This ends up creating an instance of the target POJO with all fields null.
The expected behaviour is that the target remains null of the source is null.

The fix applies a concept of lazy object instantiation, only instantiating an instance of the target object when a source mapped field value is non null
  UNLESS there is an explicit mapping to create the object instance (complex type) such as can be contained in JSON -> Java mapping
  Example: 
     ...
    {
        "jsonType" : "io.atlasmap.v2.Mapping",
        "mappingType" : "MAP",
        "inputField" : [ {
          "jsonType" : "io.atlasmap.json.v2.JsonField",
          "path" : "/Contact"
        } ],
        "outputField" : [ {
          "jsonType" : "io.atlasmap.java.v2.JavaField",
          "path" : "/contact",
          "fieldType" : "COMPLEX",
          "className" : "io.atlasmap.java.test.TargetContact"
        }

The test case was modified to test the output for the expected behaviour.

Sample code for the issue can be found at
https://github.com/johnathani/AtlasMap-Enum-Error.git