### PR TITLE
fix: Better error message when META-INF/services/* files for custom a…

### DIFF
--- a/lib/core/src/main/java/io/atlasmap/core/AtlasUtil.java
+++ b/lib/core/src/main/java/io/atlasmap/core/AtlasUtil.java
@@ -477,6 +477,11 @@ public class AtlasUtil {
                   .replaceAll("%5D", "]");
     }
 
+    /**
+     * Delete specified directory and the contents in it.
+     * @see #deleteDirectoryContents
+     * @param targetDir
+     */
     public static void deleteDirectory(File targetDir) {
         File[] allContents = targetDir.listFiles();
         if (allContents != null) {
@@ -492,6 +497,12 @@ public class AtlasUtil {
         return;
     }
 
+    /**
+     * Delete all contents in the specified directory.
+     * 
+     * @see #deleteDirectory
+     * @param targetDir
+     */
     public static void deleteDirectoryContents(File targetDir) {
         File[] allContents = targetDir.listFiles();
         if (allContents != null) {

--- a/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasFieldActionService.java
+++ b/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasFieldActionService.java
@@ -659,6 +659,12 @@ public class DefaultAtlasFieldActionService implements AtlasFieldActionService {
         FieldType currentType = determineFieldType(field);
         for (Action action : actions) {
             ActionProcessor processor = findActionProcessor(action, currentType);
+            if (processor == null) {
+                AtlasUtil.addAudit(session, field, String.format(
+                    "Couldn't find metadata for a FieldAction '%s', please make sure it's in the classpath, and also have a service declaration under META-INF/services. Ignoring...", action.getDisplayName()),
+                    AuditStatus.WARN, null);
+                continue;
+            }
             ActionDetail detail = processor.getActionDetail();
             if (detail == null) {
                 AtlasUtil.addAudit(session, field, String.format(

--- a/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasPreviewContext.java
+++ b/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasPreviewContext.java
@@ -135,6 +135,7 @@ class DefaultAtlasPreviewContext extends DefaultAtlasContext implements AtlasPre
                             AtlasUtil.addAudit(session, targetField,
                                     "It's not yet supported to have a collection field as a part of multiple target fields in a same mapping",
                                     AuditStatus.ERROR, null);
+                            session.getAudits().getAudit().addAll(session.head().getAudits());
                             return session.getAudits();
                         }
                         if (index != null) {
@@ -153,6 +154,7 @@ class DefaultAtlasPreviewContext extends DefaultAtlasContext implements AtlasPre
                             collectionHelper.copyCollectionIndexes(sourceFieldGroup, subSourceField, subTargetField, previousTargetField);
                             previousTargetField = subTargetField;
                             if (!convertSourceToTarget(session, subSourceField, subTargetField)) {
+                                session.getAudits().getAudit().addAll(session.head().getAudits());
                                 return session.getAudits();
                             };
                             Field processed = subTargetField;
@@ -177,9 +179,11 @@ class DefaultAtlasPreviewContext extends DefaultAtlasContext implements AtlasPre
                     }
                 }
                 if (session.hasErrors()) {
+                    session.getAudits().getAudit().addAll(session.head().getAudits());
                     return session.getAudits();
                 }
                 if (!convertSourceToTarget(session, session.head().getSourceField(), targetField)) {
+                    session.getAudits().getAudit().addAll(session.head().getAudits());
                     return session.getAudits();
                 }
                 Field processed = targetField;
@@ -193,6 +197,7 @@ class DefaultAtlasPreviewContext extends DefaultAtlasContext implements AtlasPre
             targetField = targetFields.get(0);
             Field combined = processCombineField(session, cloned, sourceFields, targetField);
             if (!convertSourceToTarget(session, combined, targetField)) {
+                session.getAudits().getAudit().addAll(session.head().getAudits());
                 return session.getAudits();
             }
             applyFieldActions(session, targetField);
@@ -208,9 +213,11 @@ class DefaultAtlasPreviewContext extends DefaultAtlasContext implements AtlasPre
                 if (LOG.isDebugEnabled()) {
                     LOG.error("", e);
                 }
+                session.getAudits().getAudit().addAll(session.head().getAudits());
                 return session.getAudits();
             }
             if (separatedFields == null) {
+                session.getAudits().getAudit().addAll(session.head().getAudits());
                 return session.getAudits();
             }
             for (Field f : targetFields) {
@@ -241,6 +248,7 @@ class DefaultAtlasPreviewContext extends DefaultAtlasContext implements AtlasPre
         }
         mapping.getOutputField().clear();
         mapping.getOutputField().addAll(cloned.getOutputField());
+        session.getAudits().getAudit().addAll(session.head().getAudits());
         return session.getAudits();
     }
 

--- a/lib/service/src/main/java/io/atlasmap/service/AtlasLibraryLoader.java
+++ b/lib/service/src/main/java/io/atlasmap/service/AtlasLibraryLoader.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Modifier;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -85,13 +86,26 @@ public class AtlasLibraryLoader extends CompoundClassLoader {
         reload();
     }
 
-    public void clearLibaries() {
+    public void clearLibraries() {
+        if (this.urlClassLoader != null) {
+            try {
+                this.urlClassLoader.close();
+            } catch (Exception e) {
+                LOG.warn("Ignoring an error while closing an old URLClassLoader: {}", e.getMessage());
+            }
+            this.urlClassLoader = null;
+        }
+
         File[] files = saveDir.listFiles();
         if (!saveDir.exists() || !saveDir.isDirectory() || files == null) {
             return;
         }
         for (File f : saveDir.listFiles()) {
-            f.delete();
+            try {
+                Files.delete(f.toPath());
+             } catch (Exception e) {
+                LOG.warn("Failed to remove jar file: '{}'", e.getMessage());
+            };
         }
         reload();
     }

--- a/lib/service/src/main/java/io/atlasmap/service/AtlasService.java
+++ b/lib/service/src/main/java/io/atlasmap/service/AtlasService.java
@@ -122,7 +122,7 @@ public class AtlasService {
         String atlasmapAdmPath = System.getProperty(ATLASMAP_ADM_PATH);
         if (atlasmapAdmPath != null && atlasmapAdmPath.length() > 0) {
             LOG.debug("Loading initial ADM file: {}", atlasmapAdmPath);
-            this.libraryLoader.clearLibaries();
+            this.libraryLoader.clearLibraries();
             ADMArchiveHandler admHandler = new ADMArchiveHandler(this.libraryLoader);
             java.nio.file.Path mappingDirPath = Paths.get(getMappingSubDirectory(0));
             admHandler.setPersistDirectory(mappingDirPath);
@@ -304,7 +304,7 @@ public class AtlasService {
         @ApiResponse(responseCode = "204", description = "Unable to remove all user-defined JAR files")})
     public Response resetUserLibs() {
         LOG.debug("resetUserLibs");
-        this.libraryLoader.clearLibaries();
+        this.libraryLoader.clearLibraries();
         return Response.ok().build();
     }
 
@@ -632,7 +632,12 @@ public class AtlasService {
             if (LOG.isDebugEnabled()) {
                 LOG.error("", e);
             }
-            throw new WebApplicationException("Could not read file part: " + e.getMessage());
+            StringBuilder buf = new StringBuilder();
+            buf.append("Failed to import a jar file. This error occurs when:\n")
+                .append(("\t1. The jar file is not compatible with the JVM AtlasMap backend server is running on\n"))
+                .append("\t2. The jar file is broken\n")
+                .append("\t3. There is a missing file under META-INF/services, i.e. Java service declaration for custom transformation, custom transformation model, custom mapping builder, etc\n");
+            throw new WebApplicationException(buf.toString(), e);
         }
         return Response.ok().build();
     }

--- a/lib/service/src/test/java/io/atlasmap/service/AtlasServiceTest.java
+++ b/lib/service/src/test/java/io/atlasmap/service/AtlasServiceTest.java
@@ -17,13 +17,19 @@ package io.atlasmap.service;
 
 import static io.atlasmap.v2.MappingFileType.JSON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.List;
 import java.util.jar.JarEntry;
@@ -31,21 +37,24 @@ import java.util.jar.JarOutputStream;
 
 import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
+import io.atlasmap.core.AtlasUtil;
+import io.atlasmap.v2.Action;
 import io.atlasmap.v2.AtlasMapping;
 import io.atlasmap.v2.Audit;
+import io.atlasmap.v2.AuditStatus;
 import io.atlasmap.v2.Audits;
 import io.atlasmap.v2.BaseMapping;
 import io.atlasmap.v2.Field;
@@ -54,6 +63,7 @@ import io.atlasmap.v2.Json;
 import io.atlasmap.v2.Mapping;
 import io.atlasmap.v2.MappingType;
 import io.atlasmap.v2.Mappings;
+import io.atlasmap.v2.ProcessMappingRequest;
 import io.atlasmap.v2.ProcessMappingResponse;
 import io.atlasmap.v2.StringMap;
 import io.atlasmap.v2.StringMapEntry;
@@ -61,30 +71,29 @@ import io.atlasmap.v2.StringMapEntry;
 public class AtlasServiceTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(AtlasServiceTest.class);
+    private static final String TEMP_DIR = "target/with space";
+    private static final String TEST_JAR_DIR = "target/tmp";
+    private static final String TEST_JAR_PATH = TEST_JAR_DIR + "/my.jar";
 
-    @TempDir
-    File tmpDir;
-    
     private AtlasService service = null;
     private ObjectMapper mapper = null;
-    private String initialValueOfWorkspace;
 
     @BeforeEach
     public void setUp() throws Exception {
-        initialValueOfWorkspace = System.getProperty(AtlasService.ATLASMAP_WORKSPACE);
+        File workspaceFolderWithSpace = new File(TEMP_DIR);
+        System.setProperty(AtlasService.ATLASMAP_WORKSPACE, workspaceFolderWithSpace.getAbsolutePath());
         service = new AtlasService();
         mapper = Json.mapper();
     }
 
     @AfterEach
     public void tearDown() {
+        service.resetUserLibs();
+        service.resetAllMappings();
         service = null;
         mapper = null;
-        if(initialValueOfWorkspace != null) {
-            System.setProperty(AtlasService.ATLASMAP_WORKSPACE, initialValueOfWorkspace);
-        } else {
-            System.clearProperty(AtlasService.ATLASMAP_WORKSPACE);
-        }
+        AtlasUtil.deleteDirectory(new File(TEST_JAR_DIR));
+        AtlasUtil.deleteDirectory(new File(TEMP_DIR));
     }
 
     @Test
@@ -108,7 +117,8 @@ public class AtlasServiceTest {
     @Test
     public void testGetMapping() {
         Response resp = service.getMappingRequest(JSON, 3);
-        assertEquals(byte[].class, resp.getEntity().getClass());
+        assertEquals(204, resp.getStatus());
+        assertNull(resp.getEntity());
     }
 
     @Test
@@ -132,17 +142,39 @@ public class AtlasServiceTest {
 
     @Test
     public void testJarUpload() throws Exception {
-        File workspaceFolderWithSpace = new File(tmpDir, "with space");
-        System.setProperty(AtlasService.ATLASMAP_WORKSPACE, workspaceFolderWithSpace.getAbsolutePath());
-        new File("target/tmp").mkdirs();
+        createJarFile(false, false);
+        FileInputStream jarIn = new FileInputStream(TEST_JAR_PATH);
+        Response resUL = service.uploadLibrary(jarIn);
+        assertEquals(200, resUL.getStatus());
+        Response resFA = service.listFieldActions(null);
+        assertEquals(200, resFA.getStatus());
+        String responseJson = new String((byte[])resFA.getEntity());
+        assertTrue(responseJson.contains("myCustomFieldAction"));
+        Response resMB = service.listMappingBuilderClasses(null);
+        assertEquals(200, resMB.getStatus());
+        ArrayNode builders = (ArrayNode) new ObjectMapper().readTree((byte[])resMB.getEntity()).get("ArrayList");
+        assertEquals(1, builders.size());
+        assertEquals("io.atlasmap.service.my.MyCustomMappingBuilder", builders.get(0).asText());
+
+        BufferedInputStream in = new BufferedInputStream(new FileInputStream("src/test/resources/mappings/atlasmapping-custom-action.json"));
+        Response resVD = service.validateMappingRequest(in, 0, null);
+        assertEquals(200, resVD.getStatus());
+    }
+
+    private void createJarFile(boolean skipModel, boolean skipProcessor) throws Exception {
+        new File(TEST_JAR_DIR).mkdirs();
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         int answer = compiler.run(System.in, System.out, System.err,
-                "-d", "target/tmp",
+                "-d", TEST_JAR_DIR,
                 "src/test/resources/upload/io/atlasmap/service/my/MyCustomMappingBuilder.java",
                 "src/test/resources/upload/io/atlasmap/service/my/MyFieldActions.java",
                 "src/test/resources/upload/io/atlasmap/service/my/MyFieldActionsModel.java");
         assertEquals(0, answer);
-        JarOutputStream jarOut = new JarOutputStream(new FileOutputStream("target/tmp/my.jar"));
+        File jarFile = new File(TEST_JAR_PATH);
+        if (jarFile.exists()) {
+            jarFile.delete();
+        }
+        JarOutputStream jarOut = new JarOutputStream(new FileOutputStream(jarFile));
         jarOut.putNextEntry(new JarEntry("io/"));
         jarOut.closeEntry();
         jarOut.putNextEntry(new JarEntry("io/atlasmap/"));
@@ -154,7 +186,7 @@ public class AtlasServiceTest {
         JarEntry classEntry = new JarEntry("io/atlasmap/service/my/MyFieldActions.class");
         jarOut.putNextEntry(classEntry);
         byte[] buffer = new byte[1024];
-        BufferedInputStream in = new BufferedInputStream(new FileInputStream("target/tmp/io/atlasmap/service/my/MyFieldActions.class"));
+        BufferedInputStream in = new BufferedInputStream(new FileInputStream(TEST_JAR_DIR + "/io/atlasmap/service/my/MyFieldActions.class"));
         int count = -1;
         while ((count = in.read(buffer)) != -1) {
             jarOut.write(buffer, 0, count);
@@ -172,7 +204,7 @@ public class AtlasServiceTest {
         jarOut.closeEntry();
         classEntry = new JarEntry("io/atlasmap/service/my/MyCustomMappingBuilder.class");
         jarOut.putNextEntry(classEntry);
-        in = new BufferedInputStream(new FileInputStream("target/tmp/io/atlasmap/service/my/MyCustomMappingBuilder.class"));
+        in = new BufferedInputStream(new FileInputStream(TEST_JAR_DIR + "/io/atlasmap/service/my/MyCustomMappingBuilder.class"));
         count = -1;
         while ((count = in.read(buffer)) != -1) {
             jarOut.write(buffer, 0, count);
@@ -184,39 +216,77 @@ public class AtlasServiceTest {
         jarOut.closeEntry();
         jarOut.putNextEntry(new JarEntry("META-INF/services/"));
         jarOut.closeEntry();
-        JarEntry svcEntry = new JarEntry("META-INF/services/io.atlasmap.spi.AtlasFieldAction");
-        jarOut.putNextEntry(svcEntry);
-        in = new BufferedInputStream(new FileInputStream("src/test/resources/upload/META-INF/services/io.atlasmap.spi.AtlasFieldAction"));
-        while ((count = in.read(buffer)) != -1) {
-            jarOut.write(buffer, 0, count);
+        if (!skipProcessor) {
+            JarEntry svcEntry = new JarEntry("META-INF/services/io.atlasmap.spi.AtlasFieldAction");
+            jarOut.putNextEntry(svcEntry);
+            in = new BufferedInputStream(new FileInputStream("src/test/resources/upload/META-INF/services/io.atlasmap.spi.AtlasFieldAction"));
+            while ((count = in.read(buffer)) != -1) {
+                jarOut.write(buffer, 0, count);
+            }
+            in.close();
+            jarOut.closeEntry();
         }
-        in.close();
-        jarOut.closeEntry();
-        svcEntry = new JarEntry("META-INF/services/io.atlasmap.v2.Action");
-        jarOut.putNextEntry(svcEntry);
-        in = new BufferedInputStream(new FileInputStream("src/test/resources/upload/META-INF/services/io.atlasmap.v2.Action"));
-        while ((count = in.read(buffer)) != -1) {
-            jarOut.write(buffer, 0, count);
+        if (!skipModel) {
+            JarEntry svcEntry = new JarEntry("META-INF/services/io.atlasmap.v2.Action");
+            jarOut.putNextEntry(svcEntry);
+            in = new BufferedInputStream(new FileInputStream("src/test/resources/upload/META-INF/services/io.atlasmap.v2.Action"));
+            while ((count = in.read(buffer)) != -1) {
+                jarOut.write(buffer, 0, count);
+            }
+            in.close();
+            jarOut.closeEntry();
         }
-        in.close();
-        jarOut.closeEntry();
         jarOut.close();
-        FileInputStream jarIn = new FileInputStream("target/tmp/my.jar");
+    }
+
+    @Test
+    public void testJarUploadNoModelLoader() throws Exception {
+        assumeFalse(isWindowsJDK8());
+
+        createJarFile(true, false);
+        FileInputStream jarIn = new FileInputStream(TEST_JAR_PATH);
+        WebApplicationException e = assertThrows(WebApplicationException.class, () -> {
+            service.uploadLibrary(jarIn);
+        });
+        assertTrue(e.getMessage().contains("META-INF/services"), e.getMessage());
+    }
+
+    @Test
+    public void testJarUploadNoProcessorLoader() throws Exception {
+        assumeFalse(isWindowsJDK8());
+
+        createJarFile(false, true);
+        FileInputStream jarIn = new FileInputStream(TEST_JAR_PATH);
         Response resUL = service.uploadLibrary(jarIn);
         assertEquals(200, resUL.getStatus());
         Response resFA = service.listFieldActions(null);
         assertEquals(200, resFA.getStatus());
         String responseJson = new String((byte[])resFA.getEntity());
-        assertTrue(responseJson.contains("myCustomFieldAction"), responseJson);
-        Response resMB = service.listMappingBuilderClasses(null);
-        assertEquals(200, resMB.getStatus());
-        ArrayNode builders = (ArrayNode) new ObjectMapper().readTree((byte[])resMB.getEntity()).get("ArrayList");
-        assertEquals(1, builders.size());
-        assertEquals("io.atlasmap.service.my.MyCustomMappingBuilder", builders.get(0).asText());
+        assertFalse(responseJson.contains("myCustomFieldAction"));
 
-        in = new BufferedInputStream(new FileInputStream("src/test/resources/mappings/atlasmapping-custom-action.json"));
-        Response resVD = service.validateMappingRequest(in, 0, null);
-        assertEquals(200, resVD.getStatus());
+        BufferedInputStream in = new BufferedInputStream(new FileInputStream("src/test/resources/mappings/atlasmapping-custom-action.json"));
+        AtlasMapping am = mapper.readValue(in, AtlasMapping.class);
+        Mapping m = (Mapping) am.getMappings().getMapping().get(0);
+        Field f = m.getInputField().get(0);
+        f.setValue("foo");
+        Action action = f.getActions().get(0);
+        Method method = action.getClass().getDeclaredMethod("setParam", new Class[] {String.class});
+        method.invoke(action, "param");
+        ProcessMappingRequest request = new ProcessMappingRequest();
+        request.setMapping(m);
+        Response resMR = service.processMappingRequest(new ByteArrayInputStream(mapper.writeValueAsBytes(request)), null);
+        assertEquals(200, resMR.getStatus());
+        ProcessMappingResponse pmr = Json.mapper().readValue((byte[])resMR.getEntity(), ProcessMappingResponse.class);
+        assertEquals(1, pmr.getAudits().getAudit().size(), printAudit(pmr.getAudits()));
+        Audit audit = pmr.getAudits().getAudit().get(0);
+        assertEquals(AuditStatus.WARN, audit.getStatus());
+        assertTrue(audit.getMessage().contains("Couldn't find metadata for a FieldAction 'MyFieldActionsModel'"));
+        assertEquals("foo", pmr.getMapping().getOutputField().get(0).getValue());
+    }
+
+    private boolean isWindowsJDK8() {
+        return System.getProperty("os.name").toLowerCase().contains("win")
+            && Double.parseDouble(System.getProperty("java.specification.version")) < 9;
     }
 
     @Test
@@ -251,6 +321,31 @@ public class AtlasServiceTest {
         assertEquals(0, resp.getAudits().getAudit().size(), printAudit(resp.getAudits()));
         Field field = resp.getMapping().getInputField().get(0);
         assertEquals("/primitives/stringPrimitive", field.getPath());
+    }
+
+    @Test
+    public void testProcessMappingCustomAction() throws Exception {
+        createJarFile(false, false);
+        FileInputStream jarIn = new FileInputStream(TEST_JAR_PATH);
+        Response resUL = service.uploadLibrary(jarIn);
+        assertEquals(200, resUL.getStatus());
+        Response resFA = service.listFieldActions(null);
+        assertEquals(200, resFA.getStatus());
+        BufferedInputStream in = new BufferedInputStream(new FileInputStream("src/test/resources/mappings/atlasmapping-custom-action.json"));
+        AtlasMapping am = mapper.readValue(in, AtlasMapping.class);
+        Mapping m = (Mapping) am.getMappings().getMapping().get(0);
+        Field f = m.getInputField().get(0);
+        f.setValue("foo");
+        Action action = f.getActions().get(0);
+        Method method = action.getClass().getDeclaredMethod("setParam", new Class[] {String.class});
+        method.invoke(action, "param");
+        ProcessMappingRequest request = new ProcessMappingRequest();
+        request.setMapping(m);
+        Response resMR = service.processMappingRequest(new ByteArrayInputStream(mapper.writeValueAsBytes(request)), null);
+        assertEquals(200, resMR.getStatus());
+        ProcessMappingResponse pmr = Json.mapper().readValue((byte[])resMR.getEntity(), ProcessMappingResponse.class);
+        assertEquals(0, pmr.getAudits().getAudit().size(), printAudit(pmr.getAudits()));
+        assertEquals("param foo", pmr.getMapping().getOutputField().get(0).getValue());
     }
 
     protected UriInfo generateTestUriInfo(String baseUri, String absoluteUri) throws Exception {


### PR DESCRIPTION
…ction are missing

Fixes: #3399

fix: Reset all doesn't dispose jar on windows

Fixes: atlasmap#3403
Since URLClassLoader keeps file handler open, on windows, loaded jar file can't be removed until URLClassLoader#close() is invoked and file handlers are released.
Unfortunately even URLClassLoader#close() didn't help on windows+java8. Thus tests are conditionally skipped.