### PR TITLE
fix: notify of mapping changes in initialization

### DIFF
--- a/ui/packages/atlasmap-core/src/services/initialization.service.ts
+++ b/ui/packages/atlasmap-core/src/services/initialization.service.ts
@@ -149,7 +149,26 @@ export class InitializationService {
       this.updateLoadingStatus('Loading source/target documents.');
       this.cfg.documentService.inspectDocuments().subscribe({
         next: () => {
+          // updateStatus() will nullify this.cfg.preloadedMappingJson
+          // let's store it for comparisson below
+          const preloadedMappingJson = this.cfg.preloadedMappingJson;
           this.updateStatus();
+          this.systemInitializedSource.subscribe(() => {
+            if (preloadedMappingJson) {
+              const maybeUpdatedMappingJson = JSON.stringify(
+                MappingSerializer.serializeMappings(this.cfg)
+              );
+              // inspection might change the mapping, for example the preloaded
+              // mapping could have a document URI that is no longer the same
+              // after inspection, e.g. when parameters change on the provided
+              // documents and differ from the parameters embedded in the
+              // provided mapping; in that case we need to notify that mapping
+              // has been changed
+              if (preloadedMappingJson !== maybeUpdatedMappingJson) {
+                this.cfg.mappingService.notifyMappingUpdated();
+              }
+            }
+          });
         },
       });
 

--- a/ui/test-resources/mapping/atlasmapping-cvs-to-json.json
+++ b/ui/test-resources/mapping/atlasmapping-cvs-to-json.json
@@ -1,0 +1,30 @@
+{
+  "AtlasMapping": {
+    "jsonType": "io.atlasmap.v2.AtlasMapping",
+    "dataSource": [
+      {
+        "jsonType": "io.atlasmap.v2.DataSource",
+        "id": "source",
+        "name": "source",
+        "description": "source",
+        "uri": "atlas:csv:source?format=Default&headers=A%2CB%2CC",
+        "dataSourceType": "SOURCE"
+      },
+      {
+        "jsonType": "io.atlasmap.json.v2.JsonDataSource",
+        "id": "target",
+        "name": "target",
+        "description": "target",
+        "uri": "atlas:json:target",
+        "dataSourceType": "TARGET"
+      }
+    ],
+    "mappings": {
+      "mapping": []
+    },
+    "name": "UI.0",
+    "lookupTables": { "lookupTable": [] },
+    "constants": { "constant": [] },
+    "properties": { "property": [] }
+  }
+}


### PR DESCRIPTION
When initializing with a preloaded mapping JSON, if the mapping JSON
changed, say because the inspection parameters that have changed and
this is reflected in the document URI, we need to notify that the
mapping changed.
A scenario in which this issue is encountered is when CSV parameters
change and no other change is performed. The saved mapping in that case
contains the old URI in the CVS document.

Fixes #3755