### PR TITLE
chore: Set the primary JDK target to 18

### DIFF
--- a/.github/workflows/experimental-build.yml
+++ b/.github/workflows/experimental-build.yml
@@ -12,11 +12,13 @@ on:
 jobs:
   build_maven:
     if: ${{ github.repository == 'atlasmap/atlasmap' }}
-    runs-on: ubuntu-latest
+    continue-on-error: true
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [ '18' ]
-    name: Java ${{ matrix.Java }} build
+        java: [ '18', '11' ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    name: ${{ matrix.os }}/Java${{ matrix.java }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Java versions
@@ -32,7 +34,11 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Build from root with Maven
-      run: mvn --batch-mode -Pcoverage -Dwebdriver.chrome.driver=/usr/bin/chromedriver clean install
+      if: ${{ runner.os == 'Windows' }}
+      run: mvn --batch-mode -Pcoverage "-Dwebdriver.chrome.driver=$Env:CHROMEWEBDRIVER\chromedriver.exe" clean install
+    - name: Build from root with Maven
+      if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
+      run: mvn --batch-mode -Pcoverage "-Dwebdriver.chrome.driver=${CHROMEWEBDRIVER}/chromedriver" clean install
     - name: Build lib with Maven
       working-directory: lib
       run: mvn --batch-mode clean install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Java versions
         uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: 18
           distribution: 'temurin'
       - name: Cache Maven repo
         uses: actions/cache@v2

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Java versions
         uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: 18
           distribution: 'temurin'
       - name: Cache Maven repo
         uses: actions/cache@v2

--- a/.github/workflows/supported-build.yml
+++ b/.github/workflows/supported-build.yml
@@ -16,9 +16,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '11', '17' ]
+        java: [ '18.0.0', '11.0.14' ]
         os: [ubuntu-latest, macos-latest, windows-latest]
-    name: ${{ matrix.os }} / Java${{ matrix.java }}
+    name: ${{ matrix.os }}/Java${{ matrix.java }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Java versions


### PR DESCRIPTION
Also use 11.0.14 for JDK 11 build to avoid #3969 windows build error. Monitor JDK 11 latest build as experimental.