### PR TITLE
ENTESB-15784 - support space in path to atlasmap workspace when loading

### DIFF
--- a/lib/service/src/main/java/io/atlasmap/service/AtlasLibraryLoader.java
+++ b/lib/service/src/main/java/io/atlasmap/service/AtlasLibraryLoader.java
@@ -21,6 +21,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Modifier;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
@@ -105,18 +106,14 @@ public class AtlasLibraryLoader extends CompoundClassLoader {
         URL candidateURLs[] = this.urlClassLoader.getURLs();
 
         for (int i=0; i < candidateURLs.length; i++) {
-            ZipInputStream zip;
-            try {
-                zip = new ZipInputStream(new FileInputStream(candidateURLs[i].getPath()));
-
+            try (ZipInputStream zip = new ZipInputStream(new FileInputStream(candidateURLs[i].toURI().getPath()))) {
                 for (ZipEntry entry = zip.getNextEntry(); entry != null; entry = zip.getNextEntry()) {
                     if (!entry.isDirectory() && entry.getName().endsWith(classSuffix)) {
                         String className = entry.getName().replace('/', '.');
                         classNames.add(className.substring(0, className.length() - classSuffix.length()));
                     }
                 }
-                zip.close();
-            } catch (IOException e) {
+            } catch (IOException | URISyntaxException e) {
                 throw new AtlasException(String.format("URL library '%s' access error: %s",
                     candidateURLs[i].getPath(), e.getMessage()));
             }

--- a/lib/service/src/test/java/io/atlasmap/service/AtlasServiceTest.java
+++ b/lib/service/src/test/java/io/atlasmap/service/AtlasServiceTest.java
@@ -37,6 +37,7 @@ import javax.ws.rs.core.UriInfo;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,11 +62,16 @@ public class AtlasServiceTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(AtlasServiceTest.class);
 
+    @TempDir
+    File tmpDir;
+    
     private AtlasService service = null;
     private ObjectMapper mapper = null;
+    private String initialValueOfWorkspace;
 
     @BeforeEach
     public void setUp() throws Exception {
+        initialValueOfWorkspace = System.getProperty(AtlasService.ATLASMAP_WORKSPACE);
         service = new AtlasService();
         mapper = Json.mapper();
     }
@@ -74,6 +80,11 @@ public class AtlasServiceTest {
     public void tearDown() {
         service = null;
         mapper = null;
+        if(initialValueOfWorkspace != null) {
+            System.setProperty(AtlasService.ATLASMAP_WORKSPACE, initialValueOfWorkspace);
+        } else {
+            System.clearProperty(AtlasService.ATLASMAP_WORKSPACE);
+        }
     }
 
     @Test
@@ -121,6 +132,8 @@ public class AtlasServiceTest {
 
     @Test
     public void testJarUpload() throws Exception {
+        File workspaceFolderWithSpace = new File(tmpDir, "with space");
+        System.setProperty(AtlasService.ATLASMAP_WORKSPACE, workspaceFolderWithSpace.getAbsolutePath());
         new File("target/tmp").mkdirs();
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         int answer = compiler.run(System.in, System.out, System.err,


### PR DESCRIPTION
jars

fixes: #3324 ENTESB-15784

URL.getPath should not be used directly. it needs to go through toURi

see Javadoc https://docs.oracle.com/javase/7/docs/api/java/net/URL.html

The URL class does not itself encode or decode any URL components
according to the escaping mechanism defined in RFC2396. It is the
responsibility of the caller to encode any fields, which need to be
escaped prior to calling URL, and also to decode any escaped fields,
that are returned from URL. Furthermore, because URL has no knowledge of
URL escaping, it does not recognise equivalence between the encoded or
decoded form of the same URL

Note, the URI class does perform escaping of its component fields in
certain circumstances. The recommended way to manage the encoding and
decoding of URLs is to use URI, and to convert between these two classes
using toURI() and URI.toURL().


<!-- Please follow the guildeline - https://github.com/atlasmap/atlasmap/wiki/AtlasMap-Developer-Memo -->
Fixes: #

~~I failed so far to write a test but creating PRs to start showing work and test that i ti snot breaking something else~~ updated with a modified test