### PR TITLE
fix: Implement server side field search

### DIFF
--- a/docs/src/main/asciidoc/developer-guide/openapi/dfdl/index.adoc
+++ b/docs/src/main/asciidoc/developer-guide/openapi/dfdl/index.adoc
@@ -232,6 +232,12 @@ endif::internal-generation[]
 | 
 |  
 
+| searchPhrase
+| 
+| String 
+| 
+|  
+
 | fieldNameExclusions
 | 
 | StringList 

--- a/docs/src/main/asciidoc/developer-guide/openapi/java/index.adoc
+++ b/docs/src/main/asciidoc/developer-guide/openapi/java/index.adoc
@@ -232,6 +232,12 @@ endif::internal-generation[]
 | 
 |  
 
+| searchPhrase
+| 
+| String 
+| 
+|  
+
 | fieldNameExclusions
 | 
 | StringList 

--- a/docs/src/main/asciidoc/developer-guide/openapi/json/index.adoc
+++ b/docs/src/main/asciidoc/developer-guide/openapi/json/index.adoc
@@ -451,6 +451,12 @@ endif::internal-generation[]
 | 
 |  
 
+| searchPhrase
+| 
+| String 
+| 
+|  
+
 | fieldNameExclusions
 | 
 | StringList 

--- a/docs/src/main/asciidoc/developer-guide/openapi/xml/index.adoc
+++ b/docs/src/main/asciidoc/developer-guide/openapi/xml/index.adoc
@@ -476,6 +476,12 @@ endif::internal-generation[]
 | 
 |  
 
+| searchPhrase
+| 
+| String 
+| 
+|  
+
 | fieldNameExclusions
 | 
 | StringList 

--- a/lib/model/src/main/java/io/atlasmap/v2/BaseInspectionRequest.java
+++ b/lib/model/src/main/java/io/atlasmap/v2/BaseInspectionRequest.java
@@ -26,6 +26,9 @@ public abstract class BaseInspectionRequest implements Serializable {
     /** Paths to inspect. */
     protected List<String> inspectPaths;
 
+    /** Phrase to limit the inspection **/
+    protected String searchPhrase;
+
     /**
      * Gets the paths to inspect.
      * @return paths
@@ -40,5 +43,21 @@ public abstract class BaseInspectionRequest implements Serializable {
      */
     public void setInspectPaths(List<String> inspectPaths) {
         this.inspectPaths = inspectPaths;
+    }
+
+    /**
+     * Gets the search phrase to limit the inspection.
+     * @return searchPhrase
+     */
+    public String getSearchPhrase() {
+        return searchPhrase;
+    }
+
+    /**
+     * Gets the search phrase to limit the inspection.
+     * @param searchPhrase phrase
+     */
+    public void setSearchPhrase(String searchPhrase) {
+        this.searchPhrase = searchPhrase;
     }
 }

--- a/lib/modules/json/service/src/main/java/io/atlasmap/json/service/JsonService.java
+++ b/lib/modules/json/service/src/main/java/io/atlasmap/json/service/JsonService.java
@@ -148,7 +148,7 @@ public class JsonService {
             response.setExecutionTime(System.currentTimeMillis() - startTime);
         }
 
-        AtlasUtil.excludeNotRequestedFields(d, request.getInspectPaths());
+        AtlasUtil.excludeNotRequestedFields(d, request.getInspectPaths(), request.getSearchPhrase());
 
         response.setJsonDocument(d);
         return Response.ok().entity(toJson(response)).build();

--- a/lib/modules/xml/service/src/main/java/io/atlasmap/xml/service/XmlService.java
+++ b/lib/modules/xml/service/src/main/java/io/atlasmap/xml/service/XmlService.java
@@ -149,7 +149,7 @@ public class XmlService {
             response.setExecutionTime(System.currentTimeMillis() - startTime);
         }
 
-        AtlasUtil.excludeNotRequestedFields(d, request.getInspectPaths());
+        AtlasUtil.excludeNotRequestedFields(d, request.getInspectPaths(), request.getSearchPhrase());
 
         response.setXmlDocument(d);
         return Response.ok().entity(toJson(response)).build();


### PR DESCRIPTION
<!-- Please follow the guildeline - https://github.com/atlasmap/atlasmap/wiki/AtlasMap-Developer-Memo -->
Fixes: #603

It implements the API side by introducing searchPhrase into InspectionRequest sent to /inspect. 
It should be straightforward to modify UI search to first call the /inspect with the searchPhrase provided and then do a usual client side search to update the tree.