### PR TITLE
fix: Put CSV body and parameters into CsvInspectionRequest

### DIFF
--- a/docs/src/main/asciidoc/developer-guide/openapi/csv/index.adoc
+++ b/docs/src/main/asciidoc/developer-guide/openapi/csv/index.adoc
@@ -53,8 +53,8 @@ Inspect a CSV instance and return a Document object
 |===
 |Name| Description| Required| Default| Pattern
 
-| body
-| Csv <<string>>
+| CsvInspectionRequest
+| JsonInspectionRequest object <<CsvInspectionRequest>>
 | -
 | 
 | 
@@ -63,97 +63,6 @@ Inspect a CSV instance and return a Document object
 
 
 
-====== Query Parameters
-
-[cols="2,3,1,1,1"]
-|===
-|Name| Description| Required| Default| Pattern
-
-| format
-|  
-| -
-| null
-| 
-
-| delimiter
-|  
-| -
-| null
-| 
-
-| firstRecordAsHeader
-|  
-| -
-| null
-| 
-
-| skipRecordHeader
-|  
-| -
-| null
-| 
-
-| headers
-|  
-| -
-| null
-| 
-
-| commentMarker
-|  
-| -
-| null
-| 
-
-| escape
-|  
-| -
-| null
-| 
-
-| ignoreEmptyLines
-|  
-| -
-| null
-| 
-
-| ignoreHeaderCase
-|  
-| -
-| null
-| 
-
-| ignoreSurroundingSpaces
-|  
-| -
-| null
-| 
-
-| nullString
-|  
-| -
-| null
-| 
-
-| quote
-|  
-| -
-| null
-| 
-
-| allowDuplicateHeaderNames
-|  
-| -
-| null
-| 
-
-| allowMissingColumnNames
-|  
-| -
-| null
-| 
-
-|===
 
 
 ===== Return Type
@@ -217,6 +126,79 @@ endif::internal-generation[]
 
 | @type
 | 
+| String 
+| 
+|  
+
+|===
+
+
+[#CsvInspectionRequest]
+=== _CsvInspectionRequest_ 
+
+
+
+[.fields-CsvInspectionRequest]
+[cols="2,1,2,4,1"]
+|===
+| Field Name| Required| Type| Description| Format
+
+| uri
+| 
+| String 
+| 
+|  
+
+| inspectionType
+| 
+| String 
+| 
+|  _Enum:_ SCHEMA, INSTANCE, JAVA_CLASS, 
+
+| options
+| 
+| Map  of <<string>>
+| 
+|  
+
+| fieldNameExclusions
+| 
+| StringList 
+| 
+|  
+
+| typeNameExclusions
+| 
+| StringList 
+| 
+|  
+
+| namespaceExclusions
+| 
+| StringList 
+| 
+|  
+
+| inspectPaths
+| 
+| List  of <<string>>
+| 
+|  
+
+| searchPhrase
+| 
+| String 
+| 
+|  
+
+| csvData
+| 
+| String 
+| 
+|  
+
+| jsonType
+| X
 | String 
 | 
 |  
@@ -474,6 +456,25 @@ endif::internal-generation[]
 | field
 | 
 | List  of <<Field>>
+| 
+|  
+
+|===
+
+
+[#StringList]
+=== _StringList_ 
+
+
+
+[.fields-StringList]
+[cols="2,1,2,4,1"]
+|===
+| Field Name| Required| Type| Description| Format
+
+| string
+| 
+| List  of <<string>>
 | 
 |  
 

--- a/docs/src/main/asciidoc/developer-guide/openapi/dfdl/index.adoc
+++ b/docs/src/main/asciidoc/developer-guide/openapi/dfdl/index.adoc
@@ -143,15 +143,21 @@ endif::internal-generation[]
 |===
 | Field Name| Required| Type| Description| Format
 
-| inspectPaths
+| uri
 | 
-| List  of <<string>>
+| String 
 | 
 |  
 
-| searchPhrase
+| inspectionType
 | 
 | String 
+| 
+|  _Enum:_ SCHEMA, INSTANCE, JAVA_CLASS, 
+
+| options
+| 
+| Map  of <<string>>
 | 
 |  
 
@@ -173,33 +179,27 @@ endif::internal-generation[]
 | 
 |  
 
+| inspectPaths
+| 
+| List  of <<string>>
+| 
+|  
+
+| searchPhrase
+| 
+| String 
+| 
+|  
+
 | xmlData
 | 
 | String 
 | 
 |  
 
-| uri
-| 
-| String 
-| 
-|  
-
-| type
-| 
-| String 
-| 
-|  _Enum:_ ALL, INSTANCE, SCHEMA, NONE, 
-
 | dfdlSchemaName
 | 
 | String 
-| 
-|  
-
-| options
-| 
-| Map  of <<string>>
 | 
 |  
 

--- a/docs/src/main/asciidoc/developer-guide/openapi/java/index.adoc
+++ b/docs/src/main/asciidoc/developer-guide/openapi/java/index.adoc
@@ -143,15 +143,21 @@ endif::internal-generation[]
 |===
 | Field Name| Required| Type| Description| Format
 
-| inspectPaths
+| uri
 | 
-| List  of <<string>>
+| String 
 | 
 |  
 
-| searchPhrase
+| inspectionType
 | 
 | String 
+| 
+|  _Enum:_ SCHEMA, INSTANCE, JAVA_CLASS, 
+
+| options
+| 
+| Map  of <<string>>
 | 
 |  
 
@@ -161,9 +167,27 @@ endif::internal-generation[]
 | 
 |  
 
-| classNameExclusions
+| typeNameExclusions
 | 
 | StringList 
+| 
+|  
+
+| namespaceExclusions
+| 
+| StringList 
+| 
+|  
+
+| inspectPaths
+| 
+| List  of <<string>>
+| 
+|  
+
+| searchPhrase
+| 
+| String 
 | 
 |  
 

--- a/docs/src/main/asciidoc/developer-guide/openapi/json/index.adoc
+++ b/docs/src/main/asciidoc/developer-guide/openapi/json/index.adoc
@@ -362,15 +362,21 @@ endif::internal-generation[]
 |===
 | Field Name| Required| Type| Description| Format
 
-| inspectPaths
+| uri
 | 
-| List  of <<string>>
+| String 
 | 
 |  
 
-| searchPhrase
+| inspectionType
 | 
 | String 
+| 
+|  _Enum:_ SCHEMA, INSTANCE, JAVA_CLASS, 
+
+| options
+| 
+| Map  of <<string>>
 | 
 |  
 
@@ -392,23 +398,23 @@ endif::internal-generation[]
 | 
 |  
 
+| inspectPaths
+| 
+| List  of <<string>>
+| 
+|  
+
+| searchPhrase
+| 
+| String 
+| 
+|  
+
 | jsonData
 | 
 | String 
 | 
 |  
-
-| uri
-| 
-| String 
-| 
-|  
-
-| type
-| 
-| String 
-| 
-|  _Enum:_ ALL, INSTANCE, SCHEMA, NONE, 
 
 | jsonType
 | X

--- a/docs/src/main/asciidoc/developer-guide/openapi/kafka-connect/index.adoc
+++ b/docs/src/main/asciidoc/developer-guide/openapi/kafka-connect/index.adoc
@@ -514,6 +514,24 @@ endif::internal-generation[]
 |===
 | Field Name| Required| Type| Description| Format
 
+| uri
+| 
+| String 
+| 
+|  
+
+| inspectionType
+| 
+| String 
+| 
+|  _Enum:_ SCHEMA, INSTANCE, JAVA_CLASS, 
+
+| options
+| 
+| Map  of <<string>>
+| 
+|  
+
 | fieldNameExclusions
 | 
 | StringList 
@@ -532,7 +550,13 @@ endif::internal-generation[]
 | 
 |  
 
-| uri
+| inspectPaths
+| 
+| List  of <<string>>
+| 
+|  
+
+| searchPhrase
 | 
 | String 
 | 
@@ -541,12 +565,6 @@ endif::internal-generation[]
 | schemaData
 | 
 | String 
-| 
-|  
-
-| options
-| 
-| Map  of <<string>>
 | 
 |  
 

--- a/docs/src/main/asciidoc/developer-guide/openapi/xml/index.adoc
+++ b/docs/src/main/asciidoc/developer-guide/openapi/xml/index.adoc
@@ -387,15 +387,21 @@ endif::internal-generation[]
 |===
 | Field Name| Required| Type| Description| Format
 
-| inspectPaths
+| uri
 | 
-| List  of <<string>>
+| String 
 | 
 |  
 
-| searchPhrase
+| inspectionType
 | 
 | String 
+| 
+|  _Enum:_ SCHEMA, INSTANCE, JAVA_CLASS, 
+
+| options
+| 
+| Map  of <<string>>
 | 
 |  
 
@@ -417,23 +423,23 @@ endif::internal-generation[]
 | 
 |  
 
+| inspectPaths
+| 
+| List  of <<string>>
+| 
+|  
+
+| searchPhrase
+| 
+| String 
+| 
+|  
+
 | xmlData
 | 
 | String 
 | 
 |  
-
-| uri
-| 
-| String 
-| 
-|  
-
-| type
-| 
-| String 
-| 
-|  _Enum:_ ALL, INSTANCE, SCHEMA, NONE, 
 
 | jsonType
 | X

--- a/lib/model/src/main/java/io/atlasmap/v2/BaseInspectionRequest.java
+++ b/lib/model/src/main/java/io/atlasmap/v2/BaseInspectionRequest.java
@@ -16,18 +16,176 @@
 package io.atlasmap.v2;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The base class for Document inspection request that AtlasMap UI sends
  * to the backend.
  */
 public abstract class BaseInspectionRequest implements Serializable {
-    /** Paths to inspect. */
-    protected List<String> inspectPaths;
 
-    /** Phrase to limit the inspection **/
-    protected String searchPhrase;
+    /** URI. */
+    private String uri;
+    /** Inspection type. */
+    private InspectionType inspectionType;
+    /** Inspection options. */
+    private Map<String, String> options = new HashMap<>();
+    /** Field name exclusions. */
+    private StringList fieldNameExclusions;
+    /** Type name exclusions. */
+    private StringList typeNameExclusions;
+    /** Namespace exclusions. */
+    private StringList namespaceExclusions;
+    /** Inspection Paths. */
+    private List<String> inspectPaths;
+    /** Search Paths. */
+    private String searchPhrase;
+
+    /**
+     * Gets the value of the uri property.
+     *
+     * @return
+     *     possible object is
+     *     {@link String }
+     *
+     */
+    public String getUri() {
+        return uri;
+    }
+
+    /**
+     * Sets the value of the uri property.
+     *
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *
+     */
+    public void setUri(String value) {
+        this.uri = value;
+    }
+
+    /**
+     * Gets the value of the inspectionType property.
+     *
+     * @return
+     *     possible object is
+     *     {@link InspectionType }
+     *
+     */
+    public InspectionType getInspectionType() {
+        return inspectionType;
+    }
+
+    /**
+     * Sets the value of the inspectionType property.
+     *
+     * @param value
+     *     allowed object is
+     *     {@link InspectionType }
+     *
+     */
+    public void setInspectionType(InspectionType value) {
+        this.inspectionType = value;
+    }
+
+    /**
+     * Gets the value of the options property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Map }
+     *     
+     */
+    public Map<String, String> getOptions() {
+        return this.options;
+    }
+
+    /**
+     * Sets the value of the options property.
+     * 
+     * @param options
+     *     allowed object is
+     *     {@link Map }
+     *     
+     */
+    public void setOptions(Map<String, String> options) {
+        this.options = options;
+    }
+
+    /**
+     * Gets the value of the fieldNameExclusions property.
+     *
+     * @return
+     *     possible object is
+     *     {@link StringList }
+     *
+     */
+    public StringList getFieldNameExclusions() {
+        return fieldNameExclusions;
+    }
+
+    /**
+     * Sets the value of the fieldNameExclusions property.
+     *
+     * @param value
+     *     allowed object is
+     *     {@link StringList }
+     *
+     */
+    public void setFieldNameExclusions(StringList value) {
+        this.fieldNameExclusions = value;
+    }
+
+    /**
+     * Gets the value of the typeNameExclusions property.
+     *
+     * @return
+     *     possible object is
+     *     {@link StringList }
+     *
+     */
+    public StringList getTypeNameExclusions() {
+        return typeNameExclusions;
+    }
+
+    /**
+     * Sets the value of the typeNameExclusions property.
+     *
+     * @param value
+     *     allowed object is
+     *     {@link StringList }
+     *
+     */
+    public void setTypeNameExclusions(StringList value) {
+        this.typeNameExclusions = value;
+    }
+
+    /**
+     * Gets the value of the namespaceExclusions property.
+     *
+     * @return
+     *     possible object is
+     *     {@link StringList }
+     *
+     */
+    public StringList getNamespaceExclusions() {
+        return namespaceExclusions;
+    }
+
+    /**
+     * Sets the value of the namespaceExclusions property.
+     *
+     * @param value
+     *     allowed object is
+     *     {@link StringList }
+     *
+     */
+    public void setNamespaceExclusions(StringList value) {
+        this.namespaceExclusions = value;
+    }
 
     /**
      * Gets the paths to inspect.
@@ -59,5 +217,184 @@ public abstract class BaseInspectionRequest implements Serializable {
      */
     public void setSearchPhrase(String searchPhrase) {
         this.searchPhrase = searchPhrase;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if ((object == null)||(this.getClass()!= object.getClass())) {
+            return false;
+        }
+        if (this == object) {
+            return true;
+        }
+        final BaseInspectionRequest that = ((BaseInspectionRequest) object);
+        {
+            StringList leftFieldNameExclusions;
+            leftFieldNameExclusions = this.getFieldNameExclusions();
+            StringList rightFieldNameExclusions;
+            rightFieldNameExclusions = that.getFieldNameExclusions();
+            if (this.fieldNameExclusions!= null) {
+                if (that.fieldNameExclusions!= null) {
+                    if (!leftFieldNameExclusions.equals(rightFieldNameExclusions)) {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            } else {
+                if (that.fieldNameExclusions!= null) {
+                    return false;
+                }
+            }
+        }
+        {
+            StringList leftTypeNameExclusions;
+            leftTypeNameExclusions = this.getTypeNameExclusions();
+            StringList rightTypeNameExclusions;
+            rightTypeNameExclusions = that.getTypeNameExclusions();
+            if (this.typeNameExclusions!= null) {
+                if (that.typeNameExclusions!= null) {
+                    if (!leftTypeNameExclusions.equals(rightTypeNameExclusions)) {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            } else {
+                if (that.typeNameExclusions!= null) {
+                    return false;
+                }
+            }
+        }
+        {
+            StringList leftNamespaceExclusions;
+            leftNamespaceExclusions = this.getNamespaceExclusions();
+            StringList rightNamespaceExclusions;
+            rightNamespaceExclusions = that.getNamespaceExclusions();
+            if (this.namespaceExclusions!= null) {
+                if (that.namespaceExclusions!= null) {
+                    if (!leftNamespaceExclusions.equals(rightNamespaceExclusions)) {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            } else {
+                if (that.namespaceExclusions!= null) {
+                    return false;
+                }
+            }
+        }
+        {
+            String leftUri;
+            leftUri = this.getUri();
+            String rightUri;
+            rightUri = that.getUri();
+            if (this.uri!= null) {
+                if (that.uri!= null) {
+                    if (!leftUri.equals(rightUri)) {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            } else {
+                if (that.uri!= null) {
+                    return false;
+                }
+            }
+        }
+        {
+            InspectionType leftType;
+            leftType = this.getInspectionType();
+            InspectionType rightType;
+            rightType = that.getInspectionType();
+            if (this.inspectionType!= null) {
+                if (that.inspectionType!= null) {
+                    if (!leftType.equals(rightType)) {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            } else {
+                if (that.inspectionType!= null) {
+                    return false;
+                }
+            }
+        }
+        {
+            Map<String, String> leftOptions;
+            leftOptions = this.getOptions();
+            Map<String, String> rightOptions;
+            rightOptions = that.getOptions();
+            if (leftOptions !=  null) {
+                if (rightOptions != null) {
+                    if (!leftOptions.equals(rightOptions)) {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            } else {
+                if (rightOptions != null) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int currentHashCode = 1;
+        {
+            currentHashCode = (currentHashCode* 31);
+            StringList theFieldNameExclusions;
+            theFieldNameExclusions = this.getFieldNameExclusions();
+            if (this.fieldNameExclusions!= null) {
+                currentHashCode += theFieldNameExclusions.hashCode();
+            }
+        }
+        {
+            currentHashCode = (currentHashCode* 31);
+            StringList theTypeNameExclusions;
+            theTypeNameExclusions = this.getTypeNameExclusions();
+            if (this.typeNameExclusions!= null) {
+                currentHashCode += theTypeNameExclusions.hashCode();
+            }
+        }
+        {
+            currentHashCode = (currentHashCode* 31);
+            StringList theNamespaceExclusions;
+            theNamespaceExclusions = this.getNamespaceExclusions();
+            if (this.namespaceExclusions!= null) {
+                currentHashCode += theNamespaceExclusions.hashCode();
+            }
+        }
+        {
+            currentHashCode = (currentHashCode* 31);
+            String theUri;
+            theUri = this.getUri();
+            if (this.uri!= null) {
+                currentHashCode += theUri.hashCode();
+            }
+        }
+        {
+            currentHashCode = (currentHashCode* 31);
+            InspectionType theType;
+            theType = this.getInspectionType();
+            if (this.inspectionType!= null) {
+                currentHashCode += theType.hashCode();
+            }
+        }
+        {
+            currentHashCode = (currentHashCode* 31);
+            Map<String, String> theOptions = this.getOptions();
+            if (this.options != null) {
+                currentHashCode += theOptions.hashCode();
+            }
+        }
+        return currentHashCode;
     }
 }

--- a/lib/modules/csv/core/src/main/java/io/atlasmap/csv/core/CsvConfig.java
+++ b/lib/modules/csv/core/src/main/java/io/atlasmap/csv/core/CsvConfig.java
@@ -15,6 +15,21 @@
  */
 package io.atlasmap.csv.core;
 
+import static io.atlasmap.csv.v2.CsvConstants.OPTION_ALLOW_DUPLICATE_HEADER_NAMES;
+import static io.atlasmap.csv.v2.CsvConstants.OPTION_ALLOW_MISSING_COLUMN_NAMES;
+import static io.atlasmap.csv.v2.CsvConstants.OPTION_COMMENT_MARKER;
+import static io.atlasmap.csv.v2.CsvConstants.OPTION_DELIMITER;
+import static io.atlasmap.csv.v2.CsvConstants.OPTION_ESCAPE;
+import static io.atlasmap.csv.v2.CsvConstants.OPTION_FIRST_RECORD_AS_HEADER;
+import static io.atlasmap.csv.v2.CsvConstants.OPTION_FORMAT;
+import static io.atlasmap.csv.v2.CsvConstants.OPTION_HEADERS;
+import static io.atlasmap.csv.v2.CsvConstants.OPTION_IGNORE_EMPTY_LINES;
+import static io.atlasmap.csv.v2.CsvConstants.OPTION_IGNORE_HEADER_CASE;
+import static io.atlasmap.csv.v2.CsvConstants.OPTION_IGNORE_SURROUNDING_SPACES;
+import static io.atlasmap.csv.v2.CsvConstants.OPTION_NULL_STRING;
+import static io.atlasmap.csv.v2.CsvConstants.OPTION_QUOTE;
+import static io.atlasmap.csv.v2.CsvConstants.OPTION_SKIP_HEADER_RECORD;
+
 import java.util.Map;
 
 import org.apache.commons.csv.CSVFormat;
@@ -68,48 +83,48 @@ public class CsvConfig {
      * @return config
      */
     public static CsvConfig newConfig(Map<String, String> config) {
-        CsvConfig csvConfig = new CsvConfig(config.get("format"));
-        String delimiter = config.get("delimiter");
+        CsvConfig csvConfig = new CsvConfig(config.get(OPTION_FORMAT));
+        String delimiter = config.get(OPTION_DELIMITER);
 
         for (Map.Entry<String, String> entry: config.entrySet()) {
             switch (entry.getKey()) {
-                case "delimiter":
+                case OPTION_DELIMITER:
                     csvConfig.delimiter = delimiter.charAt(0);
                     break;
-                case "firstRecordAsHeader":
+                case OPTION_FIRST_RECORD_AS_HEADER:
                     csvConfig.firstRecordAsHeader = entry.getValue() == null || Boolean.valueOf(entry.getValue());
                     break;
-                case "skipHeaderRecord":
+                case OPTION_SKIP_HEADER_RECORD:
                     csvConfig.skipHeaderRecord = entry.getValue() == null || Boolean.valueOf(entry.getValue());
                     break;
-                case "commentMarker":
+                case OPTION_COMMENT_MARKER:
                     csvConfig.commentMarker = entry.getValue().charAt(0);
                     break;
-                case "headers":
+                case OPTION_HEADERS:
                     csvConfig.headers = entry.getValue();
                     break;
-                case "escape":
+                case OPTION_ESCAPE:
                     csvConfig.escape = entry.getValue().charAt(0);
                     break;
-                case "ignoreEmptyLines":
+                case OPTION_IGNORE_EMPTY_LINES:
                     csvConfig.ignoreEmptyLines = entry.getValue() == null || Boolean.valueOf(entry.getValue());
                     break;
-                case "ignoreHeaderCase":
+                case OPTION_IGNORE_HEADER_CASE:
                     csvConfig.ignoreHeaderCase = entry.getValue() == null || Boolean.valueOf(entry.getValue());
                     break;
-                case "ignoreSurroundingSpaces":
+                case OPTION_IGNORE_SURROUNDING_SPACES:
                     csvConfig.ignoreSurroundingSpaces = entry.getValue() == null || Boolean.valueOf(entry.getValue());
                     break;
-                case "nullString":
+                case OPTION_NULL_STRING:
                     csvConfig.nullString = entry.getValue();
                     break;
-                case "quote":
+                case OPTION_QUOTE:
                     csvConfig.quote = entry.getValue().charAt(0);
                     break;
-                case "allowDuplicateHeaderNames":
+                case OPTION_ALLOW_DUPLICATE_HEADER_NAMES:
                     csvConfig.allowDuplicateHeaderNames = entry.getValue() == null || Boolean.valueOf(entry.getValue());
                     break;
-                case "allowMissingColumnNames":
+                case OPTION_ALLOW_MISSING_COLUMN_NAMES:
                     csvConfig.allowMissingColumnNames = entry.getValue() == null || Boolean.valueOf(entry.getValue());
                     break;
             }

--- a/lib/modules/csv/model/src/main/java/io/atlasmap/csv/v2/CsvConstants.java
+++ b/lib/modules/csv/model/src/main/java/io/atlasmap/csv/v2/CsvConstants.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atlasmap.csv.v2;
+
+/**
+ * The collection of constants for CSV module.
+ */
+public class CsvConstants {
+    /** Option name for the format. */
+    public static final String OPTION_FORMAT = "format";
+    /** Option name for the delimiter. */
+    public static final String OPTION_DELIMITER = "delimiter";
+    /** Option name for the firstRecordAsHeader. */
+    public static final String OPTION_FIRST_RECORD_AS_HEADER = "firstRecordAsHeader";
+    /** Option name for the skipRecordHeader. */
+    public static final String OPTION_SKIP_HEADER_RECORD = "skipHeaderRecord";
+    /** Option name for the headers. */
+    public static final String OPTION_HEADERS = "headers";
+    /** Option name for the commentMarker. */
+    public static final String OPTION_COMMENT_MARKER = "commentMarker";
+    /** Option name for the escape. */
+    public static final String OPTION_ESCAPE = "escape";
+    /** Option name for the ignoreEmptyLines. */
+    public static final String OPTION_IGNORE_EMPTY_LINES = "ignoreEmptyLines";
+    /** Option name for the ignoreHeaderCase. */
+    public static final String OPTION_IGNORE_HEADER_CASE = "ignoreHeaderCase";
+    /** Option name for the ignoreSurroundingSpaces. */
+    public static final String OPTION_IGNORE_SURROUNDING_SPACES = "ignoreSurroundingSpaces";
+    /** Option name for the nullString. */
+    public static final String OPTION_NULL_STRING = "nullString";
+    /** Option name for the quote. */
+    public static final String OPTION_QUOTE = "quote";
+    /** Option name for the allowDuplicateHeaderNames. */
+    public static final String OPTION_ALLOW_DUPLICATE_HEADER_NAMES = "allowDuplicateHeaderNames";
+    /** Option name for the allowMissingColumnNames. */
+    public static final String OPTION_ALLOW_MISSING_COLUMN_NAMES = "allowMissingColumnNames";
+}

--- a/lib/modules/csv/model/src/main/java/io/atlasmap/csv/v2/CsvDataSource.java
+++ b/lib/modules/csv/model/src/main/java/io/atlasmap/csv/v2/CsvDataSource.java
@@ -15,14 +15,12 @@
  */
 package io.atlasmap.csv.v2;
 
-import java.io.Serializable;
-
 import io.atlasmap.v2.DataSource;
 
 /**
  * The {@link DataSource} implementation for CSV Document.
  */
-public class CsvDataSource extends DataSource implements Serializable {
+public class CsvDataSource extends DataSource {
 
     private static final long serialVersionUID = 1L;
     /** Template. */

--- a/lib/modules/csv/model/src/main/java/io/atlasmap/csv/v2/CsvInspectionRequest.java
+++ b/lib/modules/csv/model/src/main/java/io/atlasmap/csv/v2/CsvInspectionRequest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atlasmap.kafkaconnect.v2;
+package io.atlasmap.csv.v2;
 
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -21,38 +21,38 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.atlasmap.v2.BaseInspectionRequest;
 
 /**
- * The top container object of Kafka Connect Document inspection request that AtlasMap UI sends
+ * The top container object of CSV Document inspection request that AtlasMap UI sends
  * to the backend.
  */
-@JsonRootName("KafkaConnectInspectionRequest")
+@JsonRootName("CsvInspectionRequest")
 @JsonTypeInfo(include = JsonTypeInfo.As.PROPERTY, use = JsonTypeInfo.Id.CLASS, property = "jsonType")
-public class KafkaConnectInspectionRequest extends BaseInspectionRequest {
+public class CsvInspectionRequest extends BaseInspectionRequest {
 
-    /** Schema data. */
-    private String schemaData;
+    /** Raw CSV data to inspect. */
+    private String csvData;
 
     /**
-     * Gets the value of the schemaData property.
-     * 
+     * Gets the value of the jsonData property.
+     *
      * @return
      *     possible object is
      *     {@link String }
-     *     
+     *
      */
-    public String getSchemaData() {
-        return schemaData;
+    public String getCsvData() {
+        return csvData;
     }
 
     /**
-     * Sets the value of the schemaData property.
-     * 
+     * Sets the value of the jsonData property.
+     *
      * @param value
      *     allowed object is
      *     {@link String }
-     *     
+     *
      */
-    public void setSchemaData(String value) {
-        this.schemaData = value;
+    public void setCsvData(String value) {
+        this.csvData = value;
     }
 
     @Override
@@ -60,24 +60,22 @@ public class KafkaConnectInspectionRequest extends BaseInspectionRequest {
         if (!super.equals(object)) {
             return false;
         }
-        final KafkaConnectInspectionRequest that = ((KafkaConnectInspectionRequest) object);
-        {
-            String leftSchemaData;
-            leftSchemaData = this.getSchemaData();
-            String rightSchemaData;
-            rightSchemaData = that.getSchemaData();
-            if (this.schemaData!= null) {
-                if (that.schemaData!= null) {
-                    if (!leftSchemaData.equals(rightSchemaData)) {
-                        return false;
-                    }
-                } else {
+        final CsvInspectionRequest that = ((CsvInspectionRequest) object);
+        String leftCsvData;
+        leftCsvData = this.getCsvData();
+        String rightCsvData;
+        rightCsvData = that.getCsvData();
+        if (this.csvData != null) {
+            if (that.csvData != null) {
+                if (!leftCsvData.equals(rightCsvData)) {
                     return false;
                 }
             } else {
-                if (that.schemaData!= null) {
-                    return false;
-                }
+                return false;
+            }
+        } else {
+            if (that.csvData != null) {
+                return false;
             }
         }
         return true;
@@ -86,13 +84,10 @@ public class KafkaConnectInspectionRequest extends BaseInspectionRequest {
     @Override
     public int hashCode() {
         int currentHashCode = (super.hashCode() * 31);
-        {
-            currentHashCode = (currentHashCode* 31);
-            String theJsonData;
-            theJsonData = this.getSchemaData();
-            if (this.schemaData!= null) {
-                currentHashCode += theJsonData.hashCode();
-            }
+        String theJsonData;
+        theJsonData = this.getCsvData();
+        if (this.csvData != null) {
+            currentHashCode += theJsonData.hashCode();
         }
         return currentHashCode;
     }

--- a/lib/modules/csv/service/src/test/java/io/atlasmap/csv/service/CsvServiceTest.java
+++ b/lib/modules/csv/service/src/test/java/io/atlasmap/csv/service/CsvServiceTest.java
@@ -28,7 +28,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.atlasmap.csv.v2.CsvComplexType;
+import io.atlasmap.csv.v2.CsvConstants;
 import io.atlasmap.csv.v2.CsvField;
+import io.atlasmap.csv.v2.CsvInspectionRequest;
 import io.atlasmap.csv.v2.CsvInspectionResponse;
 import io.atlasmap.v2.Json;
 
@@ -48,17 +50,19 @@ public class CsvServiceTest {
 
     @Test
     public void testSchema() throws Exception {
+
         final String source =
             "header1,header2,header3\n"
             + "l1r1,l1r2,l1r3\n"
             + "l2r1,l2r2,l2r3\n"
             + "l3r1,l3r2,l3r3\n";
+        CsvInspectionRequest req = new CsvInspectionRequest();
+        req.setCsvData(source);
+        req.getOptions().put(CsvConstants.OPTION_DELIMITER, ",");
+        req.getOptions().put(CsvConstants.OPTION_FIRST_RECORD_AS_HEADER, "true");
+        InputStream inputStream = new ByteArrayInputStream(Json.mapper().writeValueAsBytes(req));
 
-        InputStream inputStream = new ByteArrayInputStream(source.getBytes());
-
-        Response res = csvService.inspect(inputStream, null, ",", true, null, null,
-            null, null, null, null, null, null,
-            null, null, null);
+        Response res = csvService.inspect(inputStream);
         Object entity = res.getEntity();
         assertEquals(byte[].class, entity.getClass());
         CsvInspectionResponse csvInspectionResponse = Json.mapper().readValue((byte[])entity, CsvInspectionResponse.class);
@@ -75,12 +79,11 @@ public class CsvServiceTest {
             "l1r1,l1r2,l1r3\n"
                 + "l2r1,l2r2,l2r3\n"
                 + "l3r1,l3r2,l3r3\n";
+        CsvInspectionRequest req = new CsvInspectionRequest();
+        req.setCsvData(source);
+        InputStream inputStream = new ByteArrayInputStream(Json.mapper().writeValueAsBytes(req));
 
-        InputStream inputStream = new ByteArrayInputStream(source.getBytes());
-
-        Response res = csvService.inspect(inputStream, null, null, null, null, null,
-            null, null, null, null, null, null,
-            null, null, null);
+        Response res = csvService.inspect(inputStream);
         Object entity = res.getEntity();
         assertEquals(byte[].class, entity.getClass());
         CsvInspectionResponse csvInspectionResponse = Json.mapper().readValue((byte[])entity, CsvInspectionResponse.class);
@@ -94,10 +97,12 @@ public class CsvServiceTest {
     @Test
     public void testSchemaFile() throws Exception {
         InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("test.csv");
-
-        Response res = csvService.inspect(inputStream, null, ",", true, null, null,
-            null, null, null, null, null, null,
-            null, null, null);
+        CsvInspectionRequest req = new CsvInspectionRequest();
+        req.setCsvData(new String(inputStream.readAllBytes()));
+        req.getOptions().put(CsvConstants.OPTION_DELIMITER, ",");
+        req.getOptions().put(CsvConstants.OPTION_FIRST_RECORD_AS_HEADER, "true");
+        inputStream = new ByteArrayInputStream(Json.mapper().writeValueAsBytes(req));
+        Response res = csvService.inspect(inputStream);
         Object entity = res.getEntity();
         assertEquals(byte[].class, entity.getClass());
         CsvInspectionResponse csvInspectionResponse = Json.mapper().readValue((byte[])entity, CsvInspectionResponse.class);

--- a/lib/modules/dfdl/core/pom.xml
+++ b/lib/modules/dfdl/core/pom.xml
@@ -44,6 +44,10 @@
     </dependency>
     <dependency>
       <groupId>io.atlasmap</groupId>
+      <artifactId>atlas-dfdl-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.atlasmap</groupId>
       <artifactId>atlas-xml-core</artifactId>
     </dependency>
     <dependency>

--- a/lib/modules/dfdl/core/src/main/java/io/atlasmap/dfdl/core/schema/CsvDfdlSchemaGenerator.java
+++ b/lib/modules/dfdl/core/src/main/java/io/atlasmap/dfdl/core/schema/CsvDfdlSchemaGenerator.java
@@ -37,8 +37,8 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 import io.atlasmap.api.AtlasException;
-import io.atlasmap.dfdl.core.DfdlConstants;
 import io.atlasmap.dfdl.core.DfdlSchemaGenerator;
+import io.atlasmap.dfdl.v2.DfdlConstants;
 import io.atlasmap.xml.core.XmlIOHelper;
 
 /**

--- a/lib/modules/dfdl/core/src/main/java/io/atlasmap/dfdl/inspect/DfdlInspector.java
+++ b/lib/modules/dfdl/core/src/main/java/io/atlasmap/dfdl/inspect/DfdlInspector.java
@@ -30,8 +30,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.atlasmap.api.AtlasException;
-import io.atlasmap.dfdl.core.DfdlConstants;
 import io.atlasmap.dfdl.core.DfdlSchemaResolver;
+import io.atlasmap.dfdl.v2.DfdlConstants;
 import io.atlasmap.xml.core.XmlIOHelper;
 import io.atlasmap.xml.inspect.XmlInstanceInspector;
 import io.atlasmap.xml.inspect.XmlSchemaInspector;

--- a/lib/modules/dfdl/model/src/main/java/io/atlasmap/dfdl/v2/DfdlConstants.java
+++ b/lib/modules/dfdl/model/src/main/java/io/atlasmap/dfdl/v2/DfdlConstants.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atlasmap.dfdl.core;
+package io.atlasmap.dfdl.v2;
 
 /**
  * The collection of constants for DFDL module.

--- a/lib/modules/dfdl/model/src/main/java/io/atlasmap/dfdl/v2/DfdlInspectionRequest.java
+++ b/lib/modules/dfdl/model/src/main/java/io/atlasmap/dfdl/v2/DfdlInspectionRequest.java
@@ -15,10 +15,6 @@
  */
 package io.atlasmap.dfdl.v2;
 
-import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Map;
-
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
@@ -30,38 +26,11 @@ import io.atlasmap.xml.v2.XmlInspectionRequest;
  */
 @JsonRootName("DfdlInspectionRequest")
 @JsonTypeInfo(include = JsonTypeInfo.As.PROPERTY, use = JsonTypeInfo.Id.CLASS, property = "jsonType")
-public class DfdlInspectionRequest extends XmlInspectionRequest implements Serializable {
+public class DfdlInspectionRequest extends XmlInspectionRequest {
 
     private static final long serialVersionUID = 1L;
-
     /** DFDL schema name. */
-    protected String dfdlSchemaName;
-    /** Inspection options. */
-    protected Map<String, String> options = new HashMap<>();
-
-    /**
-     * Gets the value of the options property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link Map }
-     *     
-     */
-    public Map<String, String> getOptions() {
-        return this.options;
-    }
-
-    /**
-     * Sets the value of the options property.
-     * 
-     * @param options
-     *     allowed object is
-     *     {@link Map }
-     *     
-     */
-    public void setOptions(Map<String, String> options) {
-        this.options = options;
-    }
+    private String dfdlSchemaName;
 
     /**
      * Gets the value of the dfdlSchemaName property.
@@ -93,23 +62,6 @@ public class DfdlInspectionRequest extends XmlInspectionRequest implements Seria
             return false;
         }
         final DfdlInspectionRequest that = ((DfdlInspectionRequest) object);
-        Map<String, String> leftOptions;
-        leftOptions = this.getOptions();
-        Map<String, String> rightOptions;
-        rightOptions = that.getOptions();
-        if (leftOptions !=  null) {
-            if (rightOptions != null) {
-                if (!leftOptions.equals(rightOptions)) {
-                    return false;
-                }
-            } else {
-                return false;
-            }
-        } else {
-            if (rightOptions != null) {
-                return false;
-            }
-        }
         String leftDfdl;
         leftDfdl = this.getDfdlSchemaName();
         String rightDfdl;
@@ -133,11 +85,6 @@ public class DfdlInspectionRequest extends XmlInspectionRequest implements Seria
     @Override
     public int hashCode() {
         int currentHashCode = super.hashCode();
-        currentHashCode = (currentHashCode* 31);
-        Map<String, String> theOptions = this.getOptions();
-        if (this.options != null) {
-            currentHashCode += theOptions.hashCode();
-        }
         currentHashCode = (currentHashCode* 31);
         String theDfdl = this.getDfdlSchemaName();
         if (theDfdl != null) {

--- a/lib/modules/dfdl/module/src/main/java/io/atlasmap/dfdl/module/DfdlModule.java
+++ b/lib/modules/dfdl/module/src/main/java/io/atlasmap/dfdl/module/DfdlModule.java
@@ -36,8 +36,8 @@ import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 
 import io.atlasmap.api.AtlasException;
-import io.atlasmap.dfdl.core.DfdlConstants;
 import io.atlasmap.dfdl.core.DfdlSchemaResolver;
+import io.atlasmap.dfdl.v2.DfdlConstants;
 import io.atlasmap.spi.AtlasModuleDetail;
 import io.atlasmap.xml.module.XmlModule;
 

--- a/lib/modules/dfdl/service/src/main/java/io/atlasmap/dfdl/service/DfdlService.java
+++ b/lib/modules/dfdl/service/src/main/java/io/atlasmap/dfdl/service/DfdlService.java
@@ -84,7 +84,7 @@ public class DfdlService extends ModuleService {
 
         try {
 
-            if (request.getType() == null) {
+            if (request.getInspectionType() == null) {
                 response.setErrorMessage("Instance or Schema type must be specified in request");
             } else {
                 ClassLoader loader = resourceContext != null
@@ -92,7 +92,7 @@ public class DfdlService extends ModuleService {
                     : DfdlService.class.getClassLoader();
                 DfdlInspectionService s = new DfdlInspectionService(loader);
 
-                switch (request.getType()) {
+                switch (request.getInspectionType()) {
                 case INSTANCE:
                     d = s.inspectDfdlInstance(request.getDfdlSchemaName(), request.getOptions());
                     break;
@@ -100,7 +100,7 @@ public class DfdlService extends ModuleService {
                     d = s.inspectDfdlSchema(request.getDfdlSchemaName(), request.getOptions());
                     break;
                 default:
-                    response.setErrorMessage("Unsupported inspection type: " + request.getType());
+                    response.setErrorMessage("Unsupported inspection type: " + request.getInspectionType());
                     break;
                 }
             }

--- a/lib/modules/dfdl/service/src/test/java/io/atlasmap/dfdl/service/DfdlServiceTest.java
+++ b/lib/modules/dfdl/service/src/test/java/io/atlasmap/dfdl/service/DfdlServiceTest.java
@@ -29,7 +29,7 @@ import io.atlasmap.dfdl.v2.DfdlInspectionRequest;
 import io.atlasmap.dfdl.v2.DfdlInspectionResponse;
 import io.atlasmap.v2.FieldType;
 import io.atlasmap.v2.Json;
-import io.atlasmap.xml.v2.InspectionType;
+import io.atlasmap.v2.InspectionType;
 import io.atlasmap.xml.v2.XmlComplexType;
 import io.atlasmap.xml.v2.XmlDocument;
 import io.atlasmap.xml.v2.XmlField;
@@ -57,7 +57,7 @@ public class DfdlServiceTest {
             + "l3r1,l3r2,l3r3\n";
 
         DfdlInspectionRequest request = new DfdlInspectionRequest();
-        request.setType(InspectionType.SCHEMA);
+        request.setInspectionType(InspectionType.SCHEMA);
         request.setDfdlSchemaName("csv");
         request.getOptions().put(CsvDfdlSchemaGenerator.Options.HEADER.value(), source);
         request.getOptions().put(CsvDfdlSchemaGenerator.Options.DELIMITER.value(), ",");
@@ -93,7 +93,7 @@ public class DfdlServiceTest {
             + "l3r1,l3r2,l3r3\n";
 
         DfdlInspectionRequest request = new DfdlInspectionRequest();
-        request.setType(InspectionType.INSTANCE);
+        request.setInspectionType(InspectionType.INSTANCE);
         request.setDfdlSchemaName("csv");
         request.getOptions().put(CsvDfdlSchemaGenerator.Options.EXAMPLE.value(), source);
         request.getOptions().put(CsvDfdlSchemaGenerator.Options.DELIMITER.value(), ",");

--- a/lib/modules/java/model/src/main/java/io/atlasmap/java/v2/ClassInspectionRequest.java
+++ b/lib/modules/java/model/src/main/java/io/atlasmap/java/v2/ClassInspectionRequest.java
@@ -15,15 +15,11 @@
  */
 package io.atlasmap.java.v2;
 
-import java.io.Serializable;
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import io.atlasmap.v2.BaseInspectionRequest;
 import io.atlasmap.v2.CollectionType;
-import io.atlasmap.v2.StringList;
 
 /**
  * The top container object of Java Document inspection request that AtlasMap UI sends
@@ -31,80 +27,26 @@ import io.atlasmap.v2.StringList;
  */
 @JsonRootName("ClassInspectionRequest")
 @JsonTypeInfo(include = JsonTypeInfo.As.PROPERTY, use = JsonTypeInfo.Id.CLASS, property = "jsonType")
-public class ClassInspectionRequest extends BaseInspectionRequest implements Serializable {
+public class ClassInspectionRequest extends BaseInspectionRequest {
 
     private static final long serialVersionUID = 1L;
 
-    /** field name exclusions. */
-    protected StringList fieldNameExclusions;
-    /** class name exclusions. */
-    protected StringList classNameExclusions;
     /** classpath string. */
-    protected String classpath;
+    private String classpath;
     /** class name. */
-    protected String className;
+    private String className;
     /** collection type of the Document root. */
-    protected CollectionType collectionType;
+    private CollectionType collectionType;
     /** collection class name of the Document root. */
-    protected String collectionClassName;
+    private String collectionClassName;
     /** if private fields are disabled or not. */
-    protected Boolean disablePrivateOnlyFields;
+    private Boolean disablePrivateOnlyFields;
     /** if proteceted fields are disabled or not. */
-    protected Boolean disableProtectedOnlyFields;
+    private Boolean disableProtectedOnlyFields;
     /** if public fields are disabled or not. */
-    protected Boolean disablePublicOnlyFields;
+    private Boolean disablePublicOnlyFields;
     /** if the fields that have public getter/setter are disabled or not. */
-    protected Boolean disablePublicGetterSetterFields;
-    /** Paths to inspect. */
-    protected List<String> inspectPaths;
-
-    /**
-     * Gets the value of the fieldNameExclusions property.
-     *
-     * @return
-     *     possible object is
-     *     {@link StringList }
-     *
-     */
-    public StringList getFieldNameExclusions() {
-        return fieldNameExclusions;
-    }
-
-    /**
-     * Sets the value of the fieldNameExclusions property.
-     *
-     * @param value
-     *     allowed object is
-     *     {@link StringList }
-     *
-     */
-    public void setFieldNameExclusions(StringList value) {
-        this.fieldNameExclusions = value;
-    }
-
-    /**
-     * Gets the value of the classNameExclusions property.
-     *
-     * @return
-     *     possible object is
-     *     {@link StringList }
-     *
-     */
-    public StringList getClassNameExclusions() {
-        return classNameExclusions;
-    }
-
-    /**
-     * Sets the value of the classNameExclusions property.
-     *
-     * @param value
-     *     allowed object is
-     *     {@link StringList }
-     *
-     */
-    public void setClassNameExclusions(StringList value) {
-        this.classNameExclusions = value;
-    }
+    private Boolean disablePublicGetterSetterFields;
 
     /**
      * Gets the value of the classpath property.
@@ -298,52 +240,12 @@ public class ClassInspectionRequest extends BaseInspectionRequest implements Ser
         this.disablePublicGetterSetterFields = value;
     }
 
+    @Override
     public boolean equals(Object object) {
-        if ((object == null)||(this.getClass()!= object.getClass())) {
+        if (!super.equals(object)) {
             return false;
         }
-        if (this == object) {
-            return true;
-        }
         final ClassInspectionRequest that = ((ClassInspectionRequest) object);
-        {
-            StringList leftFieldNameExclusions;
-            leftFieldNameExclusions = this.getFieldNameExclusions();
-            StringList rightFieldNameExclusions;
-            rightFieldNameExclusions = that.getFieldNameExclusions();
-            if (this.fieldNameExclusions!= null) {
-                if (that.fieldNameExclusions!= null) {
-                    if (!leftFieldNameExclusions.equals(rightFieldNameExclusions)) {
-                        return false;
-                    }
-                } else {
-                    return false;
-                }
-            } else {
-                if (that.fieldNameExclusions!= null) {
-                    return false;
-                }
-            }
-        }
-        {
-            StringList leftClassNameExclusions;
-            leftClassNameExclusions = this.getClassNameExclusions();
-            StringList rightClassNameExclusions;
-            rightClassNameExclusions = that.getClassNameExclusions();
-            if (this.classNameExclusions!= null) {
-                if (that.classNameExclusions!= null) {
-                    if (!leftClassNameExclusions.equals(rightClassNameExclusions)) {
-                        return false;
-                    }
-                } else {
-                    return false;
-                }
-            } else {
-                if (that.classNameExclusions!= null) {
-                    return false;
-                }
-            }
-        }
         {
             String leftClasspath;
             leftClasspath = this.getClasspath();
@@ -499,24 +401,9 @@ public class ClassInspectionRequest extends BaseInspectionRequest implements Ser
         return true;
     }
 
+    @Override
     public int hashCode() {
-        int currentHashCode = 1;
-        {
-            currentHashCode = (currentHashCode* 31);
-            StringList theFieldNameExclusions;
-            theFieldNameExclusions = this.getFieldNameExclusions();
-            if (this.fieldNameExclusions!= null) {
-                currentHashCode += theFieldNameExclusions.hashCode();
-            }
-        }
-        {
-            currentHashCode = (currentHashCode* 31);
-            StringList theClassNameExclusions;
-            theClassNameExclusions = this.getClassNameExclusions();
-            if (this.classNameExclusions!= null) {
-                currentHashCode += theClassNameExclusions.hashCode();
-            }
-        }
+        int currentHashCode = (super.hashCode() * 31);
         {
             currentHashCode = (currentHashCode* 31);
             String theClasspath;

--- a/lib/modules/json/model/src/main/java/io/atlasmap/json/v2/JsonInspectionRequest.java
+++ b/lib/modules/json/model/src/main/java/io/atlasmap/json/v2/JsonInspectionRequest.java
@@ -15,13 +15,10 @@
  */
 package io.atlasmap.json.v2;
 
-import java.io.Serializable;
-
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import io.atlasmap.v2.BaseInspectionRequest;
-import io.atlasmap.v2.StringList;
 
 /**
  * The top container object of JSON Document inspection request that AtlasMap UI sends
@@ -29,93 +26,10 @@ import io.atlasmap.v2.StringList;
  */
 @JsonRootName("JsonInspectionRequest")
 @JsonTypeInfo(include = JsonTypeInfo.As.PROPERTY, use = JsonTypeInfo.Id.CLASS, property = "jsonType")
-public class JsonInspectionRequest extends BaseInspectionRequest implements Serializable {
+public class JsonInspectionRequest extends BaseInspectionRequest {
 
-    private static final long serialVersionUID = 1L;
-    /** Field name exclusions. */
-    protected StringList fieldNameExclusions;
-    /** Type name exclusions. */
-    protected StringList typeNameExclusions;
-    /** Namespace exclusions. */
-    protected StringList namespaceExclusions;
     /** Raw JSON schema/instance data to inspect. */
-    protected String jsonData;
-    /** URI. */
-    protected String uri;
-    /** Inspection type. */
-    protected InspectionType type;
-
-    /**
-     * Gets the value of the fieldNameExclusions property.
-     *
-     * @return
-     *     possible object is
-     *     {@link StringList }
-     *
-     */
-    public StringList getFieldNameExclusions() {
-        return fieldNameExclusions;
-    }
-
-    /**
-     * Sets the value of the fieldNameExclusions property.
-     *
-     * @param value
-     *     allowed object is
-     *     {@link StringList }
-     *
-     */
-    public void setFieldNameExclusions(StringList value) {
-        this.fieldNameExclusions = value;
-    }
-
-    /**
-     * Gets the value of the typeNameExclusions property.
-     *
-     * @return
-     *     possible object is
-     *     {@link StringList }
-     *
-     */
-    public StringList getTypeNameExclusions() {
-        return typeNameExclusions;
-    }
-
-    /**
-     * Sets the value of the typeNameExclusions property.
-     *
-     * @param value
-     *     allowed object is
-     *     {@link StringList }
-     *
-     */
-    public void setTypeNameExclusions(StringList value) {
-        this.typeNameExclusions = value;
-    }
-
-    /**
-     * Gets the value of the namespaceExclusions property.
-     *
-     * @return
-     *     possible object is
-     *     {@link StringList }
-     *
-     */
-    public StringList getNamespaceExclusions() {
-        return namespaceExclusions;
-    }
-
-    /**
-     * Sets the value of the namespaceExclusions property.
-     *
-     * @param value
-     *     allowed object is
-     *     {@link StringList }
-     *
-     */
-    public void setNamespaceExclusions(StringList value) {
-        this.namespaceExclusions = value;
-    }
+    private String jsonData;
 
     /**
      * Gets the value of the jsonData property.
@@ -141,175 +55,27 @@ public class JsonInspectionRequest extends BaseInspectionRequest implements Seri
         this.jsonData = value;
     }
 
-    /**
-     * Gets the value of the uri property.
-     *
-     * @return
-     *     possible object is
-     *     {@link String }
-     *
-     */
-    public String getUri() {
-        return uri;
-    }
-
-    /**
-     * Sets the value of the uri property.
-     *
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *
-     */
-    public void setUri(String value) {
-        this.uri = value;
-    }
-
-    /**
-     * Gets the value of the type property.
-     *
-     * @return
-     *     possible object is
-     *     {@link InspectionType }
-     *
-     */
-    public InspectionType getType() {
-        return type;
-    }
-
-    /**
-     * Sets the value of the type property.
-     *
-     * @param value
-     *     allowed object is
-     *     {@link InspectionType }
-     *
-     */
-    public void setType(InspectionType value) {
-        this.type = value;
-    }
-
     @Override
     public boolean equals(Object object) {
-        if ((object == null)||(this.getClass()!= object.getClass())) {
+        if (!super.equals(object)) {
             return false;
         }
-        if (this == object) {
-            return true;
-        }
         final JsonInspectionRequest that = ((JsonInspectionRequest) object);
-        {
-            StringList leftFieldNameExclusions;
-            leftFieldNameExclusions = this.getFieldNameExclusions();
-            StringList rightFieldNameExclusions;
-            rightFieldNameExclusions = that.getFieldNameExclusions();
-            if (this.fieldNameExclusions!= null) {
-                if (that.fieldNameExclusions!= null) {
-                    if (!leftFieldNameExclusions.equals(rightFieldNameExclusions)) {
-                        return false;
-                    }
-                } else {
+        String leftJsonData;
+        leftJsonData = this.getJsonData();
+        String rightJsonData;
+        rightJsonData = that.getJsonData();
+        if (this.jsonData != null) {
+            if (that.jsonData != null) {
+                if (!leftJsonData.equals(rightJsonData)) {
                     return false;
                 }
             } else {
-                if (that.fieldNameExclusions!= null) {
-                    return false;
-                }
+                return false;
             }
-        }
-        {
-            StringList leftTypeNameExclusions;
-            leftTypeNameExclusions = this.getTypeNameExclusions();
-            StringList rightTypeNameExclusions;
-            rightTypeNameExclusions = that.getTypeNameExclusions();
-            if (this.typeNameExclusions!= null) {
-                if (that.typeNameExclusions!= null) {
-                    if (!leftTypeNameExclusions.equals(rightTypeNameExclusions)) {
-                        return false;
-                    }
-                } else {
-                    return false;
-                }
-            } else {
-                if (that.typeNameExclusions!= null) {
-                    return false;
-                }
-            }
-        }
-        {
-            StringList leftNamespaceExclusions;
-            leftNamespaceExclusions = this.getNamespaceExclusions();
-            StringList rightNamespaceExclusions;
-            rightNamespaceExclusions = that.getNamespaceExclusions();
-            if (this.namespaceExclusions!= null) {
-                if (that.namespaceExclusions!= null) {
-                    if (!leftNamespaceExclusions.equals(rightNamespaceExclusions)) {
-                        return false;
-                    }
-                } else {
-                    return false;
-                }
-            } else {
-                if (that.namespaceExclusions!= null) {
-                    return false;
-                }
-            }
-        }
-        {
-            String leftJsonData;
-            leftJsonData = this.getJsonData();
-            String rightJsonData;
-            rightJsonData = that.getJsonData();
-            if (this.jsonData!= null) {
-                if (that.jsonData!= null) {
-                    if (!leftJsonData.equals(rightJsonData)) {
-                        return false;
-                    }
-                } else {
-                    return false;
-                }
-            } else {
-                if (that.jsonData!= null) {
-                    return false;
-                }
-            }
-        }
-        {
-            String leftUri;
-            leftUri = this.getUri();
-            String rightUri;
-            rightUri = that.getUri();
-            if (this.uri!= null) {
-                if (that.uri!= null) {
-                    if (!leftUri.equals(rightUri)) {
-                        return false;
-                    }
-                } else {
-                    return false;
-                }
-            } else {
-                if (that.uri!= null) {
-                    return false;
-                }
-            }
-        }
-        {
-            InspectionType leftType;
-            leftType = this.getType();
-            InspectionType rightType;
-            rightType = that.getType();
-            if (this.type!= null) {
-                if (that.type!= null) {
-                    if (!leftType.equals(rightType)) {
-                        return false;
-                    }
-                } else {
-                    return false;
-                }
-            } else {
-                if (that.type!= null) {
-                    return false;
-                }
+        } else {
+            if (that.jsonData != null) {
+                return false;
             }
         }
         return true;
@@ -317,54 +83,11 @@ public class JsonInspectionRequest extends BaseInspectionRequest implements Seri
 
     @Override
     public int hashCode() {
-        int currentHashCode = 1;
-        {
-            currentHashCode = (currentHashCode* 31);
-            StringList theFieldNameExclusions;
-            theFieldNameExclusions = this.getFieldNameExclusions();
-            if (this.fieldNameExclusions!= null) {
-                currentHashCode += theFieldNameExclusions.hashCode();
-            }
-        }
-        {
-            currentHashCode = (currentHashCode* 31);
-            StringList theTypeNameExclusions;
-            theTypeNameExclusions = this.getTypeNameExclusions();
-            if (this.typeNameExclusions!= null) {
-                currentHashCode += theTypeNameExclusions.hashCode();
-            }
-        }
-        {
-            currentHashCode = (currentHashCode* 31);
-            StringList theNamespaceExclusions;
-            theNamespaceExclusions = this.getNamespaceExclusions();
-            if (this.namespaceExclusions!= null) {
-                currentHashCode += theNamespaceExclusions.hashCode();
-            }
-        }
-        {
-            currentHashCode = (currentHashCode* 31);
-            String theJsonData;
-            theJsonData = this.getJsonData();
-            if (this.jsonData!= null) {
-                currentHashCode += theJsonData.hashCode();
-            }
-        }
-        {
-            currentHashCode = (currentHashCode* 31);
-            String theUri;
-            theUri = this.getUri();
-            if (this.uri!= null) {
-                currentHashCode += theUri.hashCode();
-            }
-        }
-        {
-            currentHashCode = (currentHashCode* 31);
-            InspectionType theType;
-            theType = this.getType();
-            if (this.type!= null) {
-                currentHashCode += theType.hashCode();
-            }
+        int currentHashCode = (super.hashCode() * 31);
+        String theJsonData;
+        theJsonData = this.getJsonData();
+        if (this.jsonData != null) {
+            currentHashCode += theJsonData.hashCode();
         }
         return currentHashCode;
     }

--- a/lib/modules/json/model/src/test/java/io/atlasmap/json/v2/AtlasJsonModelFactoryTest.java
+++ b/lib/modules/json/model/src/test/java/io/atlasmap/json/v2/AtlasJsonModelFactoryTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.atlasmap.v2.Json;
+import io.atlasmap.v2.InspectionType;
 
 
 public class AtlasJsonModelFactoryTest {
@@ -41,7 +42,7 @@ public class AtlasJsonModelFactoryTest {
     @Test
     public void testCreateJsonInspection() throws Exception {
         JsonInspectionRequest request = new JsonInspectionRequest();
-        request.setType(InspectionType.INSTANCE);
+        request.setInspectionType(InspectionType.INSTANCE);
         request.setJsonData("{\n" + "  \"id\": \"0001\",\n" + "  \"type\": \"donut\",\n" + "  \"name\": \"Cake\",\n"
                 + "  \"ppu\": 0.55,\n" + "  \"batters\":\n" + "  {\n" + "    \"batter\":\n" + "    [\n"
                 + "      { \"id\": \"1001\", \"type\": \"Regular\" },\n"

--- a/lib/modules/json/service/src/main/java/io/atlasmap/json/service/JsonService.java
+++ b/lib/modules/json/service/src/main/java/io/atlasmap/json/service/JsonService.java
@@ -71,7 +71,7 @@ public class JsonService extends ModuleService {
 
         try {
 
-            if (request.getType() == null || request.getJsonData() == null) {
+            if (request.getInspectionType() == null || request.getJsonData() == null) {
                 response.setErrorMessage(
                         "Json data and Instance or Schema inspection type must be specified in request");
             } else {
@@ -81,7 +81,7 @@ public class JsonService extends ModuleService {
                 if (!validJsonData(jsonData)) {
                     response.setErrorMessage("Invalid json payload specified");
                 } else {
-                    switch (request.getType()) {
+                    switch (request.getInspectionType()) {
                     case INSTANCE:
                         d = s.inspectJsonDocument(jsonData);
                         break;
@@ -89,7 +89,7 @@ public class JsonService extends ModuleService {
                         d = s.inspectJsonSchema(jsonData);
                         break;
                     default:
-                        response.setErrorMessage("Unsupported inspection type: " + request.getType());
+                        response.setErrorMessage("Unsupported inspection type: " + request.getInspectionType());
                         break;
                     }
                 }

--- a/lib/modules/xml/model/src/main/java/io/atlasmap/xml/v2/InspectionType.java
+++ b/lib/modules/xml/model/src/main/java/io/atlasmap/xml/v2/InspectionType.java
@@ -16,7 +16,7 @@
 package io.atlasmap.xml.v2;
 
 /**
- * @deprecated Migrate to {@code io.atlasmap.v2.InspectionType}.
+ * @deprecated Migrate to {@link io.atlasmap.v2.InspectionType}.
  */
 @Deprecated
 public enum InspectionType {

--- a/lib/modules/xml/model/src/main/java/io/atlasmap/xml/v2/XmlInspectionRequest.java
+++ b/lib/modules/xml/model/src/main/java/io/atlasmap/xml/v2/XmlInspectionRequest.java
@@ -15,13 +15,10 @@
  */
 package io.atlasmap.xml.v2;
 
-import java.io.Serializable;
-
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import io.atlasmap.v2.BaseInspectionRequest;
-import io.atlasmap.v2.StringList;
 
 /**
  * The top container object of XML Document inspection request that AtlasMap UI sends
@@ -29,93 +26,11 @@ import io.atlasmap.v2.StringList;
  */
 @JsonRootName("XmlInspectionRequest")
 @JsonTypeInfo(include = JsonTypeInfo.As.PROPERTY, use = JsonTypeInfo.Id.CLASS, property = "jsonType")
-public class XmlInspectionRequest extends BaseInspectionRequest implements Serializable {
+public class XmlInspectionRequest extends BaseInspectionRequest {
 
     private static final long serialVersionUID = 1L;
-    /** Field name exclusions. */
-    protected StringList fieldNameExclusions;
-    /** Type name exclusions. */
-    protected StringList typeNameExclusions;
-    /** Namespace exclusions. */
-    protected StringList namespaceExclusions;
     /** Raw XML schema/instance data to inspect. */
-    protected String xmlData;
-    /** URI. */
-    protected String uri;
-    /** Inspection type. */
-    protected InspectionType type;
-
-    /**
-     * Gets the value of the fieldNameExclusions property.
-     *
-     * @return
-     *     possible object is
-     *     {@link StringList }
-     *
-     */
-    public StringList getFieldNameExclusions() {
-        return fieldNameExclusions;
-    }
-
-    /**
-     * Sets the value of the fieldNameExclusions property.
-     *
-     * @param value
-     *     allowed object is
-     *     {@link StringList }
-     *
-     */
-    public void setFieldNameExclusions(StringList value) {
-        this.fieldNameExclusions = value;
-    }
-
-    /**
-     * Gets the value of the typeNameExclusions property.
-     *
-     * @return
-     *     possible object is
-     *     {@link StringList }
-     *
-     */
-    public StringList getTypeNameExclusions() {
-        return typeNameExclusions;
-    }
-
-    /**
-     * Sets the value of the typeNameExclusions property.
-     *
-     * @param value
-     *     allowed object is
-     *     {@link StringList }
-     *
-     */
-    public void setTypeNameExclusions(StringList value) {
-        this.typeNameExclusions = value;
-    }
-
-    /**
-     * Gets the value of the namespaceExclusions property.
-     *
-     * @return
-     *     possible object is
-     *     {@link StringList }
-     *
-     */
-    public StringList getNamespaceExclusions() {
-        return namespaceExclusions;
-    }
-
-    /**
-     * Sets the value of the namespaceExclusions property.
-     *
-     * @param value
-     *     allowed object is
-     *     {@link StringList }
-     *
-     */
-    public void setNamespaceExclusions(StringList value) {
-        this.namespaceExclusions = value;
-    }
+    private String xmlData;
 
     /**
      * Gets the value of the xmlData property.
@@ -141,175 +56,27 @@ public class XmlInspectionRequest extends BaseInspectionRequest implements Seria
         this.xmlData = value;
     }
 
-    /**
-     * Gets the value of the uri property.
-     *
-     * @return
-     *     possible object is
-     *     {@link String }
-     *
-     */
-    public String getUri() {
-        return uri;
-    }
-
-    /**
-     * Sets the value of the uri property.
-     *
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *
-     */
-    public void setUri(String value) {
-        this.uri = value;
-    }
-
-    /**
-     * Gets the value of the type property.
-     *
-     * @return
-     *     possible object is
-     *     {@link InspectionType }
-     *
-     */
-    public InspectionType getType() {
-        return type;
-    }
-
-    /**
-     * Sets the value of the type property.
-     *
-     * @param value
-     *     allowed object is
-     *     {@link InspectionType }
-     *
-     */
-    public void setType(InspectionType value) {
-        this.type = value;
-    }
-
     @Override
     public boolean equals(Object object) {
-        if ((object == null)||(this.getClass()!= object.getClass())) {
+        if (!super.equals(object)) {
             return false;
         }
-        if (this == object) {
-            return true;
-        }
         final XmlInspectionRequest that = ((XmlInspectionRequest) object);
-        {
-            StringList leftFieldNameExclusions;
-            leftFieldNameExclusions = this.getFieldNameExclusions();
-            StringList rightFieldNameExclusions;
-            rightFieldNameExclusions = that.getFieldNameExclusions();
-            if (this.fieldNameExclusions!= null) {
-                if (that.fieldNameExclusions!= null) {
-                    if (!leftFieldNameExclusions.equals(rightFieldNameExclusions)) {
-                        return false;
-                    }
-                } else {
+        String leftXmlData;
+        leftXmlData = this.getXmlData();
+        String rightXmlData;
+        rightXmlData = that.getXmlData();
+        if (this.xmlData!= null) {
+            if (that.xmlData!= null) {
+                if (!leftXmlData.equals(rightXmlData)) {
                     return false;
                 }
             } else {
-                if (that.fieldNameExclusions!= null) {
-                    return false;
-                }
+                return false;
             }
-        }
-        {
-            StringList leftTypeNameExclusions;
-            leftTypeNameExclusions = this.getTypeNameExclusions();
-            StringList rightTypeNameExclusions;
-            rightTypeNameExclusions = that.getTypeNameExclusions();
-            if (this.typeNameExclusions!= null) {
-                if (that.typeNameExclusions!= null) {
-                    if (!leftTypeNameExclusions.equals(rightTypeNameExclusions)) {
-                        return false;
-                    }
-                } else {
-                    return false;
-                }
-            } else {
-                if (that.typeNameExclusions!= null) {
-                    return false;
-                }
-            }
-        }
-        {
-            StringList leftNamespaceExclusions;
-            leftNamespaceExclusions = this.getNamespaceExclusions();
-            StringList rightNamespaceExclusions;
-            rightNamespaceExclusions = that.getNamespaceExclusions();
-            if (this.namespaceExclusions!= null) {
-                if (that.namespaceExclusions!= null) {
-                    if (!leftNamespaceExclusions.equals(rightNamespaceExclusions)) {
-                        return false;
-                    }
-                } else {
-                    return false;
-                }
-            } else {
-                if (that.namespaceExclusions!= null) {
-                    return false;
-                }
-            }
-        }
-        {
-            String leftXmlData;
-            leftXmlData = this.getXmlData();
-            String rightXmlData;
-            rightXmlData = that.getXmlData();
-            if (this.xmlData!= null) {
-                if (that.xmlData!= null) {
-                    if (!leftXmlData.equals(rightXmlData)) {
-                        return false;
-                    }
-                } else {
-                    return false;
-                }
-            } else {
-                if (that.xmlData!= null) {
-                    return false;
-                }
-            }
-        }
-        {
-            String leftUri;
-            leftUri = this.getUri();
-            String rightUri;
-            rightUri = that.getUri();
-            if (this.uri!= null) {
-                if (that.uri!= null) {
-                    if (!leftUri.equals(rightUri)) {
-                        return false;
-                    }
-                } else {
-                    return false;
-                }
-            } else {
-                if (that.uri!= null) {
-                    return false;
-                }
-            }
-        }
-        {
-            InspectionType leftType;
-            leftType = this.getType();
-            InspectionType rightType;
-            rightType = that.getType();
-            if (this.type!= null) {
-                if (that.type!= null) {
-                    if (!leftType.equals(rightType)) {
-                        return false;
-                    }
-                } else {
-                    return false;
-                }
-            } else {
-                if (that.type!= null) {
-                    return false;
-                }
+        } else {
+            if (that.xmlData!= null) {
+                return false;
             }
         }
         return true;
@@ -317,54 +84,11 @@ public class XmlInspectionRequest extends BaseInspectionRequest implements Seria
 
     @Override
     public int hashCode() {
-        int currentHashCode = 1;
-        {
-            currentHashCode = (currentHashCode* 31);
-            StringList theFieldNameExclusions;
-            theFieldNameExclusions = this.getFieldNameExclusions();
-            if (this.fieldNameExclusions!= null) {
-                currentHashCode += theFieldNameExclusions.hashCode();
-            }
-        }
-        {
-            currentHashCode = (currentHashCode* 31);
-            StringList theTypeNameExclusions;
-            theTypeNameExclusions = this.getTypeNameExclusions();
-            if (this.typeNameExclusions!= null) {
-                currentHashCode += theTypeNameExclusions.hashCode();
-            }
-        }
-        {
-            currentHashCode = (currentHashCode* 31);
-            StringList theNamespaceExclusions;
-            theNamespaceExclusions = this.getNamespaceExclusions();
-            if (this.namespaceExclusions!= null) {
-                currentHashCode += theNamespaceExclusions.hashCode();
-            }
-        }
-        {
-            currentHashCode = (currentHashCode* 31);
-            String theXmlData;
-            theXmlData = this.getXmlData();
-            if (this.xmlData!= null) {
-                currentHashCode += theXmlData.hashCode();
-            }
-        }
-        {
-            currentHashCode = (currentHashCode* 31);
-            String theUri;
-            theUri = this.getUri();
-            if (this.uri!= null) {
-                currentHashCode += theUri.hashCode();
-            }
-        }
-        {
-            currentHashCode = (currentHashCode* 31);
-            InspectionType theType;
-            theType = this.getType();
-            if (this.type!= null) {
-                currentHashCode += theType.hashCode();
-            }
+        int currentHashCode = (super.hashCode() * 31);
+        String theXmlData;
+        theXmlData = this.getXmlData();
+        if (this.xmlData!= null) {
+            currentHashCode += theXmlData.hashCode();
         }
         return currentHashCode;
     }

--- a/lib/modules/xml/model/src/test/java/io/atlasmap/xml/v2/BaseMarshallerTest.java
+++ b/lib/modules/xml/model/src/test/java/io/atlasmap/xml/v2/BaseMarshallerTest.java
@@ -44,6 +44,7 @@ import io.atlasmap.v2.DataSource;
 import io.atlasmap.v2.DataSourceType;
 import io.atlasmap.v2.FieldStatus;
 import io.atlasmap.v2.FieldType;
+import io.atlasmap.v2.InspectionType;
 import io.atlasmap.v2.Length;
 import io.atlasmap.v2.LookupEntry;
 import io.atlasmap.v2.LookupTable;
@@ -502,7 +503,7 @@ public abstract class BaseMarshallerTest {
 
     public XmlInspectionRequest generateInspectionRequest() {
         XmlInspectionRequest xmlInspectionRequest = new XmlInspectionRequest();
-        xmlInspectionRequest.setType(InspectionType.INSTANCE);
+        xmlInspectionRequest.setInspectionType(InspectionType.INSTANCE);
 
         final String xmlData = "<data>\n" + "     <intField a='1'>32000</intField>\n"
                 + "     <longField>12421</longField>\n" + "     <stringField>abc</stringField>\n"

--- a/lib/modules/xml/service/src/main/java/io/atlasmap/xml/service/XmlService.java
+++ b/lib/modules/xml/service/src/main/java/io/atlasmap/xml/service/XmlService.java
@@ -79,12 +79,12 @@ public class XmlService extends ModuleService {
 
         try {
 
-            if (request.getType() == null) {
+            if (request.getInspectionType() == null) {
                 response.setErrorMessage("Instance or Schema type must be specified in request");
             } else {
                 XmlInspectionService s = new XmlInspectionService();
 
-                switch (request.getType()) {
+                switch (request.getInspectionType()) {
                 case INSTANCE:
                     d = s.inspectXmlDocument(request.getXmlData());
                     break;
@@ -92,7 +92,7 @@ public class XmlService extends ModuleService {
                     d = s.inspectSchema(request.getXmlData());
                     break;
                 default:
-                    response.setErrorMessage("Unsupported inspection type: " + request.getType());
+                    response.setErrorMessage("Unsupported inspection type: " + request.getInspectionType());
                     break;
                 }
             }

--- a/lib/modules/xml/service/src/test/java/io/atlasmap/xml/service/XmlServiceTest.java
+++ b/lib/modules/xml/service/src/test/java/io/atlasmap/xml/service/XmlServiceTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.atlasmap.v2.Json;
-import io.atlasmap.xml.v2.InspectionType;
+import io.atlasmap.v2.InspectionType;
 import io.atlasmap.xml.v2.XmlComplexType;
 import io.atlasmap.xml.v2.XmlDocument;
 import io.atlasmap.xml.v2.XmlInspectionRequest;
@@ -85,7 +85,7 @@ public class XmlServiceTest {
                 + "    </xs:complexType>\n" + "  </xs:element>\n" + "</xs:schema>";
 
         XmlInspectionRequest request = new XmlInspectionRequest();
-        request.setType(InspectionType.SCHEMA);
+        request.setInspectionType(InspectionType.SCHEMA);
         request.setXmlData(source);
         Response res = xmlService.inspect(request);
         Object entity = res.getEntity();
@@ -101,7 +101,7 @@ public class XmlServiceTest {
     @Test
     public void testAllLevelsIncludedIfIncludePathsEmpty() throws Exception {
         XmlInspectionRequest request = new XmlInspectionRequest();
-        request.setType(InspectionType.SCHEMA);
+        request.setInspectionType(InspectionType.SCHEMA);
         request.setXmlData(sourceXml);
         request.setInspectPaths(new ArrayList<>());
         Response res = xmlService.inspect(request);
@@ -122,7 +122,7 @@ public class XmlServiceTest {
     @Test
     public void testRootLevelIncludedIfIncludePathSpecified() throws Exception {
         XmlInspectionRequest request = new XmlInspectionRequest();
-        request.setType(InspectionType.SCHEMA);
+        request.setInspectionType(InspectionType.SCHEMA);
         request.setXmlData(sourceXml);
         List<String> includePaths = new ArrayList<>();
         includePaths.add("/root");
@@ -143,7 +143,7 @@ public class XmlServiceTest {
     @Test
     public void testLevel1IncludedIfIncludePathSpecified() throws Exception {
         XmlInspectionRequest request = new XmlInspectionRequest();
-        request.setType(InspectionType.SCHEMA);
+        request.setInspectionType(InspectionType.SCHEMA);
         request.setXmlData(sourceXml);
         List<String> includePaths = new ArrayList<>();
         includePaths.add("/root/level1Field");
@@ -168,7 +168,7 @@ public class XmlServiceTest {
     @Test
     public void testLevel2IncludedIfIncludePathSpecified() throws Exception {
         XmlInspectionRequest request = new XmlInspectionRequest();
-        request.setType(InspectionType.SCHEMA);
+        request.setInspectionType(InspectionType.SCHEMA);
         request.setXmlData(sourceXml);
         List<String> includePaths = new ArrayList<>();
         includePaths.add("/root/level1Field/level2Field");
@@ -193,7 +193,7 @@ public class XmlServiceTest {
     @Test
     public void testLevel2Field2IncludedIfIncludePathSpecified() throws Exception {
         XmlInspectionRequest request = new XmlInspectionRequest();
-        request.setType(InspectionType.SCHEMA);
+        request.setInspectionType(InspectionType.SCHEMA);
         request.setXmlData(sourceXml);
         List<String> includePaths = new ArrayList<>();
         includePaths.add("/root/level1Field/level2Field2");

--- a/standalone/src/test/resources/atlasmap-json-inspection.json
+++ b/standalone/src/test/resources/atlasmap-json-inspection.json
@@ -1,7 +1,7 @@
 {
   "JsonInspectionRequest": {
     "jsonType": "io.atlasmap.json.v2.JsonInspectionRequest",
-    "type": "SCHEMA",
+    "inspectionType": "SCHEMA",
     "jsonData": "{\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_OUT\",\"properties\":{\"count\":{\"type\":\"integer\",\"required\":true}}}"
   }
 }

--- a/ui/packages/atlasmap-core/src/contracts/common.ts
+++ b/ui/packages/atlasmap-core/src/contracts/common.ts
@@ -100,7 +100,6 @@ export enum InspectionType {
   JAVA_CLASS = 'JAVA_CLASS',
   SCHEMA = 'SCHEMA',
   INSTANCE = 'INSTANCE',
-  UNKNOWN = 'UNKNOWN',
 }
 
 /** The serialized DataSource held by {@link IAtlasMapping}. */
@@ -113,6 +112,20 @@ export interface IDataSource {
   characterEncoding?: string;
   locale?: string;
   jsonType: string;
+}
+
+/**
+ * The serialized inspection request.
+ */
+export interface IInspectionRequest {
+  jsonType: string;
+  fieldNameExclusions?: IStringList;
+  typeNameExclusions?: IStringList;
+  namespaceExclusions?: IStringList;
+  uri?: string;
+  inspectionType: InspectionType;
+  options?: { [key: string]: string };
+  inspectPaths?: string[];
 }
 
 /**

--- a/ui/packages/atlasmap-core/src/contracts/documents/csv.ts
+++ b/ui/packages/atlasmap-core/src/contracts/documents/csv.ts
@@ -14,11 +14,29 @@
     limitations under the License.
 */
 
-import { IDocument, IField, IParameter } from '../common';
+import { IDocument, IField, IInspectionRequest, IParameter } from '../common';
 
 /**
  * The CSV inspection data model contracts between frontend and backend.
  */
+export const CSV_MODEL_PACKAGE_PREFIX = 'io.atlasmap.csv.v2';
+export const CSV_INSPECTION_REQUEST_JSON_TYPE =
+  CSV_MODEL_PACKAGE_PREFIX + '.CsvInspectionRequest';
+
+/**
+ * The root object that carries {@link ICsvInspectionRequest}
+ * when it's sent to backend.
+ */
+export interface ICsvInspectionRequestContainer {
+  CsvInspectionRequest: ICsvInspectionRequest;
+}
+
+/**
+ * The serialized CSV inspection request.
+ */
+export interface ICsvInspectionRequest extends IInspectionRequest {
+  csvData?: string;
+}
 
 /**
  * The root object that carries {@link ICsvInspectionResponse}

--- a/ui/packages/atlasmap-core/src/contracts/documents/java.ts
+++ b/ui/packages/atlasmap-core/src/contracts/documents/java.ts
@@ -13,7 +13,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-import { CollectionType, IField, IStringList } from '../common';
+import {
+  CollectionType,
+  IField,
+  IInspectionRequest,
+  IStringList,
+} from '../common';
 
 /**
  * The Java class inspection data model contracts between frontend and backend.
@@ -36,10 +41,7 @@ export interface IClassInspectionRequestContainer {
 /**
  * The serialized Java class inspection request.
  */
-export interface IClassInspectionRequest {
-  jsonType: string;
-  fieldNameExclusions?: IStringList;
-  classNameExclusions?: IStringList;
+export interface IClassInspectionRequest extends IInspectionRequest {
   classpath?: string;
   className: string;
   collectionType?: CollectionType;

--- a/ui/packages/atlasmap-core/src/contracts/documents/json.ts
+++ b/ui/packages/atlasmap-core/src/contracts/documents/json.ts
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-import { IDocument, IField, IStringList, InspectionType } from '../common';
+import { IDocument, IField, IInspectionRequest } from '../common';
 
 /**
  * The JSON inspection data model contracts between frontend and backend.
@@ -38,13 +38,8 @@ export interface IJsonInspectionRequestContainer {
 /**
  * The serialized JSON inspection request.
  */
-export interface IJsonInspectionRequest {
-  fieldNameExclusions?: IStringList;
-  typeNameExclusions?: IStringList;
-  namespaceExclusions?: IStringList;
+export interface IJsonInspectionRequest extends IInspectionRequest {
   jsonData?: string;
-  uri?: string;
-  type: InspectionType;
 }
 
 /**

--- a/ui/packages/atlasmap-core/src/contracts/documents/kafkaconnect.ts
+++ b/ui/packages/atlasmap-core/src/contracts/documents/kafkaconnect.ts
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-import { IDocument, IField, IStringList } from '../common';
+import { IDocument, IField, IInspectionRequest } from '../common';
 /**
  * The KafkaConnect inspection data model contracts between frontend and backend.
  */
@@ -33,13 +33,8 @@ export interface IKafkaConnectInspectionRequestContainer {
 /**
  * The serialized Kafka Connect inspection request.
  */
-export interface IKafkaConnectInspectionRequest {
-  fieldNameExclusions?: IStringList;
-  typeNameExclusions?: IStringList;
-  namespaceExclusions?: IStringList;
-  uri?: string;
+export interface IKafkaConnectInspectionRequest extends IInspectionRequest {
   schemaData?: string;
-  options?: Map<string, string>;
 }
 
 /**

--- a/ui/packages/atlasmap-core/src/contracts/documents/xml.ts
+++ b/ui/packages/atlasmap-core/src/contracts/documents/xml.ts
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-import { IDataSource, IDocument, IField } from '../common';
+import { IDataSource, IDocument, IField, IInspectionRequest } from '../common';
 
 /**
  * The XML inspection data model contracts between frontend and backend.
@@ -27,6 +27,21 @@ export const XML_ENUM_FIELD_JSON_TYPE =
   XML_MODEL_PACKAGE_PREFIX + '.XmlEnumField';
 export const XML_INSPECTION_REQUEST_JSON_TYPE =
   XML_MODEL_PACKAGE_PREFIX + '.XmlInspectionRequest';
+
+/**
+ * The root object that carries {@link IXmlInspectionRequest}
+ * when it's sent to backend.
+ */
+export interface IXmlInspectionRequestContainer {
+  XmlInspectionRequest: IXmlInspectionRequest;
+}
+
+/**
+ * The serialized XML inspection request.
+ */
+export interface IXmlInspectionRequest extends IInspectionRequest {
+  xmlData?: string;
+}
 
 /**
  * The root object that carries {@link IXmlInspectionResponse}

--- a/ui/packages/atlasmap-core/src/models/config.model.ts
+++ b/ui/packages/atlasmap-core/src/models/config.model.ts
@@ -60,7 +60,7 @@ export class DataMapperInitializationModel {
 
   /* inspection service filtering flags */
   fieldNameExclusions: string[] = [];
-  classNameExclusions: string[] = [];
+  typeNameExclusions: string[] = [];
   disablePrivateOnlyFields = false;
   disableProtectedOnlyFields = false;
   disablePublicOnlyFields = false;

--- a/ui/packages/atlasmap-core/src/models/inspect/csv-inspection.model.ts
+++ b/ui/packages/atlasmap-core/src/models/inspect/csv-inspection.model.ts
@@ -14,19 +14,21 @@
     limitations under the License.
 */
 import {
+  CSV_INSPECTION_REQUEST_JSON_TYPE,
+  ICsvComplexType,
+  ICsvDocumentContainer,
+  ICsvField,
+  ICsvInspectionRequestContainer,
+  ICsvInspectionResponse,
+  ICsvInspectionResponseContainer,
+} from '../../contracts/documents/csv';
+import {
   DocumentInspectionModel,
   DocumentInspectionRequestModel,
   DocumentInspectionRequestOptions,
 } from './document-inspection.model';
 import { ErrorInfo, ErrorLevel, ErrorScope, ErrorType } from '../error.model';
 import { FieldType, IDocument } from '../../contracts/common';
-import {
-  ICsvComplexType,
-  ICsvDocumentContainer,
-  ICsvField,
-  ICsvInspectionResponse,
-  ICsvInspectionResponseContainer,
-} from '../../contracts/documents/csv';
 
 import { CommonUtil } from '../../utils/common-util';
 import { Field } from '../field.model';
@@ -123,6 +125,13 @@ export class CsvInspectionRequestModel extends DocumentInspectionRequestModel {
 }
 
 export class CsvInspectionRequestOptions extends DocumentInspectionRequestOptions {
-  body = this.doc.inspectionSource;
-  searchParams: { [key: string]: string } = this.doc.inspectionParameters;
+  json: ICsvInspectionRequestContainer = {
+    CsvInspectionRequest: {
+      jsonType: CSV_INSPECTION_REQUEST_JSON_TYPE,
+      inspectionType: this.doc.inspectionType,
+      csvData: this.doc.inspectionSource,
+      options: this.doc.inspectionParameters,
+      inspectPaths: this.doc.inspectionPaths,
+    },
+  };
 }

--- a/ui/packages/atlasmap-core/src/models/inspect/java-inspection.model.ts
+++ b/ui/packages/atlasmap-core/src/models/inspect/java-inspection.model.ts
@@ -154,6 +154,7 @@ export class JavaInspectionRequestOptions extends DocumentInspectionRequestOptio
       ClassInspectionRequest: {
         jsonType: JAVA_INSPECTION_REQUEST_JSON_TYPE,
         className: this.doc.inspectionSource,
+        inspectionType: this.doc.inspectionType,
         disablePrivateOnlyFields: this.cfg.initCfg.disablePrivateOnlyFields,
         disableProtectedOnlyFields: this.cfg.initCfg.disableProtectedOnlyFields,
         disablePublicOnlyFields: this.cfg.initCfg.disablePublicOnlyFields,
@@ -183,11 +184,11 @@ export class JavaInspectionRequestOptions extends DocumentInspectionRequestOptio
       };
     }
     if (
-      this.cfg.initCfg.classNameExclusions &&
-      this.cfg.initCfg.classNameExclusions.length
+      this.cfg.initCfg.typeNameExclusions &&
+      this.cfg.initCfg.typeNameExclusions.length
     ) {
-      request.ClassInspectionRequest.classNameExclusions = {
-        string: this.cfg.initCfg.classNameExclusions,
+      request.ClassInspectionRequest.typeNameExclusions = {
+        string: this.cfg.initCfg.typeNameExclusions,
       };
     }
   }

--- a/ui/packages/atlasmap-core/src/models/inspect/json-inspection.model.ts
+++ b/ui/packages/atlasmap-core/src/models/inspect/json-inspection.model.ts
@@ -25,6 +25,7 @@ import {
   IJsonDocument,
   IJsonDocumentContainer,
   IJsonField,
+  IJsonInspectionRequestContainer,
   IJsonInspectionResponse,
   IJsonInspectionResponseContainer,
   JSON_INSPECTION_REQUEST_JSON_TYPE,
@@ -134,10 +135,10 @@ export class JsonInspectionRequestModel extends DocumentInspectionRequestModel {
 }
 
 export class JsonInspectionRequestOptions extends DocumentInspectionRequestOptions {
-  json = {
+  json: IJsonInspectionRequestContainer = {
     JsonInspectionRequest: {
       jsonType: JSON_INSPECTION_REQUEST_JSON_TYPE,
-      type: this.doc.inspectionType,
+      inspectionType: this.doc.inspectionType,
       jsonData: this.doc.inspectionSource,
       inspectPaths: this.doc.inspectionPaths,
     },

--- a/ui/packages/atlasmap-core/src/models/inspect/kafkaconnect-inspection.model.ts
+++ b/ui/packages/atlasmap-core/src/models/inspect/kafkaconnect-inspection.model.ts
@@ -26,6 +26,7 @@ import {
   IKafkaConnectDocument,
   IKafkaConnectDocumentContainer,
   IKafkaConnectField,
+  IKafkaConnectInspectionRequestContainer,
   IKafkaConnectInspectionResponse,
   IKafkaConnectInspectionResponseContainer,
   KAFKACONNECT_INSPECTION_REQUEST_JSON_TYPE,
@@ -151,9 +152,10 @@ export class KafkaConnectInspectionRequestModel extends DocumentInspectionReques
 
 export class KafkaConnectInspectionRequestOptions extends DocumentInspectionRequestOptions {
   documentType = this?.doc.type === DocumentType.KAFKA_AVRO ? 'AVRO' : 'JSON';
-  json = {
+  json: IKafkaConnectInspectionRequestContainer = {
     KafkaConnectInspectionRequest: {
       jsonType: KAFKACONNECT_INSPECTION_REQUEST_JSON_TYPE,
+      inspectionType: this.doc.inspectionType,
       schemaData: this.doc.inspectionSource,
       options: { schemaType: this.documentType },
     },

--- a/ui/packages/atlasmap-core/src/models/inspect/xml-inspection.model.ts
+++ b/ui/packages/atlasmap-core/src/models/inspect/xml-inspection.model.ts
@@ -26,6 +26,7 @@ import {
   IXmlDocument,
   IXmlDocumentContainer,
   IXmlField,
+  IXmlInspectionRequestContainer,
   IXmlInspectionResponse,
   IXmlInspectionResponseContainer,
   XML_INSPECTION_REQUEST_JSON_TYPE,
@@ -160,10 +161,10 @@ export class XmlInspectionRequestModel extends DocumentInspectionRequestModel {
 }
 
 export class XmlInspectionRequestOptions extends DocumentInspectionRequestOptions {
-  json = {
+  json: IXmlInspectionRequestContainer = {
     XmlInspectionRequest: {
       jsonType: XML_INSPECTION_REQUEST_JSON_TYPE,
-      type: this.doc.inspectionType,
+      inspectionType: this.doc.inspectionType,
       xmlData: this.doc.inspectionSource,
       inspectPaths: this.doc.inspectionPaths,
     },

--- a/ui/packages/atlasmap-core/src/services/file-management.service.spec.ts
+++ b/ui/packages/atlasmap-core/src/services/file-management.service.spec.ts
@@ -354,7 +354,7 @@ describe('FileManagementService', () => {
 
     const srcCSVDoc = new DocumentDefinition();
     srcCSVDoc.name = 'dummy CSV source document';
-    srcCSVDoc.inspectionType = InspectionType.UNKNOWN;
+    srcCSVDoc.inspectionType = InspectionType.INSTANCE;
     srcCSVDoc.inspectionSource = 'dummy CSV';
     srcCSVDoc.initModel = new DocumentInitializationModel();
     srcCSVDoc.initModel.isSource = true;

--- a/ui/packages/atlasmap/src/Views/ColumnMapperView/Actions/ImportAction.tsx
+++ b/ui/packages/atlasmap/src/Views/ColumnMapperView/Actions/ImportAction.tsx
@@ -68,7 +68,7 @@ const importCandidate: importDocumentType[] = [
   },
   {
     documentType: DocumentType.CSV,
-    inspectionType: InspectionType.UNKNOWN,
+    inspectionType: InspectionType.INSTANCE,
     typeName: 'CSV',
     suffix: '.csv',
   },

--- a/ui/packages/atlasmap/src/impl/dialogs/useImportDocumentDialog.tsx
+++ b/ui/packages/atlasmap/src/impl/dialogs/useImportDocumentDialog.tsx
@@ -63,7 +63,7 @@ export function useImportDocumentDialog(): [
               configModel,
               isSource,
               DocumentType.CSV,
-              InspectionType.UNKNOWN,
+              InspectionType.INSTANCE,
               inspectionParameters,
             );
           }, getCsvParameterOptions());


### PR DESCRIPTION
Fixes: #3392
This also helps to store InspectionRequest directly as a Document metadata for #3750 and #1476