### PR TITLE
fix: Fix unhandled promise rejection in UI tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,9 +79,9 @@
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>
-    <node.version>v14.17.3</node.version>
-    <npm.version>6.14.13</npm.version>
-    <yarn.version>v1.22.10</yarn.version>
+    <node.version>v16.13.1</node.version>
+    <npm.version>8.3.0</npm.version>
+    <yarn.version>v1.22.17</yarn.version>
     <checkstyle.skip>false</checkstyle.skip>
   </properties>
 

--- a/ui/packages/atlasmap-core/src/services/document-management.service.spec.ts
+++ b/ui/packages/atlasmap-core/src/services/document-management.service.spec.ts
@@ -18,12 +18,12 @@ import {
   DocumentInitializationModel,
 } from '../models/config.model';
 import { DocumentType, FieldType, InspectionType } from '../contracts/common';
+import { Input, Options } from 'ky';
 
 import { DocumentDefinition } from '../models/document-definition.model';
 import { DocumentManagementService } from '../services/document-management.service';
 import { Field } from '../models/field.model';
 import { InitializationService } from './initialization.service';
-import { Input } from 'ky';
 import { MappingDefinition } from '../models/mapping-definition.model';
 import { TestUtils } from '../../test/test-util';
 import atlasmapInspectionComplexObjectRootedJson from '../../../../test-resources/inspected/atlasmap-inspection-complex-object-rooted.json';
@@ -338,6 +338,16 @@ describe('DocumentManagementService', () => {
   });
 
   test('Constant field', () => {
+    spyOn(ky, 'put').and.callFake((_url: Input, options: Options) => {
+      return new (class {
+        json(): Promise<any> {
+          return Promise.resolve(options.json);
+        }
+        arrayBuffer(): Promise<ArrayBuffer> {
+          return Promise.resolve(new ArrayBuffer(0));
+        }
+      })();
+    });
     cfg.mappings = new MappingDefinition();
     expect(cfg.constantDoc.fields.length).toBe(0);
     service.createConstant('testConst', 'testConstVal', 'STRING', false);
@@ -368,6 +378,16 @@ describe('DocumentManagementService', () => {
   });
 
   test('Property field', () => {
+    spyOn(ky, 'put').and.callFake((_url: Input, options: Options) => {
+      return new (class {
+        json(): Promise<any> {
+          return Promise.resolve(options.json);
+        }
+        arrayBuffer(): Promise<ArrayBuffer> {
+          return Promise.resolve(new ArrayBuffer(0));
+        }
+      })();
+    });
     cfg.mappings = new MappingDefinition();
     expect(cfg.sourcePropertyDoc.fields.length).toBe(0);
     expect(cfg.targetPropertyDoc.fields.length).toBe(0);

--- a/ui/packages/atlasmap-core/src/services/mapping-expression.service.spec.ts
+++ b/ui/packages/atlasmap-core/src/services/mapping-expression.service.spec.ts
@@ -19,6 +19,7 @@ import {
 } from '../models/config.model';
 import { DocumentType, InspectionType } from '../contracts/common';
 import { IPosition, Position } from 'monaco-editor';
+import ky, { Input, Options } from 'ky';
 
 import { DocumentDefinition } from '../models/document-definition.model';
 import { Field } from '../models/field.model';
@@ -27,7 +28,6 @@ import { MappingDefinition } from '../models/mapping-definition.model';
 import { MappingExpressionService } from './mapping-expression.service';
 import { MappingModel } from '../models/mapping.model';
 import { TestUtils } from '../../test/test-util';
-import ky from 'ky';
 
 describe('MappingExpressionService', () => {
   let cfg: ConfigModel;
@@ -176,6 +176,16 @@ describe('MappingExpressionService', () => {
   });
 
   test('test adding a field to an expression makes it into the mapping', () => {
+    spyOn(ky, 'put').and.callFake((_url: Input, options: Options) => {
+      return new (class {
+        json(): Promise<any> {
+          return Promise.resolve(options.json);
+        }
+        arrayBuffer(): Promise<ArrayBuffer> {
+          return Promise.resolve(new ArrayBuffer(0));
+        }
+      })();
+    });
     TestUtils.createMockMappings(cfg);
     const mapping = cfg.mappings!.mappings[1];
 

--- a/ui/packages/atlasmap-core/src/utils/mapping-serializer.spec.ts
+++ b/ui/packages/atlasmap-core/src/utils/mapping-serializer.spec.ts
@@ -28,6 +28,7 @@ import {
   InspectionType,
 } from '../contracts/common';
 import { IAtlasMappingContainer, IMapping } from '../contracts/mapping';
+import ky, { Input, Options } from 'ky';
 
 import { CsvInspectionModel } from '../models/inspect/csv-inspection.model';
 import { DocumentInspectionUtil } from './document-inspection-util';
@@ -55,8 +56,6 @@ import atlasMappingSplitCollapseJson from '../../../../test-resources/mapping/at
 import atlasMappingSplitJson from '../../../../test-resources/mapping/atlasmapping-split.json';
 import atlasMappingTestJson from '../../../../test-resources/mapping/atlasmapping-test.json';
 import atlasmapFieldActionJson from '../../../../test-resources/fieldActions/atlasmap-field-action.json';
-
-import ky from 'ky';
 
 function createTwitter4jSourceDoc() {
   const twitter = new DocumentDefinition();
@@ -390,6 +389,16 @@ describe('MappingSerializer', () => {
     init.initialize();
     cfg = init.cfg;
     cfg.mappings = new MappingDefinition();
+    spyOn(ky, 'put').and.callFake((_url: Input, options: Options) => {
+      return new (class {
+        json(): Promise<any> {
+          return Promise.resolve(options.json);
+        }
+        arrayBuffer(): Promise<ArrayBuffer> {
+          return Promise.resolve(new ArrayBuffer(0));
+        }
+      })();
+    });
   });
 
   tName = 'deserialize & serialize mapping definition';

--- a/ui/packages/atlasmap-core/test/setup.tsx
+++ b/ui/packages/atlasmap-core/test/setup.tsx
@@ -21,3 +21,7 @@ var matchMedia = new MatchMediaMock();
 
 // re-export everything
 export * from '@testing-library/react';
+
+process.on('unhandledRejection', (reason) => {
+  console.log('REJECTION', reason);
+});

--- a/ui/packages/atlasmap-standalone/src/setupTests.js
+++ b/ui/packages/atlasmap-standalone/src/setupTests.js
@@ -13,7 +13,10 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-import '@testing-library/jest-dom';
+
+import MatchMediaMock from 'jest-matchmedia-mock';
+
+new MatchMediaMock();
 
 process.on('unhandledRejection', (reason) => {
   console.log('REJECTION', reason);


### PR DESCRIPTION
Fixes: #3560
Also updated to the latest node 16 and npm 8.3.0
node_modules would have to be rebuilt after this update. Remove it and run yarn install (or mvn install)