### PR TITLE
fix: replace existing CVS inspection parameters

### DIFF
--- a/ui/packages/atlasmap-core/src/models/inspect/csv-inspection.model.ts
+++ b/ui/packages/atlasmap-core/src/models/inspect/csv-inspection.model.ts
@@ -28,6 +28,7 @@ import {
   ICsvInspectionResponseContainer,
 } from '../../contracts/documents/csv';
 
+import { CommonUtil } from '../../utils/common-util';
 import { Field } from '../field.model';
 
 export class CsvInspectionModel extends DocumentInspectionModel {
@@ -84,8 +85,10 @@ export class CsvInspectionModel extends DocumentInspectionModel {
       this.doc.name = this.doc.id;
     }
     if (this.doc.inspectionParameters) {
-      const params = new URLSearchParams(this.doc.inspectionParameters);
-      this.doc.uri = this.doc.uri + '?' + params;
+      this.doc.uri = CommonUtil.urlWithParameters(
+        this.doc.uri,
+        this.doc.inspectionParameters
+      );
     }
 
     for (const field of csvDocument.fields.field) {

--- a/ui/packages/atlasmap-core/src/models/inspect/cvs-inspection.model.spec.ts
+++ b/ui/packages/atlasmap-core/src/models/inspect/cvs-inspection.model.spec.ts
@@ -1,0 +1,52 @@
+/*
+    Copyright (C) 2017 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+import { ConfigModel, DocumentDefinition } from '..';
+import { CsvInspectionModel } from './csv-inspection.model';
+
+describe('CsvInspectionModel', () => {
+  test('Duplicate document URI search parameters', () => {
+    const cfg = new ConfigModel();
+    const doc = new DocumentDefinition();
+    const cvs = new CsvInspectionModel(cfg, doc);
+
+    expect(cvs.doc.uri).toBeUndefined();
+
+    const response = {
+      CsvDocument: {
+        fields: {
+          field: {},
+        },
+      },
+    };
+
+    doc.uri = 'base:';
+    doc.inspectionParameters = {
+      a: '1',
+      b: '2',
+    };
+    cvs.parseResponse(response);
+    expect(cvs.doc.uri).toBe('base:?a=1&b=2');
+
+    doc.inspectionParameters = {
+      c: '3',
+      d: '4',
+    };
+
+    cvs.parseResponse(response);
+    expect(cvs.doc.uri).toBe('base:?c=3&d=4');
+  });
+});

--- a/ui/packages/atlasmap-core/src/utils/common-util.spec.ts
+++ b/ui/packages/atlasmap-core/src/utils/common-util.spec.ts
@@ -41,4 +41,16 @@ describe('CommonUtil', () => {
     const noop = CommonUtil.objectize(f);
     expect(noop).toBe(f);
   });
+
+  test('urlWithParameters', () => {
+    expect(CommonUtil.urlWithParameters('url:', {})).toBe('url:');
+    expect(CommonUtil.urlWithParameters('url:', { a: '1' })).toBe('url:?a=1');
+    expect(CommonUtil.urlWithParameters('url:?a=1', { b: '2' })).toBe(
+      'url:?b=2'
+    );
+    expect(
+      CommonUtil.urlWithParameters('url:?a=1&b=2', { b: '2', c: '3' })
+    ).toBe('url:?b=2&c=3');
+    expect(CommonUtil.urlWithParameters('url:?a=1&b=2', {})).toBe('url:');
+  });
 });

--- a/ui/packages/atlasmap-core/src/utils/common-util.ts
+++ b/ui/packages/atlasmap-core/src/utils/common-util.ts
@@ -224,4 +224,29 @@ export class CommonUtil {
       sourceStr.substr(index + origLen)
     );
   }
+
+  /**
+   * Returns the given URL with the query parameters replaced with the new
+   * values.
+   *
+   * @param url - the URL
+   * @param parameters - the new parameters to set
+   */
+  static urlWithParameters(
+    url: string,
+    parameters: string[][] | Record<string, string> | string | URLSearchParams
+  ): string {
+    const newUrl = new URL(url);
+    // we can't invoke delete in a loop over uri.searchParams, results
+    // become unreliable, so we gather the keys for deletion, also the
+    // URLSearchParams.keys() method is not available for some reason
+    const keys: string[] = [];
+    newUrl.searchParams.forEach((_, k) => keys.push(k));
+    keys.forEach((k) => newUrl.searchParams.delete(k));
+
+    const params = new URLSearchParams(parameters);
+    params.forEach((v, k) => newUrl.searchParams.append(k, v));
+
+    return newUrl.toString();
+  }
 }


### PR DESCRIPTION
When changing the CVS parameters the document URI accumulates previously
set parameters. This leads to unwanted parameters remaining, or more
than one value for a parameter being used.

This makes sure that when setting the CVS inspection parameters the
existing parameters are first removed. This way only the desired new
parameters are used.