### PR TITLE
fix: Version validation fails with 3.0.0

### DIFF
--- a/atlasmap-maven-plugin/mojo/pom.xml
+++ b/atlasmap-maven-plugin/mojo/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlasmap-maven-plugin-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/atlasmap-maven-plugin/pom.xml
+++ b/atlasmap-maven-plugin/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
 

--- a/atlasmap-maven-plugin/tests/pom.xml
+++ b/atlasmap-maven-plugin/tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlasmap-maven-plugin-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/camel/pom.xml
+++ b/camel/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>camel-atlasmap</artifactId>

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
 

--- a/docs/pom-javadoc.xml
+++ b/docs/pom-javadoc.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-docs</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>./pom.xml</relativePath>
   </parent>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
 

--- a/docs/src/main/asciidoc/developer-guide/openapi/core/index.adoc
+++ b/docs/src/main/asciidoc/developer-guide/openapi/core/index.adoc
@@ -1,6 +1,6 @@
 = AtlasMap Design Time Service API :: Core
 atlasmap@googlegroups.com
-2.4.0-SNAPSHOT
+3.0.0-SNAPSHOT
 :toc: left
 :numbered:
 :toclevels: 3

--- a/docs/src/main/asciidoc/developer-guide/openapi/csv/index.adoc
+++ b/docs/src/main/asciidoc/developer-guide/openapi/csv/index.adoc
@@ -1,6 +1,6 @@
 = AtlasMap Design Time Service API :: CSV
 atlasmap@googlegroups.com
-2.4.0-SNAPSHOT
+3.0.0-SNAPSHOT
 :toc: left
 :numbered:
 :toclevels: 3

--- a/docs/src/main/asciidoc/developer-guide/openapi/dfdl/index.adoc
+++ b/docs/src/main/asciidoc/developer-guide/openapi/dfdl/index.adoc
@@ -1,6 +1,6 @@
 = AtlasMap Design Time Service API :: DFDL
 atlasmap@googlegroups.com
-2.4.0-SNAPSHOT
+3.0.0-SNAPSHOT
 :toc: left
 :numbered:
 :toclevels: 3

--- a/docs/src/main/asciidoc/developer-guide/openapi/java/index.adoc
+++ b/docs/src/main/asciidoc/developer-guide/openapi/java/index.adoc
@@ -1,6 +1,6 @@
 = AtlasMap Design Time Service API :: Java
 atlasmap@googlegroups.com
-2.4.0-SNAPSHOT
+3.0.0-SNAPSHOT
 :toc: left
 :numbered:
 :toclevels: 3

--- a/docs/src/main/asciidoc/developer-guide/openapi/json/index.adoc
+++ b/docs/src/main/asciidoc/developer-guide/openapi/json/index.adoc
@@ -1,6 +1,6 @@
 = AtlasMap Design Time Service API :: JSON
 atlasmap@googlegroups.com
-2.4.0-SNAPSHOT
+3.0.0-SNAPSHOT
 :toc: left
 :numbered:
 :toclevels: 3

--- a/docs/src/main/asciidoc/developer-guide/openapi/kafka-connect/index.adoc
+++ b/docs/src/main/asciidoc/developer-guide/openapi/kafka-connect/index.adoc
@@ -1,6 +1,6 @@
 = AtlasMap Design Time Service API :: Kafka Connect
 atlasmap@googlegroups.com
-2.4.0-SNAPSHOT
+3.0.0-SNAPSHOT
 :toc: left
 :numbered:
 :toclevels: 3

--- a/docs/src/main/asciidoc/developer-guide/openapi/xml/index.adoc
+++ b/docs/src/main/asciidoc/developer-guide/openapi/xml/index.adoc
@@ -1,6 +1,6 @@
 = AtlasMap Design Time Service API :: XML
 atlasmap@googlegroups.com
-2.4.0-SNAPSHOT
+3.0.0-SNAPSHOT
 :toc: left
 :numbered:
 :toclevels: 3

--- a/examples/atlasmap-example-api-adm/pom.xml
+++ b/examples/atlasmap-example-api-adm/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap.examples</groupId>
     <artifactId>atlasmap-examples</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>atlasmap-example-api-adm</artifactId>
   <name>Example :: AtlasMap runtime API + ADM</name>

--- a/examples/atlasmap-example-api/pom.xml
+++ b/examples/atlasmap-example-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap.examples</groupId>
     <artifactId>atlasmap-examples</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>atlasmap-example-api</artifactId>
   <name>Example :: AtlasMap runtime API</name>

--- a/examples/camel-example-atlasmap-blueprint/pom.xml
+++ b/examples/camel-example-atlasmap-blueprint/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap.examples</groupId>
     <artifactId>atlasmap-examples</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>camel-example-atlasmap-blueprint</artifactId>

--- a/examples/camel-example-atlasmap-msgmap/pom.xml
+++ b/examples/camel-example-atlasmap-msgmap/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap.examples</groupId>
     <artifactId>atlasmap-examples</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>camel-example-atlasmap-msgmap</artifactId>

--- a/examples/camel-example-atlasmap-multidoc/pom.xml
+++ b/examples/camel-example-atlasmap-multidoc/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap.examples</groupId>
     <artifactId>atlasmap-examples</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>camel-example-atlasmap-multidoc</artifactId>

--- a/examples/camel-example-atlasmap/pom.xml
+++ b/examples/camel-example-atlasmap/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap.examples</groupId>
     <artifactId>atlasmap-examples</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>camel-example-atlasmap</artifactId>

--- a/examples/camel3/camel-example-atlasmap-msgmap/pom.xml
+++ b/examples/camel3/camel-example-atlasmap-msgmap/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap.examples.camel3</groupId>
     <artifactId>atlasmap-examples-camel3</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>camel-example-atlasmap-msgmap</artifactId>

--- a/examples/camel3/camel-example-atlasmap-multidoc/pom.xml
+++ b/examples/camel3/camel-example-atlasmap-multidoc/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap.examples.camel3</groupId>
     <artifactId>atlasmap-examples-camel3</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>camel-example-atlasmap-multidoc</artifactId>

--- a/examples/camel3/camel-example-atlasmap/pom.xml
+++ b/examples/camel3/camel-example-atlasmap/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap.examples.camel3</groupId>
     <artifactId>atlasmap-examples-camel3</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>camel-example-atlasmap</artifactId>

--- a/examples/camel3/pom.xml
+++ b/examples/camel3/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.atlasmap.examples</groupId>
     <artifactId>atlasmap-examples</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
 

--- a/kafka-smt/pom.xml
+++ b/kafka-smt/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>atlasmap-kafka-smt</artifactId>

--- a/lib/api/pom.xml
+++ b/lib/api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlasmap-lib</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/core/pom.xml
+++ b/lib/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlasmap-lib</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>atlas-core</artifactId>

--- a/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasContext.java
+++ b/lib/core/src/main/java/io/atlasmap/core/DefaultAtlasContext.java
@@ -156,11 +156,14 @@ public class DefaultAtlasContext implements AtlasContext, AtlasContextMXBean {
         if (mappingVersion != null && mappingVersion.length() > 0) {
             String[] mappingVersionComps = mappingVersion.split("\\.");
             String[] coreVersionComps = coreVersion.split("\\.");
-            if (
-                coreVersionComps.length < 2 || mappingVersionComps.length < 2 ||
-                Integer.parseInt(coreVersionComps[0]) < Integer.parseInt(mappingVersionComps[0]) ||
-                Integer.parseInt(coreVersionComps[1]) < Integer.parseInt(mappingVersionComps[1])
-            ) {
+            if (coreVersionComps.length < 2 || mappingVersionComps.length < 2) {
+                return false;
+            }
+            if (Integer.parseInt(coreVersionComps[0]) < Integer.parseInt(mappingVersionComps[0])) {
+                return false;
+            }
+            if (Integer.parseInt(coreVersionComps[0]) == Integer.parseInt(mappingVersionComps[0]) &&
+                Integer.parseInt(coreVersionComps[1]) < Integer.parseInt(mappingVersionComps[1])) {
                 return false;
             }
         }

--- a/lib/dist/pom.xml
+++ b/lib/dist/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlasmap-lib</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/expression/pom.xml
+++ b/lib/expression/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlasmap-lib</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/itests/core/pom.xml
+++ b/lib/itests/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-itests-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/lib/itests/pom.xml
+++ b/lib/itests/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlasmap-lib</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/itests/reference-mappings/pom.xml
+++ b/lib/itests/reference-mappings/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-itests-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/lib/itests/validation-mappings/pom.xml
+++ b/lib/itests/validation-mappings/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-itests-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/lib/model/pom.xml
+++ b/lib/model/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlasmap-lib</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/modules/csv/core/pom.xml
+++ b/lib/modules/csv/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-csv-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/lib/modules/csv/model/pom.xml
+++ b/lib/modules/csv/model/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-csv-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/lib/modules/csv/module/pom.xml
+++ b/lib/modules/csv/module/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-csv-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>atlas-csv-module</artifactId>

--- a/lib/modules/csv/pom.xml
+++ b/lib/modules/csv/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlasmap-lib</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/lib/modules/csv/service/pom.xml
+++ b/lib/modules/csv/service/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-csv-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/lib/modules/dfdl/core/pom.xml
+++ b/lib/modules/dfdl/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-dfdl-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/lib/modules/dfdl/model/pom.xml
+++ b/lib/modules/dfdl/model/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-dfdl-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/lib/modules/dfdl/module/pom.xml
+++ b/lib/modules/dfdl/module/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-dfdl-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>atlas-dfdl-module</artifactId>

--- a/lib/modules/dfdl/pom.xml
+++ b/lib/modules/dfdl/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlasmap-lib</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/lib/modules/dfdl/service/pom.xml
+++ b/lib/modules/dfdl/service/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-dfdl-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/modules/dfdl/test-model/pom.xml
+++ b/lib/modules/dfdl/test-model/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-dfdl-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/modules/java/core-test/pom.xml
+++ b/lib/modules/java/core-test/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-java-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/modules/java/core/pom.xml
+++ b/lib/modules/java/core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-java-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/modules/java/model/pom.xml
+++ b/lib/modules/java/model/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-java-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/modules/java/module/pom.xml
+++ b/lib/modules/java/module/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-java-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/modules/java/pom.xml
+++ b/lib/modules/java/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlasmap-lib</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/lib/modules/java/service/pom.xml
+++ b/lib/modules/java/service/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-java-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/modules/java/test-model/pom.xml
+++ b/lib/modules/java/test-model/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-java-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/modules/json/core/pom.xml
+++ b/lib/modules/json/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-json-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/lib/modules/json/model/pom.xml
+++ b/lib/modules/json/model/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-json-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/modules/json/module/pom.xml
+++ b/lib/modules/json/module/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-json-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>atlas-json-module</artifactId>

--- a/lib/modules/json/pom.xml
+++ b/lib/modules/json/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlasmap-lib</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/lib/modules/json/service/pom.xml
+++ b/lib/modules/json/service/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-json-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/modules/json/test-model/pom.xml
+++ b/lib/modules/json/test-model/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-json-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/modules/kafka-connect/core/pom.xml
+++ b/lib/modules/kafka-connect/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-kafka-connect-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/lib/modules/kafka-connect/model/pom.xml
+++ b/lib/modules/kafka-connect/model/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-kafka-connect-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/lib/modules/kafka-connect/module/pom.xml
+++ b/lib/modules/kafka-connect/module/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-kafka-connect-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>atlas-kafka-connect-module</artifactId>

--- a/lib/modules/kafka-connect/pom.xml
+++ b/lib/modules/kafka-connect/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlasmap-lib</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/lib/modules/kafka-connect/service/pom.xml
+++ b/lib/modules/kafka-connect/service/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-kafka-connect-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/modules/kafka-connect/test-model/pom.xml
+++ b/lib/modules/kafka-connect/test-model/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-kafka-connect-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/modules/xml/core/pom.xml
+++ b/lib/modules/xml/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-xml-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/lib/modules/xml/model/pom.xml
+++ b/lib/modules/xml/model/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-xml-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/lib/modules/xml/module/pom.xml
+++ b/lib/modules/xml/module/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-xml-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>atlas-xml-module</artifactId>

--- a/lib/modules/xml/pom.xml
+++ b/lib/modules/xml/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlasmap-lib</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/lib/modules/xml/service/pom.xml
+++ b/lib/modules/xml/service/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-xml-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/modules/xml/test-model/pom.xml
+++ b/lib/modules/xml/test-model/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-xml-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/modules/xml/xsom/pom.xml
+++ b/lib/modules/xml/xsom/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.atlasmap</groupId>
         <artifactId>atlas-xml-parent</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
 

--- a/lib/service/pom.xml
+++ b/lib/service/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlasmap-lib</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/mock-embedded/pom.xml
+++ b/mock-embedded/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlasmapio</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.atlasmap</groupId>
   <artifactId>atlasmapio</artifactId>
-  <version>2.4.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>AtlasMap Project</name>
   <description>AtlasMap Project</description>

--- a/standalone/pom.xml
+++ b/standalone/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlas-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
 

--- a/ui/lerna.json
+++ b/ui/lerna.json
@@ -6,5 +6,5 @@
   "npmClient": "yarn",
   "useWorkspaces": true,
   "concurrency": 1,
-  "version": "2.4.0-SNAPSHOT"
+  "version": "3.0.0-SNAPSHOT"
 }

--- a/ui/packages/atlasmap-core/package.json
+++ b/ui/packages/atlasmap-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlasmap/core",
   "description": "AtlasMap UI core library",
-  "version": "2.4.0-SNAPSHOT",
+  "version": "3.0.0-SNAPSHOT",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/ui/packages/atlasmap-standalone/package.json
+++ b/ui/packages/atlasmap-standalone/package.json
@@ -2,7 +2,7 @@
   "name": "@atlasmap/standalone",
   "description": "AtlasMap UI standalone bootstrapper",
   "license": "Apache-2.0",
-  "version": "2.4.0-SNAPSHOT",
+  "version": "3.0.0-SNAPSHOT",
   "private": true,
   "scripts": {
     "start": "react-scripts --max_old_space_size=4096 start",
@@ -15,7 +15,7 @@
     "format": "yarn lint --fix"
   },
   "dependencies": {
-    "@atlasmap/atlasmap": "^2.4.0-SNAPSHOT",
+    "@atlasmap/atlasmap": "^3.0.0-SNAPSHOT",
     "@patternfly/react-core": "^4.214.1",
     "@patternfly/react-icons": "^4.65.1",
     "@patternfly/react-styles": "^4.64.1",

--- a/ui/packages/atlasmap/package.json
+++ b/ui/packages/atlasmap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlasmap/atlasmap",
   "description": "AtlasMap UI presentation layer consists of React components",
-  "version": "2.4.0-SNAPSHOT",
+  "version": "3.0.0-SNAPSHOT",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
@@ -26,7 +26,7 @@
     "storybook": "start-storybook -p 6006"
   },
   "dependencies": {
-    "@atlasmap/core": "2.4.0-SNAPSHOT"
+    "@atlasmap/core": "^3.0.0-SNAPSHOT"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",

--- a/ui/packages/mock-embedded/package.json
+++ b/ui/packages/mock-embedded/package.json
@@ -2,7 +2,7 @@
   "name": "@atlasmap/mock-embedded",
   "description": "AtlasMap UI mock up for embedded usage",
   "license": "Apache-2.0",
-  "version": "2.4.0-SNAPSHOT",
+  "version": "3.0.0-SNAPSHOT",
   "private": true,
   "scripts": {
     "start": "react-scripts --max_old_space_size=4096 start",
@@ -15,7 +15,7 @@
     "format": "yarn lint --fix"
   },
   "dependencies": {
-    "@atlasmap/atlasmap": "^2.4.0-SNAPSHOT",
+    "@atlasmap/atlasmap": "^3.0.0-SNAPSHOT",
     "@patternfly/react-core": "^4.214.1",
     "@patternfly/react-icons": "^4.65.1",
     "@patternfly/react-styles": "^4.64.1",

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.atlasmap</groupId>
     <artifactId>atlasmapio</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 


### PR DESCRIPTION
Fixes: #4143

chore: Bump the version to 3.0.0-SNAPSHOT on main branch
Fixes: #4144