### PR TITLE
fix: path to react UI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ ../mvnw -Pitests spring-boot:run
 ```
 3. Again in a separate terminal window, run yarn build to make the REACT UI:
 ```
-$ cd ${ATLASMAP}/ui/packages/atlasmap/ui
+$ cd ${ATLASMAP}/ui/packages/atlasmap/src
 $ yarn build
 ```
 4.  Run AtlasMap standalone:


### PR DESCRIPTION
There is no `ui` directory in `${ATLASMAP}/ui/packages/atlasmap`--I'm assuming this should be `src`, right?