### PR TITLE
fix: AtlasMap is stuck after importing CSV on latest Google Chrome 105

### DIFF
--- a/ui/packages/atlasmap-core/package.json
+++ b/ui/packages/atlasmap-core/package.json
@@ -29,6 +29,7 @@
     "@types/text-encoding": "^0.0.36",
     "babel-jest": "^24.9.0",
     "eslint-plugin-header": "^3.1.1",
+    "jest-esm-transformer": "^1.0.0",
     "text-encoding": "^0.7.0",
     "ts-jest": "^24.3.0",
     "tsdx": "^0.13.1",
@@ -38,7 +39,7 @@
     "@types/file-saver": "^2.0.2",
     "@types/pako": "^1.0.1",
     "file-saver": "^2.0.5",
-    "ky": "~0.17.0",
+    "ky": "~0.31.3",
     "loglevel": "^1.7.1",
     "pako": "^2.0.3",
     "rxjs": "^6.6.7"
@@ -61,17 +62,17 @@
     "moduleNameMapper": {
       "\\.(css|less)$": "<rootDir>/test/__mocks__/styleMock.js",
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/test/__mocks__/fileMock.js",
-      "ky": "ky/umd",
       "@src": "<rootDir>/src/index.ts",
       "@src/(.*)": "<rootDir>/src/$1",
       "@test/(.*)": "<rootDir>/test/$1"
     },
     "testEnvironment": "jsdom",
     "transform": {
-      "^.+\\.(ts|tsx)$": "ts-jest"
+      "^.+\\.(ts|tsx)$": "ts-jest",
+      "ky": "jest-esm-transformer"
     },
     "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!(ky)/)"
+      "/node_modules/(?!ky/.*)/"
     ]
   },
   "eslintConfig": {

--- a/ui/packages/atlasmap-core/src/models/inspect/document-inspection.model.ts
+++ b/ui/packages/atlasmap-core/src/models/inspect/document-inspection.model.ts
@@ -14,12 +14,13 @@
     limitations under the License.
 */
 import { ErrorInfo, ErrorLevel, ErrorScope, ErrorType } from '../error.model';
-import { Input, Options } from 'ky';
 
 import { ConfigModel } from '../config.model';
 import { DocumentDefinition } from '../document-definition.model';
 import { Field } from '../field.model';
 import { IField } from '../../contracts/common';
+import { Input } from 'ky/distribution/types/options';
+import { Options } from 'ky';
 
 /**
  * Encapsulates Document inspection context.

--- a/ui/packages/atlasmap-core/src/services/document-management.service.spec.ts
+++ b/ui/packages/atlasmap-core/src/services/document-management.service.spec.ts
@@ -23,7 +23,7 @@ import { DocumentDefinition } from '../models/document-definition.model';
 import { DocumentManagementService } from '../services/document-management.service';
 import { Field } from '../models/field.model';
 import { InitializationService } from './initialization.service';
-import { Input } from 'ky';
+import type { Input } from 'ky/distribution/types/options';
 import { MappingDefinition } from '../models/mapping-definition.model';
 import { TestUtils } from '../../test/test-util';
 import atlasmapInspectionComplexObjectRootedJson from '../../../../test-resources/inspected/atlasmap-inspection-complex-object-rooted.json';
@@ -31,7 +31,7 @@ import atlasmapInspectionPoExampleSchemaJson from '../../../../test-resources/in
 import atlasmapInspectionTargetTestClassJson from '../../../../test-resources/inspected/atlasmap-inspection-io.atlasmap.java.test.TargetTestClass.json';
 import atlasmapInspectionTwitter4jStatusJson from '../../../../test-resources/inspected/atlasmap-inspection-twitter4j.Status.json';
 import fs from 'fs';
-import ky from 'ky/umd';
+import ky from 'ky';
 
 describe('DocumentManagementService', () => {
   let cfg: ConfigModel;

--- a/ui/packages/atlasmap-core/src/services/document-management.service.ts
+++ b/ui/packages/atlasmap-core/src/services/document-management.service.ts
@@ -147,6 +147,7 @@ export class DocumentManagementService {
             `Failed to inspect Document: ${docDef.name}(${docDef.id})`,
             error
           );
+          docDef.errorOccurred = true;
           reject(error);
         });
     });
@@ -410,7 +411,12 @@ export class DocumentManagementService {
           docdef.updateFromMappings(this.cfg.mappings!);
           resolve(true);
         })
-        .catch(() => {
+        .catch((error) => {
+          this.cfg.logger?.error(
+            `Failed to inspect Document ${docdef.name}(${docdef.id})`,
+            error
+          );
+          docdef.errorOccurred = true;
           resolve(false);
         });
     });

--- a/ui/packages/atlasmap-core/src/services/field-action.service.spec.ts
+++ b/ui/packages/atlasmap-core/src/services/field-action.service.spec.ts
@@ -21,14 +21,13 @@ import { FieldType } from '../contracts/common';
 import { MappingModel } from '../models/mapping.model';
 import { Multiplicity } from '../contracts/field-action';
 import atlasmapFieldActionJson from '../../../../test-resources/fieldActions/atlasmap-field-action.json';
-import ky from 'ky/umd';
+import ky from 'ky';
 import log from 'loglevel';
 
 describe('FieldActionService', () => {
   let service: FieldActionService;
   beforeEach(() => {
-    const api = ky.create({ headers: { 'ATLASMAP-XSRF-TOKEN': 'awesome' } });
-    service = new FieldActionService(api);
+    service = new FieldActionService(ky);
     service.cfg.logger = log.getLogger('copnfig');
   });
 
@@ -84,8 +83,7 @@ describe('FieldActionService.appliesToField()', () => {
     mapping.targetFields.splice(0);
     target = new Field();
     mapping.addField(target, false);
-    const api = ky.create({ headers: { 'ATLASMAP-XSRF-TOKEN': 'awesome' } });
-    service = new FieldActionService(api);
+    service = new FieldActionService(ky);
     service.cfg.logger = log.getLogger('copnfig');
   });
 

--- a/ui/packages/atlasmap-core/src/services/file-management.service.spec.ts
+++ b/ui/packages/atlasmap-core/src/services/file-management.service.spec.ts
@@ -26,7 +26,7 @@ import FileSaver from 'file-saver';
 import { InitializationService } from './initialization.service';
 import { MAPPING_JSON_TYPE } from '../contracts/mapping';
 import fs from 'fs';
-import ky from 'ky/umd';
+import ky from 'ky';
 import log from 'loglevel';
 import { mocked } from 'ts-jest/utils';
 import pako from 'pako';

--- a/ui/packages/atlasmap-core/src/services/initialization.service.spec.ts
+++ b/ui/packages/atlasmap-core/src/services/initialization.service.spec.ts
@@ -32,7 +32,7 @@ import atlasmapInspectionOldActionSourceJson from '../../../../test-resources/in
 import atlasmapInspectionOldActionTargetJson from '../../../../test-resources/inspected/atlasmap-inspection-old-action-target.json';
 import atlasmappingCvsToJson from '../../../../test-resources/mapping/atlasmapping-cvs-to-json.json';
 import atlasmappingOldActionJson from '../../../../test-resources/mapping/atlasmapping-old-action.json';
-import ky from 'ky/umd';
+import ky from 'ky';
 import { take } from 'rxjs/operators';
 
 describe('InitializationService', () => {

--- a/ui/packages/atlasmap-core/src/services/initialization.service.ts
+++ b/ui/packages/atlasmap-core/src/services/initialization.service.ts
@@ -37,7 +37,7 @@ import { MappingPreviewService } from './mapping-preview.service';
 import { MappingSerializer } from '../utils/mapping-serializer';
 import { MappingUtil } from '../utils/mapping-util';
 import { first } from 'rxjs/operators';
-import ky from 'ky/umd';
+import ky from 'ky';
 import log from 'loglevel';
 
 log.setDefaultLevel(log.levels.WARN);

--- a/ui/packages/atlasmap-core/src/services/mapping-management.service.spec.ts
+++ b/ui/packages/atlasmap-core/src/services/mapping-management.service.spec.ts
@@ -14,11 +14,12 @@
     limitations under the License.
 */
 import { LookupTableData, LookupTableUtil } from '../utils';
-import ky, { Input, Options } from 'ky';
+import ky, { Options } from 'ky';
 
 import { ConfigModel } from '../models/config.model';
 import { Field } from '../models/field.model';
 import { InitializationService } from './initialization.service';
+import { Input } from 'ky/distribution/types/options';
 import { MappingDefinition } from '../models/mapping-definition.model';
 import { MappingManagementService } from '../services/mapping-management.service';
 import { MappingModel } from '../models/mapping.model';

--- a/ui/packages/atlasmap-core/src/services/mapping-preview.service.spec.ts
+++ b/ui/packages/atlasmap-core/src/services/mapping-preview.service.spec.ts
@@ -13,9 +13,10 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-import ky, { Input, Options } from 'ky';
+import ky, { Options } from 'ky';
 import { ConfigModel } from '../models';
 import { InitializationService } from './initialization.service';
+import { Input } from 'ky/distribution/types/options';
 import { MappingModel } from '../models/mapping.model';
 import { MappingPreviewService } from './mapping-preview.service';
 import { TestUtils } from '../../test/test-util';

--- a/ui/packages/atlasmap-standalone/craco.config.js
+++ b/ui/packages/atlasmap-standalone/craco.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  babel: {
+    presets: [
+      "@babel/preset-env",
+      "@babel/preset-react"
+    ],
+    plugins: [
+      "@babel/plugin-proposal-nullish-coalescing-operator",
+      ["@babel/plugin-proposal-private-methods", { "loose": true }],
+      ["@babel/plugin-proposal-class-properties", { "loose": true }]
+    ]
+  }
+};

--- a/ui/packages/atlasmap-standalone/package.json
+++ b/ui/packages/atlasmap-standalone/package.json
@@ -5,11 +5,11 @@
   "version": "2.6.0-SNAPSHOT",
   "private": true,
   "scripts": {
-    "start": "react-scripts start",
-    "build:module": "react-scripts build",
+    "start": "craco start",
+    "build:module": "craco build",
     "build": "npm-run-all build:module lint test",
-    "test": "react-scripts test --watchAll=false --runInBand",
-    "test:coverage": "react-scripts test --watchAll=false --coverage --runInBand",
+    "test": "craco test --watchAll=false --runInBand",
+    "test:coverage": "craco test --watchAll=false --coverage --runInBand",
     "eject": "react-scripts eject",
     "lint": "tsdx lint src",
     "format": "yarn lint --fix"
@@ -31,7 +31,7 @@
     "d3-shape": "^2.1.0",
     "file-saver": "^2.0.5",
     "http-proxy-middleware": "^1.3.1",
-    "ky": "~0.17.0",
+    "ky": "~0.31.3",
     "lodash.clamp": "^4.0.3",
     "pako": "^2.0.3",
     "react": "^17.0.2",
@@ -47,6 +47,7 @@
     "use-debounce": "^8.0.3"
   },
   "devDependencies": {
+    "@craco/craco": "5.8.0",
     "@types/jest": "24.9.1",
     "typescript": "~3.9.9"
   },
@@ -91,14 +92,12 @@
     "endOfLine": "auto"
   },
   "jest": {
-    "moduleNameMapper": {
-      "ky": "ky/umd"
-    },
     "transform": {
-      "^.+\\.(ts|tsx)$": "ts-jest"
+      "^.+\\.(ts|tsx)$": "ts-jest",
+      "ky": "jest-esm-transformer"
     },
     "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!(ky|@patternfly/react-styles)/)"
+      "<rootDir>/node_modules/(?!(ky/.*|@patternfly/react-styles)/)"
     ]
   }
 }

--- a/ui/packages/atlasmap/.storybook/webpack.config.js
+++ b/ui/packages/atlasmap/.storybook/webpack.config.js
@@ -36,6 +36,21 @@ module.exports = ({ config }) => {
     ]
   })
 
+  config.module.rules.push({
+    test: /\.js$/,
+    use: [
+      {
+        loader: "babel-loader",
+        options: {
+          presets: [
+            "@babel/preset-env"
+          ]
+        },
+      }
+    ],
+    include: [ path.resolve(__dirname, '../../../node_modules/ky') ]
+  })
+
   const cssModuleRegex = /\.module\.css$/;
   config.module.rules.forEach((rule, idx) => {
     if (rule.test.test('.css')) {

--- a/ui/packages/atlasmap/package.json
+++ b/ui/packages/atlasmap/package.json
@@ -83,7 +83,7 @@
     "d3-scale": "^3.3.0",
     "d3-shape": "^2.1.0",
     "he": "^1.2.0",
-    "ky": "~0.17.0",
+    "ky": "~0.31.3",
     "react": "^17.0.2",
     "react-dnd": "^14.0.2",
     "react-dnd-html5-backend": "^14.0.0",
@@ -114,16 +114,16 @@
       "<rootDir>/test/setup.ts"
     ],
     "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/test/__mocks__/fileMock.js",
-      "ky": "ky/umd"
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/test/__mocks__/fileMock.js"
     },
     "testEnvironment": "jest-environment-jsdom-sixteen",
     "transform": {
       "^.+\\.(ts|tsx)$": "ts-jest",
-      "^.+\\.(css)$": "jest-css-modules-transform"
+      "^.+\\.(css)$": "jest-css-modules-transform",
+      "ky": "jest-esm-transformer"
     },
     "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!(ky)/)"
+      "/node_modules/(?!(ky|@patternfly/react-styles)/)"
     ]
   },
   "eslintConfig": {

--- a/ui/packages/mock-embedded/craco.config.js
+++ b/ui/packages/mock-embedded/craco.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  babel: {
+    presets: [
+      "@babel/preset-env",
+      "@babel/preset-react"
+    ],
+    plugins: [
+      "@babel/plugin-proposal-nullish-coalescing-operator",
+      ["@babel/plugin-proposal-private-methods", { "loose": true }],
+      ["@babel/plugin-proposal-class-properties", { "loose": true }]
+    ]
+  }
+};

--- a/ui/packages/mock-embedded/package.json
+++ b/ui/packages/mock-embedded/package.json
@@ -5,11 +5,11 @@
   "version": "2.6.0-SNAPSHOT",
   "private": true,
   "scripts": {
-    "start": "react-scripts --max_old_space_size=4096 start",
-    "build:module": "react-scripts --max_old_space_size=4096 build",
+    "start": "craco --max_old_space_size=4096 start",
+    "build:module": "craco --max_old_space_size=4096 build",
     "build": "npm-run-all build:module lint test",
-    "test": "react-scripts test --watchAll=false --runInBand",
-    "test:coverage": "react-scripts test --watchAll=false --coverage --runInBand",
+    "test": "craco test --watchAll=false --runInBand",
+    "test:coverage": "craco test --watchAll=false --coverage --runInBand",
     "eject": "react-scripts eject",
     "lint": "tsdx lint src",
     "format": "yarn lint --fix"
@@ -31,7 +31,7 @@
     "d3-shape": "^3.1.0",
     "file-saver": "^2.0.5",
     "http-proxy-middleware": "^1.3.1",
-    "ky": "~0.17.0",
+    "ky": "~0.31.3",
     "lodash.clamp": "^4.0.3",
     "monaco-editor": "^0.30.0",
     "monaco-editor-webpack-plugin": "^7.0.0",
@@ -49,6 +49,7 @@
     "use-debounce": "^8.0.1"
   },
   "devDependencies": {
+    "@craco/craco": "5.8.0",
     "@types/jest": "24.9.1",
     "prettier": "^2.5.0",
     "typescript": "~3.9.9"
@@ -94,11 +95,11 @@
   },
   "jest": {
     "moduleNameMapper": {
-      "ky": "ky/umd",
       "monaco-editor": "monaco-editor/esm/vs/editor/editor.api.js"
     },
     "transform": {
-      "^.+\\.(ts|tsx)$": "ts-jest"
+      "^.+\\.(ts|tsx)$": "ts-jest",
+      "ky": "jest-esm-transformer"
     },
     "transformIgnorePatterns": [
       "<rootDir>/node_modules/(?!(ky|@patternfly/react-styles|monaco-editor)/)"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -121,6 +121,15 @@
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
+"@babel/generator@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.19.0.tgz#785596c06425e59334df2ccee63ab166b738419a"
+  integrity sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==
+  dependencies:
+    "@babel/types" "^7.19.0"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    jsesc "^2.5.1"
+
 "@babel/helper-annotate-as-pure@^7.10.4", "@babel/helper-annotate-as-pure@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.13.tgz#0f58e86dfc4bb3b1fcd7db806570e177d439b6ab"
@@ -252,6 +261,14 @@
     "@babel/template" "^7.18.6"
     "@babel/types" "^7.18.9"
 
+"@babel/helper-function-name@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz#941574ed5390682e872e52d3f38ce9d1bef4648c"
+  integrity sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==
+  dependencies:
+    "@babel/template" "^7.18.10"
+    "@babel/types" "^7.19.0"
+
 "@babel/helper-get-function-arity@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz#bc63451d403a3b3082b97e1d8b3fe5bd4091e583"
@@ -323,6 +340,13 @@
   dependencies:
     "@babel/types" "^7.15.4"
 
+"@babel/helper-module-imports@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
+  integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
+  dependencies:
+    "@babel/types" "^7.18.6"
+
 "@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.13.0", "@babel/helper-module-transforms@^7.14.0", "@babel/helper-module-transforms@^7.14.2", "@babel/helper-module-transforms@^7.15.4", "@babel/helper-module-transforms@^7.9.0":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.15.4.tgz#962cc629a7f7f9a082dd62d0307fa75fe8788d7c"
@@ -336,6 +360,20 @@
     "@babel/template" "^7.15.4"
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.4"
+
+"@babel/helper-module-transforms@^7.18.6":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz#309b230f04e22c58c6a2c0c0c7e50b216d350c30"
+  integrity sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-module-imports" "^7.18.6"
+    "@babel/helper-simple-access" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/helper-validator-identifier" "^7.18.6"
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.19.0"
+    "@babel/types" "^7.19.0"
 
 "@babel/helper-optimise-call-expression@^7.12.13":
   version "7.12.13"
@@ -426,6 +464,13 @@
   integrity sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==
   dependencies:
     "@babel/types" "^7.15.4"
+
+"@babel/helper-simple-access@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz#d6d8f51f4ac2978068df934b569f08f29788c7ea"
+  integrity sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==
+  dependencies:
+    "@babel/types" "^7.18.6"
 
 "@babel/helper-skip-transparent-expression-wrappers@^7.12.1":
   version "7.12.1"
@@ -545,6 +590,11 @@
   version "7.18.11"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.11.tgz#68bb07ab3d380affa9a3f96728df07969645d2d9"
   integrity sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==
+
+"@babel/parser@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.19.0.tgz#497fcafb1d5b61376959c1c338745ef0577aa02c"
+  integrity sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.13.12":
   version "7.13.12"
@@ -1051,6 +1101,16 @@
     "@babel/helper-simple-access" "^7.13.12"
     babel-plugin-dynamic-import-node "^2.3.3"
 
+"@babel/plugin-transform-modules-commonjs@^7.4.4":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.18.6.tgz#afd243afba166cca69892e24a8fd8c9f2ca87883"
+  integrity sha512-Qfv2ZOWikpvmedXQJDSbxNqy7Xr/j2Y8/KfijM0iJyKkBTmWuvCA1yeH1yDM7NJhBW/2aXxeucLj6i80/LAJ/Q==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.18.6"
+    "@babel/helper-plugin-utils" "^7.18.6"
+    "@babel/helper-simple-access" "^7.18.6"
+    babel-plugin-dynamic-import-node "^2.3.3"
+
 "@babel/plugin-transform-modules-systemjs@^7.13.8", "@babel/plugin-transform-modules-systemjs@^7.9.0":
   version "7.13.8"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.13.8.tgz#6d066ee2bff3c7b3d60bf28dec169ad993831ae3"
@@ -1526,7 +1586,7 @@
     "@babel/parser" "^7.15.4"
     "@babel/types" "^7.15.4"
 
-"@babel/template@^7.18.6":
+"@babel/template@^7.18.10", "@babel/template@^7.18.6":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
   integrity sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==
@@ -1566,6 +1626,22 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.19.0.tgz#eb9c561c7360005c592cc645abafe0c3c4548eed"
+  integrity sha512-4pKpFRDh+utd2mbRC8JLnlsMUii3PMHjpL6a0SZ4NMZy7YFP9aXORxEhdMVOc9CpWtDF09IkciQLEhK7Ml7gRA==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.19.0"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.19.0"
+    "@babel/helper-hoist-variables" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/parser" "^7.19.0"
+    "@babel/types" "^7.19.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.11", "@babel/types@^7.12.13", "@babel/types@^7.12.7", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.13.16", "@babel/types@^7.14.2", "@babel/types@^7.15.4", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.9.0":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.15.4.tgz#74eeb86dbd6748d2741396557b9860e57fce0a0d"
@@ -1578,6 +1654,15 @@
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.10.tgz#4908e81b6b339ca7c6b7a555a5fc29446f26dde6"
   integrity sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==
+  dependencies:
+    "@babel/helper-string-parser" "^7.18.10"
+    "@babel/helper-validator-identifier" "^7.18.6"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.19.0.tgz#75f21d73d73dc0351f3368d28db73465f4814600"
+  integrity sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==
   dependencies:
     "@babel/helper-string-parser" "^7.18.10"
     "@babel/helper-validator-identifier" "^7.18.6"
@@ -1605,6 +1690,15 @@
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
+"@craco/craco@5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@craco/craco/-/craco-5.8.0.tgz#2a0f551290a5eab353b615de4d7093dd83785777"
+  integrity sha512-4rhusETLD7rJ195GxOK9VmVdv/VD4jawFxc9hcQ9TrZ3/9ny+qwc0uW+08qu9GYwEF9Eb9meSeSvpWjaqdDr1Q==
+  dependencies:
+    cross-spawn "^7.0.0"
+    lodash "^4.17.15"
+    webpack-merge "^4.2.2"
 
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
@@ -3047,7 +3141,7 @@
     node-addon-api "^3.2.1"
     node-gyp-build "^4.3.0"
 
-"@patternfly/react-core@^4.224.1", "@patternfly/react-core@^4.231.8", "@patternfly/react-core@^4.235.7":
+"@patternfly/react-core@^4.224.1", "@patternfly/react-core@^4.235.7":
   version "4.235.7"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.235.7.tgz#70f2492cb2464f000e0e3d046859e9eb57945657"
   integrity sha512-I26IE75kI2P3kIfPsw0N4/pUSzXxWw2dinGw50fDN0qBMTnSCwwiJnyCFImF0f7YF30QWOO4VPs45zdM4iiQeg==
@@ -3060,12 +3154,12 @@
     tippy.js "5.1.2"
     tslib "^2.0.0"
 
-"@patternfly/react-icons@^4.75.1", "@patternfly/react-icons@^4.82.8", "@patternfly/react-icons@^4.86.7":
+"@patternfly/react-icons@^4.75.1", "@patternfly/react-icons@^4.86.7":
   version "4.86.7"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.86.7.tgz#a385e052c8e4d9772e5f12bfde9698ea1a5b9609"
   integrity sha512-QYurZzfjOKqHWRI8zeUweXy583C11NVeRAWbxVhOhPT/aFtgkd75iZNlLpv6XI1EN/uLpa9WdkZzyuLY1txYnA==
 
-"@patternfly/react-styles@^4.74.1", "@patternfly/react-styles@^4.81.8", "@patternfly/react-styles@^4.85.7":
+"@patternfly/react-styles@^4.74.1", "@patternfly/react-styles@^4.85.7":
   version "4.85.7"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.85.7.tgz#93afa64c81cf74f7fa050fb787f02348113d62a6"
   integrity sha512-XSa8Loaouj1XEmbJmEeURXxKu5ub1VCRV0yN5YOnRo7j7XI4Yw9QarSHODzhkquI3AhkD0dPyMOaefz4P6lJKw==
@@ -3081,11 +3175,6 @@
     "@patternfly/react-tokens" "^4.87.7"
     lodash "^4.17.19"
     tslib "^2.0.0"
-
-"@patternfly/react-tokens@^4.87.7":
-  version "4.87.7"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.87.7.tgz#f96de3d2469b23ba86ead36bf8bac4ae9e7e0559"
-  integrity sha512-07A7Ya4zIAYyYn3mOCG82wMC3/Y8mtTw95a//Onu/H0oDPMJ5oT7Vd14YN7pHexCAtWvc36Mp46iZ1osIQ7yVQ==
 
 "@patternfly/react-tokens@^4.87.7":
   version "4.87.7"
@@ -12572,6 +12661,14 @@ jest-environment-node@^24.9.0:
     jest-mock "^24.9.0"
     jest-util "^24.9.0"
 
+jest-esm-transformer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/jest-esm-transformer/-/jest-esm-transformer-1.0.0.tgz#b6c58f496aa48194f96361a52f5c578fd2209726"
+  integrity sha512-FoPgeMMwy1/CEsc8tBI41i83CEO3x85RJuZi5iAMmWoARXhfgk6Jd7y+4d+z+HCkTKNVDvSWKGRhwjzU9PUbrw==
+  dependencies:
+    "@babel/core" "^7.4.4"
+    "@babel/plugin-transform-modules-commonjs" "^7.4.4"
+
 jest-get-type@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
@@ -13300,10 +13397,10 @@ klona@^2.0.4:
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.4.tgz#7bb1e3affb0cb8624547ef7e8f6708ea2e39dfc0"
   integrity sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==
 
-ky@~0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/ky/-/ky-0.17.0.tgz#c1c464bd5e88217fb75ccadcee146497a8ea2f13"
-  integrity sha512-WSDBoSr9IWJOJOIGdsVbngyFrbAkCE3Nvwa4KLF77jWiKVm2zpMUQKSqaq6bZ/4V3ez8F2ggKDMaKXnteZY+ag==
+ky@~0.31.3:
+  version "0.31.3"
+  resolved "https://registry.yarnpkg.com/ky/-/ky-0.31.3.tgz#f00e72b9c0467ab19b0b20f15daf7dff09f67dde"
+  integrity sha512-YDDQKG0Lt4PFSPZGJI8WKAm5y+1ebbeA306am+4nT7riX13wjNVD5sR/QOKtgsaQaARwrdUHlv0M9kJ1qv+Jug==
 
 language-subtag-registry@~0.3.2:
   version "0.3.21"
@@ -21198,6 +21295,13 @@ webpack-manifest-plugin@2.2.0:
     lodash ">=3.5 <5"
     object.entries "^1.1.0"
     tapable "^1.0.0"
+
+webpack-merge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.2.tgz#a27c52ea783d1398afd2087f547d7b9d2f43634d"
+  integrity sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==
+  dependencies:
+    lodash "^4.17.15"
 
 webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"


### PR DESCRIPTION
Fixes: #4320

Google Chrome 105 made a breaking change and made some case fail which used to be working fine with older Chrome. https://developer.chrome.com/articles/fetch-streaming-requests/

ky made a fix for that
https://github.com/sindresorhus/ky/issues/450

But since the newer ky no longer provides umd, we had to change the Jest configuration to deal with esm. Also we needed to introduce craco to add @babel/plugin-proposal-nullish-coalescing-operator which is required to update ky.