### PR TITLE
fix: Same name element with a different inline type in the XSD is wro…

### DIFF
--- a/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/XmlSchemaInspectionTest.java
+++ b/lib/modules/xml/core/src/test/java/io/atlasmap/xml/inspect/XmlSchemaInspectionTest.java
@@ -16,6 +16,7 @@
 package io.atlasmap.xml.inspect;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -28,6 +29,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import io.atlasmap.v2.CollectionType;
+import io.atlasmap.v2.FieldStatus;
 import io.atlasmap.v2.FieldType;
 import io.atlasmap.xml.v2.Restriction;
 import io.atlasmap.xml.v2.RestrictionType;
@@ -422,4 +424,48 @@ public class XmlSchemaInspectionTest extends BaseXmlInspectionServiceTest {
         });
     }
 
+    @Test
+    public void testInspectSchemaFileSameNameElement() throws Exception {
+        File schemaFile = Paths.get("src/test/resources/inspect/samename.xsd").toFile();
+
+        XmlInspectionService service = new XmlInspectionService();
+        XmlDocument xmlDocument = service.inspectSchema(schemaFile);
+
+        assertNotNull(xmlDocument);
+        assertNotNull(xmlDocument.getFields());
+        assertEquals(1, xmlDocument.getFields().getField().size());
+        XmlComplexType root = (XmlComplexType) xmlDocument.getFields().getField().get(0);
+        assertNotNull(root);
+        assertEquals(2, root.getXmlFields().getXmlField().size());
+        XmlField paramsField = root.getXmlFields().getXmlField().get(1);
+        assertEquals("params", paramsField.getName());
+        assertEquals("/methodCall/params", paramsField.getPath());
+        assertEquals(FieldType.COMPLEX, paramsField.getFieldType());
+        XmlComplexType paramsComplex = (XmlComplexType) paramsField;
+        assertEquals(1, paramsComplex.getXmlFields().getXmlField().size());
+        XmlField valueField = paramsComplex.getXmlFields().getXmlField().get(0);
+        assertEquals("value", valueField.getName());
+        assertEquals("/methodCall/params/value", valueField.getPath());
+        assertEquals(FieldType.COMPLEX, valueField.getFieldType());
+        XmlComplexType valueComplex = (XmlComplexType) valueField;
+        assertEquals(1, valueComplex.getXmlFields().getXmlField().size());
+        XmlField structField = valueComplex.getXmlFields().getXmlField().get(0);
+        assertEquals("struct", structField.getName());
+        assertEquals("/methodCall/params/value/struct", structField.getPath());
+        assertEquals(FieldType.COMPLEX, structField.getFieldType());
+        XmlComplexType structComplex = (XmlComplexType) structField;
+        assertEquals(1, structComplex.getXmlFields().getXmlField().size());
+        XmlField memberField = structComplex.getXmlFields().getXmlField().get(0);
+        assertEquals("member", memberField.getName());
+        assertEquals("/methodCall/params/value/struct/member", memberField.getPath());
+        assertEquals(FieldType.COMPLEX, memberField.getFieldType());
+        XmlComplexType memberComplex = (XmlComplexType) memberField;
+        assertEquals(2, memberComplex.getXmlFields().getXmlField().size());
+        XmlField value2Field = memberComplex.getXmlFields().getXmlField().get(1);
+        assertEquals("value", value2Field.getName());
+        assertEquals("/methodCall/params/value/struct/member/value", value2Field.getPath());
+        assertEquals(FieldType.COMPLEX, value2Field.getFieldType());
+        XmlComplexType value2Complex = (XmlComplexType) value2Field;
+        assertEquals(5, value2Complex.getXmlFields().getXmlField().size());
+    }
 }

--- a/lib/modules/xml/core/src/test/resources/inspect/samename.xsd
+++ b/lib/modules/xml/core/src/test/resources/inspect/samename.xsd
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Created with Liquid Technologies Online Tools 1.0 (https://www.liquid-technologies.com) -->
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="methodCall">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="methodName" type="xs:string" />
+        <xs:element name="params">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="value">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="struct">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element maxOccurs="unbounded" name="member">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="name" type="xs:string" />
+                                <xs:element name="value" maxOccurs="unbounded">
+                                  <xs:complexType>
+                                    <xs:sequence>
+                                      <xs:element minOccurs="0" name="boolean" type="xs:unsignedInt" />
+                                      <xs:element minOccurs="0" name="dateTimeiso8601" type="xs:string" />
+                                      <xs:element minOccurs="0" name="array1">
+                                        <xs:complexType>
+                                          <xs:sequence>
+                                            <xs:element name="data">
+                                              <xs:complexType>
+                                                <xs:sequence>
+                                                  <xs:element maxOccurs="unbounded" name="value">
+                                                    <xs:complexType>
+                                                      <xs:sequence>
+                                                        <xs:element name="i4" type="xs:unsignedByte" />
+                                                      </xs:sequence>
+                                                    </xs:complexType>
+                                                  </xs:element>
+                                                </xs:sequence>
+                                              </xs:complexType>
+                                            </xs:element>
+                                          </xs:sequence>
+                                        </xs:complexType>
+                                      </xs:element>
+                                      <xs:element minOccurs="0" name="string" type="xs:string" />
+                                      <xs:element minOccurs="0" name="i4" type="xs:integer" />
+                                    </xs:sequence>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
…ngly cached

Fixes: #3470
Now I can't remember why I thought we had to cache with element name in #2374. Put a real usecase if it's really needed.
