### PR TITLE
Fix GitHub Actions script and tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Java versions
         uses: actions/setup-java@v4
         with:
-          java-version: 18
+          java-version: 17
           distribution: 'temurin'
 
       - name: Setup Chrome and ChromeDriver

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,23 +11,31 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Set up Java versions
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 18
           distribution: 'temurin'
+
+      - name: Setup Chrome and ChromeDriver
+        uses: browser-actions/setup-chrome@v1
+        id: setup_chrome
+
       - name: Cache Maven repo
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Build
-        run: mvn --batch-mode -Pcoverage -Dwebdriver.chrome.driver=/usr/bin/chromedriver clean install
+        run: mvn --batch-mode -X -Pcoverage -Dwebdriver.chrome.driver=${{ steps.setup_chrome.outputs.chromedriver-path }} clean install
+
       - name: Publish docs
         run: sh publish-docs.sh
         working-directory: docs

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -10,14 +10,14 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Java versions
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
-          java-version: 18
+          java-version: 17
           distribution: 'temurin'
       - name: Cache Maven repo
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/supported-build.yml
+++ b/.github/workflows/supported-build.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ '17' ]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
     name: ${{ matrix.os }}/Java${{ matrix.java }}
     steps:
     - uses: actions/checkout@v4
@@ -78,7 +78,9 @@ jobs:
         working-directory: ui/packages/atlasmap
       - name: Publish to Chromatic
         if: steps.changed-ui.outputs.changed == 'true'
-        uses: chromaui/action@v1
+        uses: chromaui/action@v11
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: adaaa25c3df8

--- a/.github/workflows/supported-build.yml
+++ b/.github/workflows/supported-build.yml
@@ -16,29 +16,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '18', '11' ]
+        java: [ '17' ]
         os: [ubuntu-latest, macos-latest, windows-latest]
     name: ${{ matrix.os }}/Java${{ matrix.java }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Java versions
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
         distribution: 'temurin'
+    - name: Setup Chrome and ChromeDriver
+      uses: browser-actions/setup-chrome@v1
+      id: setup_chrome
     - name: Cache Maven repo
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Build from root with Maven
-      if: ${{ runner.os == 'Windows' }}
-      run: mvn --batch-mode -Pcoverage "-Dwebdriver.chrome.driver=$Env:CHROMEWEBDRIVER\chromedriver.exe" clean install
-    - name: Build from root with Maven
-      if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-      run: mvn --batch-mode -Pcoverage "-Dwebdriver.chrome.driver=${CHROMEWEBDRIVER}/chromedriver" clean install
+      run: mvn --batch-mode -Pcoverage "-Dwebdriver.chrome.driver=${{ steps.setup_chrome.outputs.chromedriver-path }}" clean install
     - name: Build lib with Maven
       working-directory: lib
       run: mvn --batch-mode clean install
@@ -58,7 +57,7 @@ jobs:
       && github.actor != 'dependabot'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: marceloprado/has-changed-path@v1

--- a/lib/modules/xml/xsom/test/com/sun/xml/xsom/XSOMParserTest.java
+++ b/lib/modules/xml/xsom/test/com/sun/xml/xsom/XSOMParserTest.java
@@ -72,8 +72,7 @@ import junit.framework.TestSuite;
  */
 public class XSOMParserTest extends TestCase {
 
-    private static String docURLStr = "http://docs.oasis-open.org/regrep/v3.0/schema/lcm.xsd";
-    //private static String docURLStr = "http://ebxmlrr.sourceforge.net/private/sun/irs/ContactMechanism/IRS-ContactMechanismCommonAggregateComponents-1.0.xsd";
+    private static String docURLStr = "https://docs.oasis-open.org/regrep/v3.0/schema/lcm.xsd";
     private static URL docURL = null;
     private static XSOMParser instance = null;
 
@@ -107,7 +106,7 @@ public class XSOMParserTest extends TestCase {
         //Following works.
         instance.parse(docURL);
 
-        //Follwoing does not work
+        //Following does not work
         InputSource inputSource = new InputSource(docURL.openStream());
 
         instance.parse(inputSource);

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -110,7 +110,7 @@
     <repository>
       <id>maven-restlet</id>
       <name>Public online Restlet repository</name>
-      <url>https://maven.restlet.com</url>
+      <url>https://maven.restlet.talend.com</url>
     </repository>
     <!-- needed for swagger2markup-maven-plugin -->
     <repository>

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3987,10 +3987,10 @@
     unfetch "^4.2.0"
     util-deprecate "^1.0.2"
 
-"@storybook/react-docgen-typescript-plugin@1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0":
-  version "1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0"
-  resolved "https://registry.yarnpkg.com/@storybook/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0.tgz#3103532ff494fb7dc3cf835f10740ecf6a26c0f9"
-  integrity sha512-eVg3BxlOm2P+chijHBTByr90IZVUtgRW56qEOLX7xlww2NBuKrcavBlcmn+HH7GIUktquWkMPtvy6e0W0NgA5w==
+"@storybook/react-docgen-typescript-plugin@1.0.2-next.0":
+  version "1.0.2-next.0"
+  resolved "https://registry.yarnpkg.com/@storybook/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-1.0.2-next.0.tgz#57692365a4eaa3dd6d8fcda26f81aed17b7f3486"
+  integrity sha512-XLyfeueIwcRnrm4heLZfq4lF/uqoSNzFv/hS4A+0HUQkDLzUwl7xZhdBnm49BfTCLhc8tLABz9zttG86zSaguw==
   dependencies:
     debug "^4.1.1"
     endent "^2.0.1"
@@ -13531,10 +13531,10 @@ klona@^2.0.4:
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.4.tgz#7bb1e3affb0cb8624547ef7e8f6708ea2e39dfc0"
   integrity sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==
 
-ky@~0.31.3:
-  version "0.31.3"
-  resolved "https://registry.yarnpkg.com/ky/-/ky-0.31.3.tgz#f00e72b9c0467ab19b0b20f15daf7dff09f67dde"
-  integrity sha512-YDDQKG0Lt4PFSPZGJI8WKAm5y+1ebbeA306am+4nT7riX13wjNVD5sR/QOKtgsaQaARwrdUHlv0M9kJ1qv+Jug==
+ky@^0.33.3:
+  version "0.33.3"
+  resolved "https://registry.yarnpkg.com/ky/-/ky-0.33.3.tgz#bf1ad322a3f2c3428c13cfa4b3af95e6c4a2f543"
+  integrity sha512-CasD9OCEQSFIam2U8efFK81Yeg8vNMTBUqtMOHlrcWQHqUX3HeCl9Dr31u4toV7emlH8Mymk5+9p0lL6mKb/Xw==
 
 language-subtag-registry@~0.3.2:
   version "0.3.21"


### PR DESCRIPTION
<!-- Please follow the guildeline - https://github.com/atlasmap/atlasmap/wiki/AtlasMap-Developer-Memo -->
chore: resolve build and dependency issues
  - chore: update GitHub Action scripts to use the latest version 4
  - chore: fix XSOMParserTest to use the latest test URL
  - chore: replace restlet url
  - chore: update yarn package versions for ky and @storybook/react-docgen-typescript-plugin
 

A few remaining issues on the GitHub Action that need to be fixed by the maintainers:

##### 1. `Publish Docker Image` stage is failing from credential issues. Log below: 
```
...
JIB> [================              ] 54.5% complete > scheduling pushing base images layers
Error:  k8s: Exception occurred while pushing the image: atlasmap/atlasmap:latest, Failed to authenticate with registry registry-1.docker.io/atlasmap/atlasmap because: 401 Unauthorized
{"details":"access token has insufficient scopes"}

Error:  k8s: Exception occurred while pushing the image: atlasmap/atlasmap:latest
Error:  k8s: Error when push JIB image [Error when push JIB image]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11.955 s
[INFO] Finished at: 2025-06-01T21:38:29Z
[INFO] ------------------------------------------------------------------------
Error:  Failed to execute goal org.eclipse.jkube:kubernetes-maven-plugin:1.10.1:push (default-cli) on project atlasmap-standalone: Error when push JIB image: Failed to authenticate with registry registry-1.docker.io/atlasmap/atlasmap because: 401 Unauthorized
Error:  {"details":"access token has insufficient scopes"}
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
Error: Process completed with exit code 1.
```

##### 2.  `Run codacy-coverage-reporter` stage is failing, also from some kind of credential issue: 
```
 codacy-coverage-reporter-linux: OK
 Running command: /home/runner/.cache/codacy/coverage-reporter/14.1.0/codacy-coverage-reporter report  -r coverage-report/target/site/jacoco-aggregate/jacoco.xml -r ui/packages/atlasmap-core/coverage/lcov.info -r ui/packages/atlasmap/coverage/lcov.info -r ui/packages/atlasmap-standalone/coverage/lcov.info --partial --> 
2025-06-02 00:09:06.506Z error [CodacyCoverageReporter] Invalid configuration: Either a project or account API token must be provided or available in an environment variable  - (CodacyCoverageReporter.scala:28)

 --> Failed!
Error: Process completed with exit code 1.
```