### PR TITLE
feat: Enhancement - add `Delete user-defined Java libraries` and `Del…

### DIFF
--- a/lib/service/src/main/java/io/atlasmap/service/AtlasService.java
+++ b/lib/service/src/main/java/io/atlasmap/service/AtlasService.java
@@ -410,6 +410,7 @@ public class AtlasService extends BaseAtlasService {
             LOG.warn("{} is not a directory - removing anyway", mappingFolderFile.getAbsolutePath());
         }
         AtlasUtil.deleteDirectory(mappingFolderFile);
+        admHandlerMap.clear();
         return Response.ok().build();
     }
 

--- a/lib/service/src/main/java/io/atlasmap/service/AtlasService.java
+++ b/lib/service/src/main/java/io/atlasmap/service/AtlasService.java
@@ -410,7 +410,7 @@ public class AtlasService extends BaseAtlasService {
             LOG.warn("{} is not a directory - removing anyway", mappingFolderFile.getAbsolutePath());
         }
         AtlasUtil.deleteDirectory(mappingFolderFile);
-        admHandlerMap.clear();
+        admHandlerMap.remove(mappingDefinitionId);
         return Response.ok().build();
     }
 

--- a/lib/service/src/test/java/io/atlasmap/service/AtlasServiceTest.java
+++ b/lib/service/src/test/java/io/atlasmap/service/AtlasServiceTest.java
@@ -27,9 +27,12 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.lang.ref.SoftReference;
 import java.lang.reflect.Method;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -43,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
+import io.atlasmap.core.ADMArchiveHandler;
 import io.atlasmap.core.AtlasUtil;
 import io.atlasmap.service.DocumentService;
 import io.atlasmap.v2.Action;
@@ -232,11 +236,15 @@ public class AtlasServiceTest {
         Response res = atlasService.importADMArchiveRequest(in, 0,
             Util.generateTestUriInfo("http://localhost:8686/v2/atlas", "http://localhost:8686/v2/atlas/project/0/adm"));
         assertEquals(200, res.getStatus());
-        java.nio.file.Path mappingFolderPath = Paths.get(atlasService.getMappingSubDirectory(0));
-        File mappingFolderFile = mappingFolderPath.toFile();
-        assertEquals(mappingFolderFile.exists(), true);
+        ADMArchiveHandler admHandler = atlasService.getADMArchiveHandler(0);
+        assertNotNull(admHandler);
+        AtlasMapping am = admHandler.getMappingDefinition();
+        assertNotNull(am);
         res = atlasService.deleteMappingProjectById(0);
         assertEquals(200, res.getStatus());
-        assertEquals(mappingFolderFile.exists(), false);
+        admHandler = atlasService.getADMArchiveHandler(0);
+        assertNotNull(admHandler);
+        am = admHandler.getMappingDefinition();
+        assertEquals(am, null);
     }
 }

--- a/lib/service/src/test/java/io/atlasmap/service/AtlasServiceTest.java
+++ b/lib/service/src/test/java/io/atlasmap/service/AtlasServiceTest.java
@@ -237,7 +237,6 @@ public class AtlasServiceTest {
         assertEquals(mappingFolderFile.exists(), true);
         res = atlasService.deleteMappingProjectById(0);
         assertEquals(200, res.getStatus());
-        mappingFolderFile = mappingFolderPath.toFile();
         assertEquals(mappingFolderFile.exists(), false);
     }
 }

--- a/lib/service/src/test/java/io/atlasmap/service/AtlasServiceTest.java
+++ b/lib/service/src/test/java/io/atlasmap/service/AtlasServiceTest.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.lang.reflect.Method;
+import java.nio.file.Paths;
 import java.util.List;
 
 import javax.ws.rs.WebApplicationException;
@@ -223,5 +224,20 @@ public class AtlasServiceTest {
         assertEquals(200, res.getStatus());
         res = documentService.getDocumentCatalogRequest(0);
         assertEquals(204, res.getStatus());  // Document catalog file was not found
+    }
+
+    @Test
+    public void testDeleteMappingProjectById() throws Exception {
+        InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream("json-schema-source-to-xml-schema-target.adm");
+        Response res = atlasService.importADMArchiveRequest(in, 0,
+            Util.generateTestUriInfo("http://localhost:8686/v2/atlas", "http://localhost:8686/v2/atlas/project/0/adm"));
+        assertEquals(200, res.getStatus());
+        java.nio.file.Path mappingFolderPath = Paths.get(atlasService.getMappingSubDirectory(0));
+        File mappingFolderFile = mappingFolderPath.toFile();
+        assertEquals(mappingFolderFile.exists(), true);
+        res = atlasService.deleteMappingProjectById(0);
+        assertEquals(200, res.getStatus());
+        mappingFolderFile = mappingFolderPath.toFile();
+        assertEquals(mappingFolderFile.exists(), false);
     }
 }

--- a/lib/service/src/test/java/io/atlasmap/service/AtlasServiceTest.java
+++ b/lib/service/src/test/java/io/atlasmap/service/AtlasServiceTest.java
@@ -18,6 +18,7 @@ package io.atlasmap.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -243,8 +244,9 @@ public class AtlasServiceTest {
         res = atlasService.deleteMappingProjectById(0);
         assertEquals(200, res.getStatus());
         admHandler = atlasService.getADMArchiveHandler(0);
-        assertNotNull(admHandler);
-        am = admHandler.getMappingDefinition();
-        assertEquals(am, null);
+        if (admHandler != null) {
+            am = admHandler.getMappingDefinition();
+            assertEquals(am, null);
+        }
     }
 }

--- a/ui/packages/atlasmap-core/src/services/document-management.service.ts
+++ b/ui/packages/atlasmap-core/src/services/document-management.service.ts
@@ -1047,21 +1047,21 @@ export class DocumentManagementService {
   }
 
   /**
-   * Delete all user-defined documents.
+   * Delete all mappings and user-defined documents.
    *
    * @returns Promise true is all documents are successfully delete, Promise
    * false otherwise.
    */
-  deleteAllDocuments(): Promise<boolean> {
+  deleteMappingProject(): Promise<boolean> {
     const url = `${this.cfg.initCfg.baseAtlasServiceUrl}project/${this.cfg.mappingDefinitionId}`;
     this.cfg.logger!.debug(
-      `Delete All Documents Request: ID=${this.cfg.mappingDefinitionId}`
+      `Delete All Documents and Mappings Request: ID=${this.cfg.mappingDefinitionId}`
     );
     return new Promise((resolve) => {
       this.api
         .delete(url)
         .then(async (response: Response) => {
-          this.cfg.logger!.debug(`Delete All Document Response: ${response}`);
+          this.cfg.logger!.debug(`Delete All Document and Mappings Response: ${response}`);
           if (response.ok) {
             resolve(
               (await this.fetchDocuments()) &&
@@ -1073,7 +1073,7 @@ export class DocumentManagementService {
         })
         .catch((error: Error) => {
           this.cfg.errorService.addBackendError(
-            `Failed to delete all documents: ${error}`
+            `Failed to delete all documents and mappings: ${error}`
           );
           resolve(false);
         });

--- a/ui/packages/atlasmap-core/src/services/document-management.service.ts
+++ b/ui/packages/atlasmap-core/src/services/document-management.service.ts
@@ -1047,6 +1047,40 @@ export class DocumentManagementService {
   }
 
   /**
+   * Delete all user-defined documents.
+   *
+   * @returns Promise true is all documents are successfully delete, Promise
+   * false otherwise.
+   */
+  deleteAllDocuments(): Promise<boolean> {
+    const url = `${this.cfg.initCfg.baseAtlasServiceUrl}project/${this.cfg.mappingDefinitionId}`;
+    this.cfg.logger!.debug(
+      `Delete All Documents Request: ID=${this.cfg.mappingDefinitionId}`
+    );
+    return new Promise((resolve) => {
+      this.api
+        .delete(url)
+        .then(async (response: Response) => {
+          this.cfg.logger!.debug(`Delete All Document Response: ${response}`);
+          if (response.ok) {
+            resolve(
+              (await this.fetchDocuments()) &&
+                this.cfg.mappingService.notifyFetchMapping()
+            );
+          } else {
+            resolve(false);
+          }
+        })
+        .catch((error: Error) => {
+          this.cfg.errorService.addBackendError(
+            `Failed to delete all documents: ${error}`
+          );
+          resolve(false);
+        });
+    });
+  }
+
+  /**
    * Simple liveness check of the Document specific backend service.
    * @param url URL
    * @param documentType Document type, such as Java, CSV, JSON, and etc.

--- a/ui/packages/atlasmap/src/impl/Atlasmap.tsx
+++ b/ui/packages/atlasmap/src/impl/Atlasmap.tsx
@@ -112,7 +112,9 @@ export const Atlasmap: FunctionComponent<IAtlasmapProps> = ({
       showExportAtlasFileToolbarItem: allowExport,
       showDeleteResetToolbarItem: allowDeleteReset,
       docsExist: sources.length > 2 || targets.length > 1,
-      librariesExist: false, // #3867
+      // TODO: determine if user-defined Java libraries exist
+      // without invoking backend service on each render
+      librariesExist: true,
       mappingsExist: mappings.length > 0,
       ...toolbarOptions,
       onImportADMArchiveFile: handlers.onImportADMArchive,

--- a/ui/packages/atlasmap/src/impl/dialogs/useCustomClassDialog.tsx
+++ b/ui/packages/atlasmap/src/impl/dialogs/useCustomClassDialog.tsx
@@ -16,8 +16,8 @@
 import { CustomClassDialog, ICustomClass } from '../../UI';
 import React, { ReactElement, useCallback, useState } from 'react';
 
+import { ConfigModel } from '@atlasmap/core';
 import { collectionTypes } from '@atlasmap/core';
-import { getCustomClassNameOptions } from '../utils/document';
 import { useToggle } from '../utils';
 
 type CustomClassCallback = (constant: ICustomClass) => void;
@@ -45,7 +45,9 @@ export function useCustomClassDialog(
   );
 
   const getCustomClassNames = async () => {
-    setCustomClassNames(await getCustomClassNameOptions());
+    setCustomClassNames(
+      await ConfigModel.getConfig().documentService.getLibraryClassNames(),
+    );
   };
 
   const dialog = (

--- a/ui/packages/atlasmap/src/impl/toolbarItems.tsx
+++ b/ui/packages/atlasmap/src/impl/toolbarItems.tsx
@@ -88,6 +88,7 @@ export const AtlasmapToolbarItem: FunctionComponent<
       toggleOff();
     };
   };
+
   const dropdownItems = [
     showImportAtlasFileToolbarItem && (
       <ImportAtlasFileToolbarItem
@@ -113,16 +114,16 @@ export const AtlasmapToolbarItem: FunctionComponent<
     showExportAtlasFileToolbarItem && (
       <DropdownSeparator key="export-separator" />
     ),
-    false /* showDeleteResetToolbarItem #3866 */ && (
+    showDeleteResetToolbarItem && (
       <DeleteDocsAndMappingsToolbarItem
         docsExist={docsExist!}
         onClick={runAndClose(onDeleteDocsAndMappings)}
         key="del-docs-mappings"
       />
     ),
-    false /* showDeleteResetToolbarItem #3867 */ && (
+    showDeleteResetToolbarItem && (
       <DeleteLibrariesToolbarItem
-        librariesExist={librariesExist!}
+        userLibrariesExist={librariesExist!}
         onClick={runAndClose(onDeleteLibraries)}
         key="del-libs"
       />
@@ -249,12 +250,12 @@ export const DeleteDocsAndMappingsToolbarItem: FunctionComponent<{
 );
 
 export const DeleteLibrariesToolbarItem: FunctionComponent<{
-  librariesExist: boolean;
+  userLibrariesExist: boolean;
   onClick: () => void;
-}> = ({ librariesExist, onClick }) => (
+}> = ({ userLibrariesExist, onClick }) => (
   <DropdownItem
     icon={<TrashIcon />}
-    isDisabled={!librariesExist}
+    isDisabled={!userLibrariesExist}
     onClick={onClick}
     data-testid="del-libs-button"
   >

--- a/ui/packages/atlasmap/src/impl/toolbarItems.tsx
+++ b/ui/packages/atlasmap/src/impl/toolbarItems.tsx
@@ -121,7 +121,7 @@ export const AtlasmapToolbarItem: FunctionComponent<
         key="del-docs-mappings"
       />
     ),
-    showDeleteResetToolbarItem && (
+    false /* showDeleteResetToolbarItem #3867 */ && (
       <DeleteLibrariesToolbarItem
         userLibrariesExist={librariesExist!}
         onClick={runAndClose(onDeleteLibraries)}

--- a/ui/packages/atlasmap/src/impl/utils/document.ts
+++ b/ui/packages/atlasmap/src/impl/utils/document.ts
@@ -140,26 +140,6 @@ export async function removeDocumentRef(
 }
 
 /**
- * Remove all documents from the UI and vackend service.
- *
- * @param cfg
- * @returns
- */
-export async function removeAllDocumentRefs(
-  cfg: ConfigModel,
-): Promise<boolean> {
-  return new Promise<boolean>(async (resolve) => {
-    for (const docDef of cfg.getDocs(true)) {
-      await removeDocumentRef(docDef, cfg);
-    }
-    for (const docDef of cfg.getDocs(false)) {
-      await removeDocumentRef(docDef, cfg);
-    }
-    resolve(true);
-  });
-}
-
-/**
  * Return the document definition associated with the specified document ID.
  *
  * @param docId - document ID

--- a/ui/packages/atlasmap/src/impl/utils/document.ts
+++ b/ui/packages/atlasmap/src/impl/utils/document.ts
@@ -182,34 +182,6 @@ export function getDocDefByName(
 }
 
 /**
- * Determine the user-defined class names associated with previously
- * imported JARs.
- */
-export async function getCustomClassNameOptions(): Promise<string[]> {
-  return new Promise<string[]>(async (resolve, reject) => {
-    const cfg = ConfigModel.getConfig();
-    cfg.documentService
-      .getLibraryClassNames()
-      .then((classNames: string[]) => {
-        resolve(classNames);
-      })
-      .catch(() => {
-        reject();
-      });
-  });
-}
-
-/**
- * @returns Return true if user-defined libraries exist, false otherwise.
- */
-export async function librariesExist(): Promise<boolean> {
-  return new Promise<boolean>(async (resolve) => {
-    const userClassNames = await getCustomClassNameOptions();
-    resolve(userClassNames.length > 0);
-  });
-}
-
-/**
  * Import a CSV, instance or schema document into either the Source panel or Target
  * panel.
  *

--- a/ui/packages/atlasmap/src/impl/utils/document.ts
+++ b/ui/packages/atlasmap/src/impl/utils/document.ts
@@ -140,6 +140,26 @@ export async function removeDocumentRef(
 }
 
 /**
+ * Remove all documents from the UI and vackend service.
+ *
+ * @param cfg
+ * @returns
+ */
+export async function removeAllDocumentRefs(
+  cfg: ConfigModel,
+): Promise<boolean> {
+  return new Promise<boolean>(async (resolve) => {
+    for (const docDef of cfg.getDocs(true)) {
+      await removeDocumentRef(docDef, cfg);
+    }
+    for (const docDef of cfg.getDocs(false)) {
+      await removeDocumentRef(docDef, cfg);
+    }
+    resolve(true);
+  });
+}
+
+/**
  * Return the document definition associated with the specified document ID.
  *
  * @param docId - document ID
@@ -196,6 +216,16 @@ export async function getCustomClassNameOptions(): Promise<string[]> {
       .catch(() => {
         reject();
       });
+  });
+}
+
+/**
+ * @returns Return true if user-defined libraries exist, false otherwise.
+ */
+export async function librariesExist(): Promise<boolean> {
+  return new Promise<boolean>(async (resolve) => {
+    const userClassNames = await getCustomClassNameOptions();
+    resolve(userClassNames.length > 0);
   });
 }
 

--- a/ui/packages/atlasmap/src/impl/utils/toolbar.ts
+++ b/ui/packages/atlasmap/src/impl/utils/toolbar.ts
@@ -98,7 +98,7 @@ export function importJarFile(selectedFile: File, cfg: ConfigModel) {
  */
 export async function delDocsAndMappingsAtlasmap() {
   const cfg = ConfigModel.getConfig();
-  await cfg.documentService.deleteAllDocuments();
+  await cfg.documentService.deleteMappingProject();
   await cfg.documentService.fetchDocuments();
 }
 

--- a/ui/packages/atlasmap/src/impl/utils/toolbar.ts
+++ b/ui/packages/atlasmap/src/impl/utils/toolbar.ts
@@ -21,7 +21,12 @@ import {
   ErrorScope,
   ErrorType,
 } from '@atlasmap/core';
-import { getDocDef, getDocDefByName, removeDocumentRef } from './document';
+import {
+  getDocDef,
+  getDocDefByName,
+  removeAllDocumentRefs,
+  removeDocumentRef,
+} from './document';
 
 /**
  * Return true if the specified file object exists as a source or target
@@ -99,8 +104,7 @@ export function importJarFile(selectedFile: File, cfg: ConfigModel) {
 export async function delDocsAndMappingsAtlasmap() {
   const cfg = ConfigModel.getConfig();
   await cfg.mappingService.removeAllMappings();
-  cfg.clearDocs(false);
-  await cfg.mappingService.notifyMappingUpdated();
+  await removeAllDocumentRefs(cfg);
   await cfg.documentService.fetchDocuments();
 }
 
@@ -119,7 +123,6 @@ export function deleteLibrariesAtlasmap() {
 export async function deleteMappingsAtlasmap() {
   const cfg = ConfigModel.getConfig();
   await cfg.mappingService.removeAllMappings();
-  await cfg.mappingService.notifyMappingUpdated();
 }
 
 /**

--- a/ui/packages/atlasmap/src/impl/utils/toolbar.ts
+++ b/ui/packages/atlasmap/src/impl/utils/toolbar.ts
@@ -21,12 +21,7 @@ import {
   ErrorScope,
   ErrorType,
 } from '@atlasmap/core';
-import {
-  getDocDef,
-  getDocDefByName,
-  removeAllDocumentRefs,
-  removeDocumentRef,
-} from './document';
+import { getDocDef, getDocDefByName, removeDocumentRef } from './document';
 
 /**
  * Return true if the specified file object exists as a source or target
@@ -103,8 +98,7 @@ export function importJarFile(selectedFile: File, cfg: ConfigModel) {
  */
 export async function delDocsAndMappingsAtlasmap() {
   const cfg = ConfigModel.getConfig();
-  await cfg.mappingService.removeAllMappings();
-  await removeAllDocumentRefs(cfg);
+  await cfg.documentService.deleteAllDocuments();
   await cfg.documentService.fetchDocuments();
 }
 


### PR DESCRIPTION
…ete documents and mappings` to the main Atlasmap pulldown menu.

Fixes: #3866

I left as a `TODO` checking if user defined libraries exist - it is default enabled in the menu.  We don't want to make a REST
backend service call on each render.  It should set something on the config model that can be checked quickly.  Needs more thought.

