### PR TITLE
Include ui/dist folder in .gitignore

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,6 +1,6 @@
 node
 _netlify
-
+dist
 # compiled output
 test-resources/inspected
 test-resources/fieldActions


### PR DESCRIPTION
it avoids having a lot of modified files listed after a full build


