### PR TITLE
fix: exponentially increasing validation requests

### DIFF
--- a/ui/packages/atlasmap-core/src/services/initialization.service.spec.ts
+++ b/ui/packages/atlasmap-core/src/services/initialization.service.spec.ts
@@ -21,6 +21,7 @@ import {
 
 import { DocumentInitializationModel } from '../models/config.model';
 import { InitializationService } from '../services/initialization.service';
+import { Subject } from 'rxjs';
 import { TextEncoder } from 'text-encoding';
 import atlasmapFieldActionJson from '../../../../test-resources/fieldActions/atlasmap-field-action.json';
 import atlasmapInspectionMockJsonInstanceJson from '../../../../test-resources/inspected/atlasmap-inspection-mock-json-instance.json';
@@ -32,6 +33,7 @@ import atlasmapInspectionOldActionTargetJson from '../../../../test-resources/in
 import atlasmappingCvsToJson from '../../../../test-resources/mapping/atlasmapping-cvs-to-json.json';
 import atlasmappingOldActionJson from '../../../../test-resources/mapping/atlasmapping-old-action.json';
 import ky from 'ky/umd';
+import { take } from 'rxjs/operators';
 
 describe('InitializationService', () => {
   let service: InitializationService;
@@ -231,24 +233,30 @@ describe('InitializationService', () => {
     });
   });
 
-  test('notify of mapping changes upon inspection in initialization', (done) => {
-    const c = service.cfg;
-    c.initCfg.baseMappingServiceUrl = 'dummy';
-    c.initCfg.baseJSONInspectionServiceUrl = 'dummy';
-    c.initCfg.baseXMLInspectionServiceUrl = 'dummy';
-    c.initCfg.baseCSVInspectionServiceUrl = 'dummy';
+  // repeat the test three times to test that the notifications are sent only once,
+  // i.e. that they do not exponentially accumulate, that's why we use the singleton
+  // service here, as initialization service is usually a singleton at runtime:
+  const serviceNotificationCase = new InitializationService(ky);
+  test.each([1, 2, 3])(
+    'notify of mapping changes upon inspection in initialization run(%i)',
+    (_, done: any) => {
+      const c = serviceNotificationCase.cfg;
+      c.initCfg.baseMappingServiceUrl = 'dummy';
+      c.initCfg.baseJSONInspectionServiceUrl = 'dummy';
+      c.initCfg.baseXMLInspectionServiceUrl = 'dummy';
+      c.initCfg.baseCSVInspectionServiceUrl = 'dummy';
 
-    const source = new DocumentInitializationModel();
-    source.isSource = true;
-    source.type = DocumentType.CSV;
-    source.inspectionType = InspectionType.INSTANCE;
-    source.id = 'source';
-    source.inspectionSource = '1,2,3';
-    source.inspectionParameters = {
-      format: 'Default',
-      headers: 'D,I,F,F,E,R,E,N,T',
-    };
-    source.inspectionResult = `{
+      const source = new DocumentInitializationModel();
+      source.isSource = true;
+      source.type = DocumentType.CSV;
+      source.inspectionType = InspectionType.INSTANCE;
+      source.id = 'source';
+      source.inspectionSource = '1,2,3';
+      source.inspectionParameters = {
+        format: 'Default',
+        headers: 'D,I,F,F,E,R,E,N,T',
+      };
+      source.inspectionResult = `{
       "CsvInspectionResponse": {
         "jsonType": "io.atlasmap.csv.v2.CsvInspectionResponse",
         "csvDocument": {
@@ -290,39 +298,44 @@ describe('InitializationService', () => {
         "executionTime": 0
       }
     }`;
-    c.addDocument(source);
+      c.addDocument(source);
 
-    const target = new DocumentInitializationModel();
-    target.isSource = false;
-    target.id = 'target';
-    target.type = DocumentType.JSON;
-    target.inspectionResult = JSON.stringify(
-      atlasmapInspectionMockJsonInstanceJson
-    );
-    c.addDocument(target);
+      const target = new DocumentInitializationModel();
+      target.isSource = false;
+      target.id = 'target';
+      target.type = DocumentType.JSON;
+      target.inspectionResult = JSON.stringify(
+        atlasmapInspectionMockJsonInstanceJson
+      );
+      c.addDocument(target);
 
-    c.preloadedMappingJson = JSON.stringify(atlasmappingCvsToJson);
+      c.preloadedMappingJson = JSON.stringify(atlasmappingCvsToJson);
 
-    spyOn(service, 'runtimeServiceActive').and.callFake(async () => {
-      c.fieldActionService.isInitialized = true;
-      return true;
-    });
+      spyOn(serviceNotificationCase, 'runtimeServiceActive').and.callFake(
+        async () => {
+          c.fieldActionService.isInitialized = true;
+          return true;
+        }
+      );
 
-    let notifyMappingUpdatedSpy: jasmine.Spy;
-    const notified = new Promise<void>((resolve) => {
-      notifyMappingUpdatedSpy = spyOn(
+      const notified = new Subject<void>();
+      const notifyMappingUpdatedSpy = spyOn(
         c.mappingService,
         'notifyMappingUpdated'
-      ).and.callFake(() => {
-        resolve();
-      });
-    });
+      ).and.callFake(() => notified.next());
 
-    service
-      .initialize()
-      .then(() => notified.then(done))
-      .catch((error) => {
-        fail(error);
-      });
-  });
+      serviceNotificationCase
+        .initialize()
+        .then(() => {
+          // we take two (at most), but we expect only one
+          notified.pipe(take(2)).subscribe(() => {
+            expect(notifyMappingUpdatedSpy.calls.count()).toBe(1);
+            done();
+          });
+        })
+        .catch((error) => {
+          fail(error);
+        });
+    }
+  );
 });

--- a/ui/packages/atlasmap-core/src/services/initialization.service.ts
+++ b/ui/packages/atlasmap-core/src/services/initialization.service.ts
@@ -36,6 +36,7 @@ import { MappingManagementService } from './mapping-management.service';
 import { MappingPreviewService } from './mapping-preview.service';
 import { MappingSerializer } from '../utils/mapping-serializer';
 import { MappingUtil } from '../utils/mapping-util';
+import { first } from 'rxjs/operators';
 import ky from 'ky/umd';
 import log from 'loglevel';
 
@@ -147,30 +148,37 @@ export class InitializationService {
 
       // load documents from initialization parameters in embedded mode
       this.updateLoadingStatus('Loading source/target documents.');
-      this.cfg.documentService.inspectDocuments().subscribe({
-        next: () => {
-          // updateStatus() will nullify this.cfg.preloadedMappingJson
-          // let's store it for comparisson below
-          const preloadedMappingJson = this.cfg.preloadedMappingJson;
-          this.updateStatus();
-          this.systemInitializedSource.subscribe(() => {
-            if (preloadedMappingJson) {
-              const maybeUpdatedMappingJson = JSON.stringify(
-                MappingSerializer.serializeMappings(this.cfg)
-              );
-              // inspection might change the mapping, for example the preloaded
-              // mapping could have a document URI that is no longer the same
-              // after inspection, e.g. when parameters change on the provided
-              // documents and differ from the parameters embedded in the
-              // provided mapping; in that case we need to notify that mapping
-              // has been changed
-              if (preloadedMappingJson !== maybeUpdatedMappingJson) {
-                this.cfg.mappingService.notifyMappingUpdated();
+      const allDocs = this.cfg.getAllDocs();
+      // assumption is that there will be at least one document present
+      const lastDoc = allDocs[allDocs.length - 1];
+      this.cfg.documentService
+        .inspectDocuments()
+        // inspectedDocuments notifies for all documents, wait till the last document
+        .pipe(first((d) => d === lastDoc))
+        .subscribe({
+          next: () => {
+            // updateStatus() will nullify this.cfg.preloadedMappingJson
+            // let's store it for comparisson below
+            const preloadedMappingJson = this.cfg.preloadedMappingJson;
+            this.updateStatus();
+            this.systemInitializedSource.pipe(first()).subscribe(() => {
+              if (preloadedMappingJson) {
+                const maybeUpdatedMappingJson = JSON.stringify(
+                  MappingSerializer.serializeMappings(this.cfg)
+                );
+                // inspection might change the mapping, for example the preloaded
+                // mapping could have a document URI that is no longer the same
+                // after inspection, e.g. when parameters change on the provided
+                // documents and differ from the parameters embedded in the
+                // provided mapping; in that case we need to notify that mapping
+                // has been changed
+                if (preloadedMappingJson !== maybeUpdatedMappingJson) {
+                  this.cfg.mappingService.notifyMappingUpdated();
+                }
               }
-            }
-          });
-        },
-      });
+            });
+          },
+        });
 
       this.initializeWithMappingDigest().finally(() => {
         this.updateStatus();


### PR DESCRIPTION
This adds two guards to the subscriptions via the `first` operator,
firstly to continue only after all the documents have been processed,
and secondly to get notifications only for the first time the
initialization was done. Otherwise the notification would be triggered
for each document times each time initialization was done, and with each
document another observer would be registered with the subject, all'
leading to an exponentially increasing number of requests to the server
to validate the mapping.

Fixes #3761