### PR TITLE
fix: UI: Set constants dialog focus to the name input widget, not value.

### DIFF
--- a/ui/packages/atlasmap/src/UI/dialogs/ConstantDialog.tsx
+++ b/ui/packages/atlasmap/src/UI/dialogs/ConstantDialog.tsx
@@ -168,7 +168,6 @@ export const ConstantDialog: FunctionComponent<IConstantDialogProps> = ({
             value={value}
             onChange={handleOnValueChange}
             id={'constvalue'}
-            autoFocus={true}
             isRequired={true}
             data-testid={'constant-value-text-input'}
           />


### PR DESCRIPTION
Fixes: #3852

<!-- Please follow the guildeline - https://github.com/atlasmap/atlasmap/wiki/AtlasMap-Developer-Memo -->
Fixes: #
